### PR TITLE
fix(gates): race web task unconditionally when web dashboard exists

### DIFF
--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -746,11 +746,16 @@ class WorkflowEngine:
         Returns:
             GateResult from whichever input source responded first.
         """
-        # If no web dashboard or no connections, use CLI only
-        if self._web_dashboard is None or not self._web_dashboard.has_connections():
+        # If no web dashboard at all, use CLI only.
+        if self._web_dashboard is None:
             return await self.gate_handler.handle_gate(agent, agent_context)
 
-        # Race CLI vs web input
+        # Race CLI vs web input. We start the web task unconditionally (not only
+        # when a client is currently connected), because the human often opens
+        # the per-run dashboard AFTER seeing the gate-waiting notification.
+        # If we bail early when ``has_connections()`` is False, a later click
+        # in the dashboard pushes a message to ``_gate_response_queue`` that
+        # nobody is awaiting, and the workflow hangs forever.
         cli_task = asyncio.create_task(
             self.gate_handler.handle_gate(agent, agent_context),
             name="gate_cli",


### PR DESCRIPTION
## Summary

`_handle_gate_with_web` decided between CLI and web gate resolution based on `self._web_dashboard.has_connections()` at the moment the gate was presented. When no WebSocket client was connected at that instant, it committed to the CLI-only path. Under `--web-bg` there is no attached stdin, and users typically open the per-run dashboard *after* seeing the gate-waiting notification, so:

1. Gate is presented, `has_connections()` is False (no one is looking yet).
2. Fall through to `gate_handler.handle_gate` → blocks on `input()` with no tty.
3. User opens the per-run dashboard, clicks Approve.
4. `gate_response` WebSocket message arrives and is put on `_gate_response_queue`.
5. **Nothing awaits the queue** — `_wait_for_web_gate` was never scheduled.
6. Workflow hangs forever. `gate_resolved` event is never emitted.

## Reproduction

- `conductor run <workflow> --web-bg`
- Wait for a `human_gate` agent to fire. Do **not** open the per-run dashboard yet.
- After the terminal shows the gate-waiting notification, open the per-run dashboard and click any option.
- WebSocket frame is sent and acknowledged; no `gate_resolved` is ever written, workflow stays blocked.

## Fix

Only bail to the CLI-only path when there is no web dashboard at all. Whenever `self._web_dashboard` exists, start both the CLI and web tasks and race them. `wait_for_gate_response` is happy to await an empty queue until a client eventually connects and clicks, and if the CLI task resolves first the web task is cancelled cleanly (already handled by `asyncio.wait(..., return_when=FIRST_COMPLETED)` and the pending-cancel loop below).

## Risk

Low. The prior `has_connections()` short-circuit was an optimization to avoid scheduling a web coroutine when clearly unused; removing it costs one extra `asyncio.create_task` per gate. No behavioral change for CLI-only runs (`_web_dashboard is None`).

## Tests

Existing gate/race path had **no test coverage**, which is why this regressed silently. Happy to add a regression test covering 'client connects after gate presented' in a follow-up if desired.