### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.8"
+version = "0.1.9"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Version bump for release v0.1.9 — includes the workflow registry feature.