### PR TITLE
chore(deps): upgrade github-copilot-sdk from 0.2.0 to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.7"
+version = "0.1.8"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -41,7 +41,8 @@ _IDLE_IGNORED_EVENTS: frozenset[str] = frozenset(
 
 # Try to import the Copilot SDK
 try:
-    from copilot import CopilotClient, PermissionHandler
+    from copilot import CopilotClient
+    from copilot.session import PermissionHandler
 
     COPILOT_SDK_AVAILABLE = True
 except ImportError:

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.5"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -364,19 +364,19 @@ wheels = [
 
 [[package]]
 name = "github-copilot-sdk"
-version = "0.2.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/e1/ef44934ab7ee158e19a96e5bfa9e0d9ed3c0ba26b64ef01a7da39ee212a4/github_copilot_sdk-0.2.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:ec96ff07c895a141778684ac3b9bebfd5b8cb089d916b0fef1e473321f9a6f24", size = 60988348, upload-time = "2026-03-20T19:50:25.024Z" },
-    { url = "https://files.pythonhosted.org/packages/95/cb/5af63e461aa2029424732002a49d8630cce7fc1ec15d13d3889f72fd40bf/github_copilot_sdk-0.2.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a54a7f7f68d6b552df4c510716de4505e9b2ff3677ce028b0b945ee6900c5b24", size = 57751425, upload-time = "2026-03-20T19:50:28.907Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/dd/9f03607da3910daa87228b3b53949de17e5c929bd308fed865b12def600b/github_copilot_sdk-0.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e60ba6fd4d4619ea3ba6631d1f204b0393ad53aaef04d4e817c9d50a0e673d04", size = 63861154, upload-time = "2026-03-20T19:50:32.711Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f6/8a5499e9ccb446de4233d51429e6890e0438a46d8e84bc0f72fe525214bd/github_copilot_sdk-0.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:0afbd64921daff2e678f895aa8e5348ec1d5d52f6144065022bb8556cb7888cf", size = 62041828, upload-time = "2026-03-20T19:50:36.869Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/a5/341c5a2eb322e24d6550cc2beb190a2b808aeb9b55aa57e85e603858c7b1/github_copilot_sdk-0.2.0-py3-none-win_amd64.whl", hash = "sha256:07599d4b8c6801de0ea8c0ad5f80a0b832b67831dfc6c29f4c3178a0da2c8cf9", size = 56484359, upload-time = "2026-03-20T19:50:40.665Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/f2/4a73bce97382bdbd6d9413a9baac8fa7cf10bf77ad25c0574470e28cfee4/github_copilot_sdk-0.2.0-py3-none-win_arm64.whl", hash = "sha256:e9f382f1145ed0c79cc6fd3fff20622d9ca47ef184cbbf91ffb74192ab489d2e", size = 54484731, upload-time = "2026-03-20T19:50:44.337Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/15/51c75638d5c662d109be53fca1f42de373d02be505f336c02a2b3db10b26/github_copilot_sdk-0.2.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:75bcd2ed3cc1b6a63c140c3c86850b9fb97b8d595a238f26be67db54bf037c6b", size = 58290616, upload-time = "2026-04-10T09:03:14.187Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2e/228bd47c424cb423430842fa3836559018346a514776417ae04da3d9ba23/github_copilot_sdk-0.2.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a5a679a8afcec901092855c9abd906d06e83407b54008a78a8e980f44464a2d2", size = 55043721, upload-time = "2026-04-10T09:03:17.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/13/d28af1baef7e194ea54d895e2e8f1ce061d85a9f38282fe8f3679a3f919f/github_copilot_sdk-0.2.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:19a2ae280b550fbc4fcdce8293afe4dc4a822ec987ee353ce6a7d218577a5b3b", size = 61236750, upload-time = "2026-04-10T09:03:21.358Z" },
+    { url = "https://files.pythonhosted.org/packages/99/21/9658979f0c694e0a7393c555cf41dd0a6bc6be6e52aed85e8d2a5fe698f8/github_copilot_sdk-0.2.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:06cf4c14acba2a32d28adae85c26b2b6324c1d29d8cf57c7eb73babcdc052558", size = 59414326, upload-time = "2026-04-10T09:03:24.932Z" },
+    { url = "https://files.pythonhosted.org/packages/36/be/dfd87b372ada6b4aa96a1333784e0df7eabe9da40db560b211358d6b98d9/github_copilot_sdk-0.2.2-py3-none-win_amd64.whl", hash = "sha256:887553330d92b266d45cbde5d6d480809471ae23c5f0e3762a7b73ff2c75e34c", size = 53874015, upload-time = "2026-04-10T09:03:28.804Z" },
+    { url = "https://files.pythonhosted.org/packages/89/cf/fb3ffda1967a8fb71f0ec32b099ef858b0342851f11cd4fc8b89bd8df10a/github_copilot_sdk-0.2.2-py3-none-win_arm64.whl", hash = "sha256:7d76badbed12e012a811552e91f29a79bdca3e597fd876869d313399fd27c5ad", size = 51806384, upload-time = "2026-04-10T09:03:32.346Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrade the Copilot SDK from 0.2.0 to 0.2.2.

## Changes
- Update `PermissionHandler` import path from `copilot` to `copilot.session` (dropped from top-level exports in 0.2.2)
- Lock file updated to resolve SDK 0.2.2

## New SDK features (additive, not yet used)
- `CopilotClient`/`CopilotSession` support `async with` (0.2.1)
- Elicitation support for interactive prompts (0.2.1)
- `enableConfigDiscovery` for auto MCP discovery (0.2.2)
- Session filesystem support (0.2.2)

## Verification
- All 1802 tests pass
- 3 example workflows tested live (`simple-qa`, `script-step`, `for-each-simple`)
- Parallel for-each with `max_concurrent=3` ran without permission errors (the pattern that historically triggered regressions in 0.1.31/0.1.32)