### PR TITLE
fix: use UTF-8 encoding for subprocess output on Windows

### DIFF
--- a/src/conductor/cli/update.py
+++ b/src/conductor/cli/update.py
@@ -17,6 +17,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -334,7 +335,10 @@ def run_update(console: Console) -> None:
         renamed_exes = _rename_windows_exes()
 
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")  # noqa: S603
+        # Set PYTHONUTF8=1 so child Python processes use UTF-8 encoding
+        # instead of the system default (cp1252 on Windows).
+        env = {**os.environ, "PYTHONUTF8": "1"}
+        proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", env=env)  # noqa: S603
 
         if proc.returncode == 0:
             console.print(f"[green]Successfully upgraded to v{version}[/green]")

--- a/src/conductor/cli/update.py
+++ b/src/conductor/cli/update.py
@@ -334,7 +334,7 @@ def run_update(console: Console) -> None:
         renamed_exes = _rename_windows_exes()
 
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+        proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")  # noqa: S603
 
         if proc.returncode == 0:
             console.print(f"[green]Successfully upgraded to v{version}[/green]")

--- a/src/conductor/executor/script.py
+++ b/src/conductor/executor/script.py
@@ -92,7 +92,11 @@ class ScriptExecutor:
         # Build environment (merge os.environ + agent.env)
         # Note: ${VAR:-default} patterns in agent.env are already resolved
         # by the config loader during YAML parsing.
-        env = {**os.environ, **agent.env} if agent.env else None
+        # Always set PYTHONUTF8=1 so child Python processes use UTF-8 encoding
+        # instead of the system default (cp1252 on Windows), preventing garbled
+        # Unicode characters in script output.
+        base_env = {**os.environ, "PYTHONUTF8": "1"}
+        env = {**base_env, **agent.env} if agent.env else base_env
 
         _verbose_log(f"  Script: {rendered_command} {' '.join(rendered_args)}")
 

--- a/src/conductor/mcp_auth.py
+++ b/src/conductor/mcp_auth.py
@@ -69,6 +69,7 @@ def get_azure_token(scope: str) -> str | None:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=30,
         )
         if result.returncode == 0:

--- a/src/conductor/mcp_auth.py
+++ b/src/conductor/mcp_auth.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
 import urllib.request
 from typing import Any
@@ -55,6 +56,9 @@ def get_azure_token(scope: str) -> str | None:
         The access token string, or None if token acquisition fails.
     """
     try:
+        # Set PYTHONUTF8=1 so child Python processes use UTF-8 encoding
+        # instead of the system default (cp1252 on Windows).
+        env = {**os.environ, "PYTHONUTF8": "1"}
         result = subprocess.run(
             [
                 "az",
@@ -70,6 +74,7 @@ def get_azure_token(scope: str) -> str | None:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            env=env,
             timeout=30,
         )
         if result.returncode == 0:


### PR DESCRIPTION
## Summary

Fixes #89 — Unicode characters (emoji, em-dash, etc.) are garbled on Windows when passed between agents or posted via tools.

## Root Cause

Python defaults to cp1252 (charmap) encoding on Windows for subprocess pipes and text=True mode. This mangles non-ASCII characters in script output and subprocess calls.

## Changes

- **executor/script.py**: Set PYTHONUTF8=1 in subprocess env so child Python processes use UTF-8
- **cli/update.py**: Added encoding="utf-8" to subprocess.run()
- **mcp_auth.py**: Added encoding="utf-8" to subprocess.run()

## Testing

All 75 existing tests pass. Lint clean.
