### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.5"
+version = "0.1.6"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bump version from 0.1.5 to 0.1.6 for release.

## Changes since v0.1.5

- feat: Add workflow replay command and YAML config viewer (#70)
- feat: Add context window % visualization to web dashboard (#56)
- fix: use return instead of exit in install.ps1 to avoid killing session (#61)
- chore(deps): Bump anthropic from 0.86.0 to 0.87.0 (#71)
- chore(deps): Bump pygments from 2.19.2 to 2.20.0 (#69)
- chore(deps): Bump cryptography from 46.0.5 to 46.0.6 (#67)
- chore(deps): Bump picomatch in /src/conductor/web/frontend (#63)