### PR TITLE
fix: add random suffix to log filenames to prevent collision

### DIFF
--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -52,7 +52,13 @@ def generate_log_path(workflow_name: str) -> Path:
     Returns:
         Path to the auto-generated log file.
     """
+    import secrets
+
     timestamp = time.strftime("%Y%m%d-%H%M%S")
+    # Append random suffix to avoid filename collisions
+    # when multiple runs start in the same second
+    suffix = secrets.token_hex(4)
+    timestamp = f"{timestamp}-{suffix}"
     path = Path(tempfile.gettempdir()) / "conductor" / f"conductor-{workflow_name}-{timestamp}.log"
     path.parent.mkdir(parents=True, exist_ok=True)
     return path

--- a/src/conductor/engine/checkpoint.py
+++ b/src/conductor/engine/checkpoint.py
@@ -167,7 +167,13 @@ class CheckpointManager:
                 workflow_hash = "sha256:unknown"
 
             # Build checkpoint dict
+            import secrets
+
             timestamp = time.strftime("%Y%m%d-%H%M%S")
+            # Append random suffix to avoid filename collisions
+            # when multiple runs start in the same second
+            suffix = secrets.token_hex(4)
+            timestamp = f"{timestamp}-{suffix}"
             created_at = datetime.now(UTC).isoformat()
             workflow_name = workflow_path.stem
 

--- a/src/conductor/engine/event_log.py
+++ b/src/conductor/engine/event_log.py
@@ -56,7 +56,13 @@ class EventLogSubscriber:
     """
 
     def __init__(self, workflow_name: str) -> None:
+        import secrets
+
         ts = time.strftime("%Y%m%d-%H%M%S")
+        # Append random suffix to avoid filename collisions
+        # when multiple runs start in the same second
+        suffix = secrets.token_hex(4)
+        ts = f"{ts}-{suffix}"
         self._path = (
             Path(tempfile.gettempdir())
             / "conductor"

--- a/tests/test_engine/test_event_log.py
+++ b/tests/test_engine/test_event_log.py
@@ -76,6 +76,26 @@ class TestEventLogSubscriber:
         sub.on_event(WorkflowEvent(type="late", timestamp=time.time(), data={}))
         sub.close()  # Double close should be safe
 
+    def test_filenames_unique_for_simultaneous_starts(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        subs = [EventLogSubscriber("same-workflow") for _ in range(3)]
+        paths = [s.path for s in subs]
+        # All paths must be distinct even when created in rapid succession
+        assert len(set(paths)) == len(paths), f"Expected unique paths, got {paths}"
+        for s in subs:
+            s.close()
+
+    def test_filename_contains_random_suffix(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        sub = EventLogSubscriber("ts-test")
+        # Filename should match pattern: conductor-<name>-YYYYMMDD-HHMMSS-<8 hex chars>.events.jsonl
+        import re
+
+        assert re.search(r"\d{8}-\d{6}-[0-9a-f]{8}\.events\.jsonl$", sub.path.name), (
+            f"Filename lacks random suffix: {sub.path.name}"
+        )
+        sub.close()
+
     def test_integrates_with_emitter(self, tmp_path, monkeypatch):
         from conductor.events import WorkflowEventEmitter
 


### PR DESCRIPTION
## Problem

When multiple workflow runs start in the same second (common when orchestrating parallel runs), \	ime.strftime('%Y%m%d-%H%M%S')\ produces identical timestamps, causing all runs to write to the same event log file. This corrupts event logs, checkpoint files, and CLI log files by interleaving events from different runs.

## Solution

Append a random 8-character hex suffix (via \secrets.token_hex(4)\) to filenames across all three affected locations:

- \EventLogSubscriber\ (\vent_log.py\)
- \CheckpointManager.save_checkpoint\ (\checkpoint.py\)
- \generate_log_path\ (\cli/run.py\)

### Before
\\\
conductor-workflow-20260416-014816.events.jsonl
\\\

### After
\\\
conductor-workflow-20260416-014816-a3b7c9f1.events.jsonl
\\\

## Backward Compatibility

Fully backward compatible — existing tools that glob \*.events.jsonl\, \*.json\, or \*.log\ continue to work. Filenames remain human-readable with the timestamp prefix; the suffix only prevents collisions.

## Testing

- Added \	est_filenames_unique_for_simultaneous_starts\ — creates 3 subscribers in rapid succession, asserts all paths are unique
- Added \	est_filename_contains_random_suffix\ — validates the 8-char hex suffix format in filenames

## Note

One pre-existing test (\	est_handles_non_serializable_data\) fails on Windows due to a path separator assertion (\\\\\some\\\\path\ vs \/some/path\). This is unrelated to this change.