### PR TITLE
fix(web): stop busy-looping on stale gate_response messages

### DIFF
--- a/src/conductor/web/server.py
+++ b/src/conductor/web/server.py
@@ -286,8 +286,14 @@ class WebDashboard:
         """Wait for a gate response from a web client.
 
         Blocks until a ``gate_response`` message is received via WebSocket
-        that matches the given agent name.  Non-matching messages are
-        re-queued so they are not lost.
+        that matches the given agent name.
+
+        Non-matching messages are discarded with a warning. Because
+        conductor only presents one gate at a time, any ``gate_response``
+        addressed to a different agent is stale (e.g. a duplicate click
+        from a dashboard that missed the first resolution) and cannot be
+        delivered — re-queueing would only cause it to be re-examined on
+        every subsequent gate with no chance of ever matching.
 
         Args:
             agent_name: The name of the human_gate agent to wait for.
@@ -300,10 +306,11 @@ class WebDashboard:
             msg = await self._gate_response_queue.get()
             if msg.get("agent_name") == agent_name:
                 return msg
-            # Not for this agent — put it back
-            self._gate_response_queue.put_nowait(msg)
-            # Yield to avoid busy-loop
-            await asyncio.sleep(0.01)
+            logger.warning(
+                "Discarding stale gate_response for agent %r while waiting on %r",
+                msg.get("agent_name"),
+                agent_name,
+            )
 
     # ------------------------------------------------------------------
     # Auto-shutdown (--web-bg)

--- a/tests/test_web/test_server.py
+++ b/tests/test_web/test_server.py
@@ -499,6 +499,50 @@ class TestServerStartupFailure:
             await dashboard.start()
 
 
+class TestWaitForGateResponse:
+    """Tests for WebDashboard.wait_for_gate_response stale-message handling."""
+
+    @pytest.mark.asyncio
+    async def test_returns_matching_response(self) -> None:
+        """Returns the message whose agent_name matches the awaited agent."""
+        _, dashboard = _make_dashboard()
+        await dashboard._gate_response_queue.put(
+            {"agent_name": "plan_approval", "selected_value": "approved"}
+        )
+
+        msg = await asyncio.wait_for(
+            dashboard.wait_for_gate_response("plan_approval"), timeout=1.0
+        )
+
+        assert msg["selected_value"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_discards_stale_non_matching_messages(self) -> None:
+        """Non-matching gate_response messages are discarded, not re-queued.
+
+        Regression test for the busy-loop bug where stale messages (e.g. a
+        duplicate click for a previously-resolved gate) were re-queued with
+        a 10ms sleep, spinning at ~100Hz forever because ``asyncio.Queue``
+        has no dedup.
+        """
+        _, dashboard = _make_dashboard()
+        # Enqueue a stale message followed by the matching one.
+        await dashboard._gate_response_queue.put(
+            {"agent_name": "old_gate", "selected_value": "approved"}
+        )
+        await dashboard._gate_response_queue.put(
+            {"agent_name": "current_gate", "selected_value": "rejected"}
+        )
+
+        msg = await asyncio.wait_for(
+            dashboard.wait_for_gate_response("current_gate"), timeout=1.0
+        )
+
+        assert msg["agent_name"] == "current_gate"
+        assert msg["selected_value"] == "rejected"
+        assert dashboard._gate_response_queue.empty()
+
+
 async def _short_grace(event: asyncio.Event, delay: float) -> None:
     """Helper for testing: short grace period."""
     await asyncio.sleep(delay)

--- a/tests/test_web/test_server.py
+++ b/tests/test_web/test_server.py
@@ -510,9 +510,7 @@ class TestWaitForGateResponse:
             {"agent_name": "plan_approval", "selected_value": "approved"}
         )
 
-        msg = await asyncio.wait_for(
-            dashboard.wait_for_gate_response("plan_approval"), timeout=1.0
-        )
+        msg = await asyncio.wait_for(dashboard.wait_for_gate_response("plan_approval"), timeout=1.0)
 
         assert msg["selected_value"] == "approved"
 
@@ -534,9 +532,7 @@ class TestWaitForGateResponse:
             {"agent_name": "current_gate", "selected_value": "rejected"}
         )
 
-        msg = await asyncio.wait_for(
-            dashboard.wait_for_gate_response("current_gate"), timeout=1.0
-        )
+        msg = await asyncio.wait_for(dashboard.wait_for_gate_response("current_gate"), timeout=1.0)
 
         assert msg["agent_name"] == "current_gate"
         assert msg["selected_value"] == "rejected"


### PR DESCRIPTION
## Summary

`WebDashboardServer.wait_for_gate_response` had a latent busy-loop bug that becomes reachable as soon as any `gate_response` WebSocket message targets a different agent than the one currently being awaited.

`python
while True:
    msg = await self._gate_response_queue.get()
    if msg.get(""agent_name"") == agent_name:
        return msg
    # Not for this agent — put it back
    self._gate_response_queue.put_nowait(msg)
    await asyncio.sleep(0.01)
`

`asyncio.Queue` has no deduplication. The same stale message is dequeued, re-enqueued, and re-inspected forever at ~100 iterations/sec, pinning a CPU core and preventing the waiter from ever blocking on a truly-empty queue.

## Why does this happen at all?

Conductor only presents one gate at a time, so in principle the queue should only ever contain messages targeting the active gate. But stale `gate_response` messages can reach the queue:

- A user double-clicks an option in the per-run dashboard.
- Two clients are connected and each sends a response.
- A slow client's frame arrives after the gate already resolved via another path.
- A malformed / buggy client sends a response with the wrong agent_name.

Previously this was masked by the `has_connections()` short-circuit in `_handle_gate_with_web` that skipped the web path entirely when no client was connected at gate-presentation time. With #95 removing that short-circuit, the spin becomes trivially reachable.

## Fix

Since only one gate is ever awaited concurrently, a non-matching `gate_response` is definitionally stale — the coroutine that would have accepted it is already gone, and re-queueing can never deliver it. Discard stale messages with a warning log, letting the next `await .get()` block properly on an empty queue until a genuine matching message arrives.

## Risk

Low. The `# so they are not lost` comment in the original code suggests re-queueing was defensive for a hypothetical future where multiple gates could be active simultaneously. Conductor's current architecture doesn't support that, and if it's ever added, a per-agent dispatch (e.g. `dict[str, Future]`) would be the right primitive rather than a shared queue with round-robin rescheduling.

## Tests

No existing tests cover `wait_for_gate_response`. A unit test that pushes a non-matching then matching message would document the contract — happy to add if desired.

## Related

- #95 (gate-race connection check) exposes this latent bug; both fixes should land together or #95 first, #96 second.