### PR TITLE
fix: add per-agent verbose attribution for parallel and for_each execution

### DIFF
--- a/examples/for-each-agent-attribution.yaml
+++ b/examples/for-each-agent-attribution.yaml
@@ -1,0 +1,68 @@
+# For-Each Agent Attribution
+#
+# This example focuses on verbose log attribution for parallel for_each execution.
+# Run with:
+#   uv run conductor run examples/for-each-agent-attribution.yaml --verbose
+
+workflow:
+  name: for-each-agent-attribution
+  description: Demonstrates per-item qualified agent names in for_each execution
+  version: "1.0.0"
+  entry_point: finder
+
+  runtime:
+    provider: copilot
+    default_model: claude-sonnet-4.5
+
+  limits:
+    max_iterations: 20
+
+for_each:
+  - name: analyze_items
+    type: for_each
+    source: finder.output.items
+    as: item
+    key_by: id
+    max_concurrent: 3
+    failure_mode: continue_on_error
+
+    agent:
+      name: analyzer
+      model: claude-sonnet-4.5
+      prompt: |
+        Analyze item {{ item.id }} with value: {{ item.value }}
+      output:
+        id:
+          type: string
+        summary:
+          type: string
+
+    routes:
+      - to: aggregator
+
+agents:
+  - name: finder
+    model: claude-sonnet-4.5
+    prompt: |
+      Return three objects with fields id and value.
+    output:
+      items:
+        type: array
+    routes:
+      - to: analyze_items
+
+  - name: aggregator
+    model: claude-sonnet-4.5
+    input:
+      - analyze_items.outputs
+    prompt: |
+      Summarize the outputs from all analyzed items.
+    output:
+      final:
+        type: string
+    routes:
+      - to: $end
+
+output:
+  final: "{{ aggregator.output.final }}"
+  analyzed_count: "{{ analyze_items.outputs | length }}"

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -2377,17 +2377,26 @@ class WorkflowEngine:
                     key if for_each_group.key_by else None,
                 )
 
+                # Qualify per-item agent names so concurrent verbose logs are attributable.
+                qualified_agent = for_each_group.agent.model_copy(
+                    update={"name": f"{for_each_group.agent.name}[{key}]"}
+                )
+
                 # Execute agent with injected context (get executor for multi-provider)
-                executor = await self._get_executor_for_agent(for_each_group.agent)
+                executor = await self._get_executor_for_agent(qualified_agent)
 
                 # Item-scoped event callback that tags all streaming events with item_key
                 def _item_callback(event_type: str, data: dict[str, Any]) -> None:
-                    data_with_agent = {"agent_name": for_each_group.name, "item_key": key, **data}
+                    data_with_agent = {
+                        "agent_name": qualified_agent.name,
+                        "item_key": key,
+                        **data,
+                    }
                     self._emit(event_type, data_with_agent)
 
                 event_callback = _item_callback if self._event_emitter else None
                 output = await executor.execute(
-                    for_each_group.agent,
+                    qualified_agent,
                     agent_context,
                     event_callback=event_callback,
                 )

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -478,6 +478,7 @@ class CopilotProvider(AgentProvider):
                     full_enabled,
                     interrupt_signal=interrupt_signal,
                     event_callback=event_callback,
+                    agent_name=agent.name,
                 )
                 response_content = sdk_response.content
 
@@ -557,7 +558,11 @@ class CopilotProvider(AgentProvider):
 
                         # Send recovery prompt and get new response
                         recovery_response = await self._send_and_wait(
-                            session, recovery_prompt, verbose_enabled, full_enabled
+                            session,
+                            recovery_prompt,
+                            verbose_enabled,
+                            full_enabled,
+                            agent_name=agent.name,
                         )
                         response_content = recovery_response.content
 
@@ -604,6 +609,7 @@ class CopilotProvider(AgentProvider):
         full_enabled: bool,
         interrupt_signal: asyncio.Event | None = None,
         event_callback: EventCallback | None = None,
