### PR TITLE
fix: read turn_id instead of turn from Copilot SDK events

### DIFF
--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -1120,7 +1120,7 @@ class CopilotProvider(AgentProvider):
         elif event_type == "assistant.turn_start":
             # Only show processing indicator in full mode
             if full_mode:
-                turn = getattr(event.data, "turn", None)
+                turn = getattr(event.data, "turn_id", None)
                 turn_info = f" (turn {turn})" if turn else ""
                 text = Text()
                 text.append("    │  ", style="dim")
@@ -1177,7 +1177,7 @@ class CopilotProvider(AgentProvider):
                 )
 
             elif event_type == "assistant.turn_start":
-                turn = getattr(event.data, "turn", None)
+                turn = getattr(event.data, "turn_id", None)
                 callback("agent_turn_start", {"turn": turn})
 
             elif event_type == "assistant.message":


### PR DESCRIPTION
## Summary
Fixes the web dashboard showing **Turn ?** instead of the actual turn number when using the Copilot provider.

## Root Cause
The Copilot SDK exposes the turn number as 	urn_id on vent.data, not 	urn. The two getattr(event.data, "turn", ...) calls in CopilotProvider always returned None, causing the dashboard's nullish fallback to render "Turn ?".

## Changes
Two-line fix in src/conductor/providers/copilot.py:
- _log_event_verbose (line 1123): getattr(event.data, "turn", None) → getattr(event.data, "turn_id", None)
- _forward_event (line 1180): getattr(event.data, "turn", None) → getattr(event.data, "turn_id", None)

The callback payload key remains "turn" — only the SDK attribute name changes.

Fixes #62