### PR TITLE
fix: suppress PowerShell stderr noise from uv tool install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -115,7 +115,12 @@ try {
             Write-Info "Retrying install (attempt $attempt/$maxRetries)…"
             Start-Sleep -Seconds 2
         }
-        uv tool install --force "git+https://github.com/$Repo.git@$tagName" -c $constraintsFile 2>$null
+        $output = $null
+        try {
+            $output = & uv tool install --force "git+https://github.com/$Repo.git@$tagName" -c $constraintsFile 2>&1
+        } catch {
+            # PowerShell treats native stderr as errors when ErrorActionPreference=Stop
+        }
         if ($LASTEXITCODE -eq 0) {
             $installed = $true
             break


### PR DESCRIPTION
## Problem

When installing conductor on Windows via `irm https://aka.ms/conductor/install.ps1 | iex`, users see scary red error text even though the install succeeds:

```
uv : Resolved 53 packages in 71ms
    + CategoryInfo          : NotSpecified: (Resolved 53 packages in 71ms:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
```

## Cause

The script sets `$ErrorActionPreference = 'Stop'`. PowerShell converts any native command stderr output into `ErrorRecord` objects, and with `Stop` mode, these surface as `NativeCommandError` exceptions. `uv` writes progress info (like "Resolved 53 packages") to stderr, triggering this.

## Fix

Wrap the `uv tool install` call in `try/catch` and capture stderr with `2>&1`. The `$LASTEXITCODE` check still correctly determines success/failure.