+        agent_name: str | None = None,
     ) -> SDKResponse:
         """Send a prompt to the session and wait for response.
 
@@ -616,6 +622,7 @@ class CopilotProvider(AgentProvider):
                 When set, the method will attempt to abort the session and
                 return partial content with ``partial=True``.
             event_callback: Optional callback for streaming SDK events upstream.
+            agent_name: Optional agent name for attributing verbose event logs.
 
         Returns:
             SDKResponse with content and usage data. If interrupted,
@@ -690,7 +697,12 @@ class CopilotProvider(AgentProvider):
 
             # Verbose logging for intermediate progress
             if verbose_enabled:
-                self._log_event_verbose(event_type, event, full_enabled)
+                self._log_event_verbose(
+                    event_type,
+                    event,
+                    full_enabled,
+                    agent_name=agent_name,
+                )
 
         session.on(on_event)
         await session.send({"prompt": prompt})
@@ -868,7 +880,10 @@ class CopilotProvider(AgentProvider):
 
         try:
             sdk_response = await self._send_and_wait(
-                session, guidance, verbose_enabled, full_enabled
+                session,
+                guidance,
+                verbose_enabled,
+                full_enabled,
             )
 
             content: dict[str, Any]
@@ -1005,7 +1020,13 @@ class CopilotProvider(AgentProvider):
             f"than the raw JSON object."
         )
 
-    def _log_event_verbose(self, event_type: str, event: Any, full_mode: bool) -> None:
+    def _log_event_verbose(
+        self,
+        event_type: str,
+        event: Any,
+        full_mode: bool,
+        agent_name: str | None = None,
+    ) -> None:
         """Log SDK events in verbose mode for progress visibility.
 
         Note: Caller must check is_verbose() before calling - contextvars
@@ -1015,6 +1036,7 @@ class CopilotProvider(AgentProvider):
             event_type: The event type string.
             event: The event object.
             full_mode: If True, show full details (args, results, reasoning).
+            agent_name: Optional agent name to prepend for attribution.
         """
         from rich.console import Console
         from rich.text import Text
@@ -1038,6 +1060,8 @@ class CopilotProvider(AgentProvider):
 
             text = Text()
             text.append("    ├─ ", style="dim")
+            if agent_name:
+                text.append(f"[{agent_name}] ", style="magenta")
             text.append("🔧 ", style="")
             text.append(str(tool_name), style="cyan bold")
             _print(text)
@@ -1060,6 +1084,8 @@ class CopilotProvider(AgentProvider):
             if tool_name:
                 text = Text()
                 text.append("    │  ", style="dim")
+                if agent_name:
+                    text.append(f"[{agent_name}] ", style="magenta")
                 text.append("✓ ", style="green")
                 text.append(str(tool_name), style="dim")
                 _print(text)
@@ -1091,25 +1117,31 @@ class CopilotProvider(AgentProvider):
                         display_reasoning = reasoning
                     text = Text()
                     text.append("    │  ", style="dim")
+                    if agent_name:
+                        text.append(f"[{agent_name}] ", style="magenta")
                     text.append("💭 ", style="")
                     text.append(display_reasoning.replace("\n", " "), style="italic dim")
                     _print(text)
 
         elif event_type == "subagent.started":
-            agent_name = getattr(event.data, "name", None) or "unknown"
+            subagent_name = getattr(event.data, "name", None) or "unknown"
             text = Text()
             text.append("    ├─ ", style="dim")
+            if agent_name:
+                text.append(f"[{agent_name}] ", style="magenta")
             text.append("🤖 ", style="")
             text.append("Sub-agent: ", style="dim")
-            text.append(str(agent_name), style="magenta bold")
+            text.append(str(subagent_name), style="magenta bold")
             _print(text)
 
         elif event_type == "subagent.completed":
-            agent_name = getattr(event.data, "name", None) or "unknown"
+            subagent_name = getattr(event.data, "name", None) or "unknown"
             text = Text()
             text.append("    │  ", style="dim")
+            if agent_name:
+                text.append(f"[{agent_name}] ", style="magenta")
             text.append("✓ ", style="green")
-            text.append(f"Sub-agent done: {agent_name}", style="dim")
+            text.append(f"Sub-agent done: {subagent_name}", style="dim")
             _print(text)
 
         elif event_type == "assistant.turn_start":
@@ -1119,6 +1151,8 @@ class CopilotProvider(AgentProvider):
                 turn_info = f" (turn {turn})" if turn else ""
                 text = Text()
                 text.append("    │  ", style="dim")
+                if agent_name:
+                    text.append(f"[{agent_name}] ", style="magenta")
                 text.append("⏳ ", style="yellow")
                 text.append(f"Processing{turn_info}...", style="dim italic")
                 _print(text)

--- a/tests/test_engine/test_event_emission.py
+++ b/tests/test_engine/test_event_emission.py
@@ -836,6 +836,110 @@ class TestForEachGroupEvents:
         assert completed.data["success_count"] == 1
         assert completed.data["failure_count"] == 1
 
+    @pytest.mark.asyncio
+    async def test_for_each_qualifies_agent_names_in_call_history(self) -> None:
+        """Each for-each item executes with a qualified per-item agent name."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="foreach-agent-name-test",
+                entry_point="finder",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=20),
+            ),
+            agents=[
+                AgentDef(
+                    name="finder",
+                    model="gpt-4",
+                    prompt="find items",
+                    output={"items": OutputField(type="array")},
+                    routes=[RouteDef(to="process_items")],
+                ),
+            ],
+            for_each=[
+                ForEachDef(
+                    name="process_items",
+                    type="for_each",
+                    source="finder.output.items",
+                    **{"as": "item"},
+                    agent=AgentDef(
+                        name="processor",
+                        model="gpt-4",
+                        prompt="process {{ item }}",
+                        output={"result": OutputField(type="string")},
+                    ),
+                    max_concurrent=5,
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"result": "done"},
+        )
+
+        def handler(a, p, c):
+            if a.name == "finder":
+                return {"items": ["a", "b", "c"]}
+            return {"result": f"processed-{a.name}"}
+
+        provider = CopilotProvider(mock_handler=handler)
+        engine = WorkflowEngine(config, provider)
+        await engine.run({})
+
+        call_names = {entry["agent_name"] for entry in provider.get_call_history()}
+        assert "finder" in call_names
+        assert {"processor[0]", "processor[1]", "processor[2]"}.issubset(call_names)
+
+    @pytest.mark.asyncio
+    async def test_for_each_qualifies_agent_names_with_key_by(self) -> None:
+        """for_each key_by values are reflected in qualified per-item agent names."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="foreach-key-by-agent-name-test",
+                entry_point="finder",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=20),
+            ),
+            agents=[
+                AgentDef(
+                    name="finder",
+                    model="gpt-4",
+                    prompt="find items",
+                    output={"items": OutputField(type="array")},
+                    routes=[RouteDef(to="process_items")],
+                ),
+            ],
+            for_each=[
+                ForEachDef(
+                    name="process_items",
+                    type="for_each",
+                    source="finder.output.items",
+                    key_by="id",
+                    **{"as": "item"},
+                    agent=AgentDef(
+                        name="processor",
+                        model="gpt-4",
+                        prompt="process {{ item.id }}",
+                        output={"result": OutputField(type="string")},
+                    ),
+                    max_concurrent=5,
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"result": "done"},
+        )
+
+        def handler(a, p, c):
+            if a.name == "finder":
+                return {"items": [{"id": "item_a"}, {"id": "item_b"}]}
+            return {"result": f"processed-{a.name}"}
+
+        provider = CopilotProvider(mock_handler=handler)
+        engine = WorkflowEngine(config, provider)
+        await engine.run({})
+
+        call_names = {entry["agent_name"] for entry in provider.get_call_history()}
+        assert {"processor[item_a]", "processor[item_b]"}.issubset(call_names)
+
 
 class TestTimestamps:
     """Tests that all events have valid timestamps."""

--- a/tests/test_integration/test_for_each.py
+++ b/tests/test_integration/test_for_each.py
@@ -611,7 +611,7 @@ class TestForEachExecution:
             await asyncio.sleep(0.1)  # Simulate processing time
             return AgentOutput(
                 content={"result": "ok"}
-                if agent.name == "processor"
+                if agent.name == "processor" or agent.name.startswith("processor[")
                 else {"items": ["A", "B", "C", "D", "E"]},
                 raw_response={},
                 model="gpt-4",

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -1,7 +1,9 @@
 """Unit tests for the CopilotProvider implementation."""
 
 import contextlib
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -556,3 +558,74 @@ class TestLogParseRecovery:
             max_attempts=5,
             error=long_error,
         )
+
+
+class TestVerboseAgentAttribution:
+    """Tests for agent attribution in verbose provider logs."""
+
+    def test_log_event_verbose_prefixes_agent_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verbose tool logs include an agent prefix when provided."""
+        provider = CopilotProvider(mock_handler=stub_handler)
+        captured: list[str] = []
+
+        import rich.console as rich_console
+
+        def _patched_print(self: Any, *args: Any, **kwargs: Any) -> None:
+            if args:
+                captured.append(getattr(args[0], "plain", str(args[0])))
+
+        monkeypatch.setattr(rich_console.Console, "print", _patched_print)
+
+        event = SimpleNamespace(
+            data=SimpleNamespace(tool_name="view", arguments={"path": "/tmp/file.py"})
+        )
+        provider._log_event_verbose(
+            "tool.execution_start",
+            event,
+            full_mode=False,
+            agent_name="analyzer[item_a]",
+        )
+
+        assert any("[analyzer[item_a]]" in line and "view" in line for line in captured)
+
+    @pytest.mark.asyncio
+    async def test_send_and_wait_passes_agent_name_to_verbose_logger(self) -> None:
+        """_send_and_wait forwards agent_name to verbose event logging calls."""
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        class _FakeSession:
+            def __init__(self) -> None:
+                self._callback: Any = None
+
+            def on(self, callback: Any) -> None:
+                self._callback = callback
+
+            async def send(self, _message: dict[str, Any]) -> None:
+                assert self._callback is not None
+                self._callback(
+                    SimpleNamespace(
+                        type=SimpleNamespace(value="tool.execution_start"),
+                        data=SimpleNamespace(tool_name="view"),
+                    )
+                )
+                self._callback(
+                    SimpleNamespace(
+                        type=SimpleNamespace(value="session.idle"),
+                        data=SimpleNamespace(),
+                    )
+                )
+
+        provider._log_event_verbose = MagicMock()
+        session = _FakeSession()
+
+        await provider._send_and_wait(
+            session,
+            prompt="test",
+            verbose_enabled=True,
+            full_enabled=False,
+            agent_name="analyzer[item_a]",
+        )
+
+        first_call = provider._log_event_verbose.call_args_list[0]
+        assert first_call.args[0] == "tool.execution_start"
+        assert first_call.kwargs["agent_name"] == "analyzer[item_a]"


### PR DESCRIPTION
## Summary
- add optional `agent_name` plumbing from `_execute_sdk_call()` into `_send_and_wait()` and `_log_event_verbose()`
- prefix verbose provider events with `[agent_name]` for tool start/complete, reasoning, sub-agent start/complete, and turn start
- qualify for_each execution agent names per item via `model_copy(update={"name": f"{base}[{key}]"})`
- execute for_each items with the qualified agent and emit streaming event `agent_name` using the qualified value
- add a runnable example workflow at `examples/for-each-agent-attribution.yaml`

## Why
Verbose logs from concurrent agent runs were interleaved without attribution, making debugging and grep-based analysis impractical for parallel and for_each execution.

## Testing
- `uv run pytest tests/test_providers/test_copilot.py tests/test_engine/test_event_emission.py -q`
- `uv run pytest tests/test_providers -q`
- `uv run conductor validate examples/for-each-agent-attribution.yaml`

## Added Coverage
- provider verbose logging now tested for `[agent]` prefix output
- `_send_and_wait` test verifies `agent_name` is forwarded to `_log_event_verbose`
- for_each tests verify per-item qualified names in provider call history for both index keys and `key_by` values

Fixes microsoft/conductor#16
