### PR TITLE
feat(composition): dynamic sub-workflow inputs via input_mapping (#101)

### DIFF
--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -475,6 +475,24 @@ class AgentDef(BaseModel):
         workflow: ./research-pipeline.yaml
     """
 
+    input_mapping: dict[str, str] | None = None
+    """Optional mapping of sub-workflow input names to Jinja2 expressions.
+
+    Each key is a sub-workflow input parameter name. Each value is a Jinja2
+    template expression evaluated against the parent workflow's context.
+
+    When present, the rendered values are passed as the sub-workflow's inputs
+    instead of forwarding the parent's workflow.input.* values.
+
+    Only valid for type='workflow' agents.
+
+    Example::
+
+        input_mapping:
+          work_item_id: "{{ task_manager.output.current_issue_id }}"
+          title: "{{ task_manager.output.current_issue_title }}"
+    """
+
     max_session_seconds: float | None = Field(None, ge=1.0)
     """Maximum wall-clock duration for this agent's session in seconds.
 
@@ -529,6 +547,8 @@ class AgentDef(BaseModel):
                 raise ValueError("human_gate agents require 'options'")
             if not self.prompt:
                 raise ValueError("human_gate agents require 'prompt'")
+            if self.input_mapping:
+                raise ValueError("human_gate agents cannot have 'input_mapping'")
         elif self.type == "script":
             if not self.command:
                 raise ValueError("script agents require 'command'")
@@ -555,6 +575,8 @@ class AgentDef(BaseModel):
                 raise ValueError("script agents cannot have 'max_agent_iterations'")
             if self.retry is not None:
                 raise ValueError("script agents cannot have 'retry'")
+            if self.input_mapping:
+                raise ValueError("script agents cannot have 'input_mapping'")
         elif self.type == "workflow":
             if not self.workflow:
                 raise ValueError("workflow agents require 'workflow' path")
@@ -578,6 +600,13 @@ class AgentDef(BaseModel):
                 raise ValueError("workflow agents cannot have 'max_agent_iterations'")
             if self.retry is not None:
                 raise ValueError("workflow agents cannot have 'retry'")
+        else:
+            # Regular agent or human_gate — input_mapping is not valid
+            if self.input_mapping:
+                raise ValueError(
+                    f"'{self.type or 'agent'}' agents cannot have 'input_mapping' "
+                    "(only workflow agents support input_mapping)"
+                )
         return self
 
 

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -547,7 +547,7 @@ class AgentDef(BaseModel):
                 raise ValueError("human_gate agents require 'options'")
             if not self.prompt:
                 raise ValueError("human_gate agents require 'prompt'")
-            if self.input_mapping:
+            if self.input_mapping is not None:
                 raise ValueError("human_gate agents cannot have 'input_mapping'")
         elif self.type == "script":
             if not self.command:
@@ -575,7 +575,7 @@ class AgentDef(BaseModel):
                 raise ValueError("script agents cannot have 'max_agent_iterations'")
             if self.retry is not None:
                 raise ValueError("script agents cannot have 'retry'")
-            if self.input_mapping:
+            if self.input_mapping is not None:
                 raise ValueError("script agents cannot have 'input_mapping'")
         elif self.type == "workflow":
             if not self.workflow:
@@ -602,7 +602,7 @@ class AgentDef(BaseModel):
                 raise ValueError("workflow agents cannot have 'retry'")
         else:
             # Regular agent or human_gate — input_mapping is not valid
-            if self.input_mapping:
+            if self.input_mapping is not None:
                 raise ValueError(
                     f"'{self.type or 'agent'}' agents cannot have 'input_mapping' "
                     "(only workflow agents support input_mapping)"

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -546,17 +546,21 @@ class WorkflowEngine:
 
         # Build sub-workflow inputs from the parent context
         sub_inputs: dict[str, Any]
-        if agent.input_mapping:
+        if agent.input_mapping is not None:
             # Dynamic inputs: render each Jinja2 expression against parent context
             renderer = TemplateRenderer()
             sub_inputs = {}
             for key, template_expr in agent.input_mapping.items():
-                rendered = renderer.render(template_expr, context)
-                # Attempt to parse rendered values as JSON for non-string types
                 try:
-                    sub_inputs[key] = json.loads(rendered)
-                except (json.JSONDecodeError, ValueError):
-                    sub_inputs[key] = rendered
+                    rendered = renderer.render(template_expr, context)
+                except Exception as e:
+                    raise ExecutionError(
+                        f"Failed to render input_mapping key '{key}' for agent "
+                        f"'{agent.name}': {e}",
+                        suggestion=f"Check that the expression '{template_expr}' "
+                        "references valid context variables.",
+                    ) from e
+                sub_inputs[key] = rendered
         else:
             # Default: forward parent's workflow.input.* values
             workflow_ctx = context.get("workflow", {})
@@ -577,14 +581,6 @@ class WorkflowEngine:
             web_dashboard=self._web_dashboard,
             _subworkflow_depth=self._subworkflow_depth + 1,
         )
-
-        # Inject parent agent outputs into the child workflow's context.
-        # This allows sub-workflow agents that declare parent agents in their
-        # input: list (e.g., task_manager.output?) to access parent state
-        # even when input_mapping doesn't cover all fields.
-        for key, value in context.items():
-            if key not in ("workflow", "context") and isinstance(value, dict):
-                child_engine.context.agent_outputs[key] = value.get("output", value)
 
         return await child_engine.run(sub_inputs)
 

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -578,6 +578,14 @@ class WorkflowEngine:
             _subworkflow_depth=self._subworkflow_depth + 1,
         )
 
+        # Inject parent agent outputs into the child workflow's context.
+        # This allows sub-workflow agents that declare parent agents in their
+        # input: list (e.g., task_manager.output?) to access parent state
+        # even when input_mapping doesn't cover all fields.
+        for key, value in context.items():
+            if key not in ("workflow", "context") and isinstance(value, dict):
+                child_engine.context.agent_outputs[key] = value.get("output", value)
+
         return await child_engine.run(sub_inputs)
 
     def _get_context_window_for_agent(self, agent: AgentDef) -> int | None:

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -545,11 +545,24 @@ class WorkflowEngine:
             ) from exc
 
         # Build sub-workflow inputs from the parent context
-        # Extract workflow.input.* values from the parent context
-        workflow_ctx = context.get("workflow", {})
-        sub_inputs: dict[str, Any] = (
-            dict(workflow_ctx.get("input", {})) if isinstance(workflow_ctx, dict) else {}
-        )
+        sub_inputs: dict[str, Any]
+        if agent.input_mapping:
+            # Dynamic inputs: render each Jinja2 expression against parent context
+            renderer = TemplateRenderer()
+            sub_inputs = {}
+            for key, template_expr in agent.input_mapping.items():
+                rendered = renderer.render(template_expr, context)
+                # Attempt to parse rendered values as JSON for non-string types
+                try:
+                    sub_inputs[key] = json.loads(rendered)
+                except (json.JSONDecodeError, ValueError):
+                    sub_inputs[key] = rendered
+        else:
+            # Default: forward parent's workflow.input.* values
+            workflow_ctx = context.get("workflow", {})
+            sub_inputs = (
+                dict(workflow_ctx.get("input", {})) if isinstance(workflow_ctx, dict) else {}
+            )
 
         # Create child engine inheriting provider/registry but with deeper depth
         child_engine = WorkflowEngine(

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -555,8 +555,7 @@ class WorkflowEngine:
                     rendered = renderer.render(template_expr, context)
                 except Exception as e:
                     raise ExecutionError(
-                        f"Failed to render input_mapping key '{key}' for agent "
-                        f"'{agent.name}': {e}",
+                        f"Failed to render input_mapping key '{key}' for agent '{agent.name}': {e}",
                         suggestion=f"Check that the expression '{template_expr}' "
                         "references valid context variables.",
                     ) from e

--- a/tests/test_config/test_workflow_type_schema.py
+++ b/tests/test_config/test_workflow_type_schema.py
@@ -284,3 +284,58 @@ class TestWorkflowWorkflowConfig:
         # Should not raise
         warnings = validate_workflow_config(config)
         assert isinstance(warnings, list)
+
+
+class TestInputMapping:
+    """Tests for input_mapping on workflow agents."""
+
+    def test_valid_input_mapping(self) -> None:
+        """Test that input_mapping is accepted on workflow agents."""
+        agent = AgentDef(
+            name="sub_wf",
+            type="workflow",
+            workflow="./sub.yaml",
+            input_mapping={
+                "work_item_id": "{{ intake.output.epic_id }}",
+                "title": "{{ intake.output.epic_title }}",
+            },
+        )
+        assert agent.input_mapping is not None
+        assert len(agent.input_mapping) == 2
+
+    def test_workflow_without_input_mapping(self) -> None:
+        """Test that workflow agents work without input_mapping (backward compat)."""
+        agent = AgentDef(name="sub_wf", type="workflow", workflow="./sub.yaml")
+        assert agent.input_mapping is None
+
+    def test_input_mapping_on_regular_agent_raises(self) -> None:
+        """Test that input_mapping on a regular agent raises ValidationError."""
+        with pytest.raises(ValidationError, match="input_mapping"):
+            AgentDef(
+                name="regular",
+                prompt="do something",
+                input_mapping={"key": "{{ value }}"},
+            )
+
+    def test_input_mapping_on_human_gate_raises(self) -> None:
+        """Test that input_mapping on a human_gate raises ValidationError."""
+        with pytest.raises(ValidationError, match="input_mapping"):
+            AgentDef(
+                name="gate",
+                type="human_gate",
+                prompt="Choose",
+                options=[
+                    GateOption(label="Yes", value="yes", route="next"),
+                ],
+                input_mapping={"key": "{{ value }}"},
+            )
+
+    def test_input_mapping_on_script_raises(self) -> None:
+        """Test that input_mapping on a script agent raises ValidationError."""
+        with pytest.raises(ValidationError, match="input_mapping"):
+            AgentDef(
+                name="script",
+                type="script",
+                command="echo hi",
+                input_mapping={"key": "{{ value }}"},
+            )

--- a/tests/test_engine/test_subworkflow.py
+++ b/tests/test_engine/test_subworkflow.py
@@ -525,3 +525,418 @@ class TestSubWorkflowIterationCounting:
         await engine.run({})
 
         assert engine.limits.current_iteration == 1
+
+
+class TestSubWorkflowInputMapping:
+    """Tests for input_mapping on sub-workflow agents."""
+
+    @pytest.mark.asyncio
+    async def test_input_mapping_renders_expressions(self, tmp_workflow_dir: Path) -> None:
+        """Test that input_mapping Jinja2 expressions are rendered and passed as strings."""
+        _write_yaml(
+            tmp_workflow_dir / "sub.yaml",
+            """\
+            workflow:
+              name: sub-wf
+              entry_point: inner
+              runtime:
+                provider: copilot
+              input:
+                item_id:
+                  type: string
+                  required: true
+                title:
+                  type: string
+                  required: true
+              limits:
+                max_iterations: 5
+            agents:
+              - name: inner
+                prompt: "Work on {{ workflow.input.item_id }}: {{ workflow.input.title }}"
+                routes:
+                  - to: "$end"
+            output:
+              result: "{{ inner.output.result }}"
+            """,
+        )
+
+        parent_path = tmp_workflow_dir / "parent.yaml"
+        parent_path.write_text("dummy", encoding="utf-8")
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="setup",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="setup",
+                    prompt="Setup",
+                    routes=[RouteDef(to="sub_wf")],
+                ),
+                AgentDef(
+                    name="sub_wf",
+                    type="workflow",
+                    workflow="sub.yaml",
+                    input_mapping={
+                        "item_id": "{{ setup.output.id }}",
+                        "title": "{{ setup.output.name }}",
+                    },
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"result": "{{ sub_wf.output.result }}"},
+        )
+
+        received_prompts: list[str] = []
+
+        def mock_handler(agent, prompt, context):
+            received_prompts.append(prompt)
+            if agent.name == "setup":
+                return {"id": "42", "name": "Fix the bug"}
+            return {"result": "done"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        engine = WorkflowEngine(config, provider, workflow_path=parent_path)
+        result = await engine.run({})
+
+        assert result["result"] == "done"
+        # The inner agent should have received the mapped values
+        assert any("42" in p and "Fix the bug" in p for p in received_prompts)
+
+    @pytest.mark.asyncio
+    async def test_input_mapping_values_are_strings(self, tmp_workflow_dir: Path) -> None:
+        """Test that input_mapping passes values as strings (no json.loads coercion).
+
+        The rendered template values are always strings when entering the child
+        workflow. Output template rendering may coerce them further, so we verify
+        via the prompt the child agent actually receives.
+        """
+        _write_yaml(
+            tmp_workflow_dir / "sub.yaml",
+            """\
+            workflow:
+              name: sub-wf
+              entry_point: inner
+              runtime:
+                provider: copilot
+              input:
+                count:
+                  type: string
+                  required: true
+                flag:
+                  type: string
+                  required: true
+              limits:
+                max_iterations: 5
+            agents:
+              - name: inner
+                prompt: "Count={{ workflow.input.count }} Flag={{ workflow.input.flag }}"
+                routes:
+                  - to: "$end"
+            output:
+              result: "{{ inner.output.result }}"
+            """,
+        )
+
+        parent_path = tmp_workflow_dir / "parent.yaml"
+        parent_path.write_text("dummy", encoding="utf-8")
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="setup",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="setup",
+                    prompt="Setup",
+                    routes=[RouteDef(to="sub_wf")],
+                ),
+                AgentDef(
+                    name="sub_wf",
+                    type="workflow",
+                    workflow="sub.yaml",
+                    input_mapping={
+                        "count": "{{ setup.output.num }}",
+                        "flag": "{{ setup.output.active }}",
+                    },
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"result": "{{ sub_wf.output.result }}"},
+        )
+
+        received_prompts: list[str] = []
+
+        def mock_handler(agent, prompt, context):
+            received_prompts.append(prompt)
+            if agent.name == "setup":
+                return {"num": "42", "active": "true"}
+            return {"result": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        engine = WorkflowEngine(config, provider, workflow_path=parent_path)
+        await engine.run({})
+
+        # The child's inner agent should see the string values rendered into the prompt
+        inner_prompt = [p for p in received_prompts if "Count=" in p][0]
+        assert "Count=42" in inner_prompt
+        assert "Flag=true" in inner_prompt
+
+    @pytest.mark.asyncio
+    async def test_no_input_mapping_forwards_parent_inputs(self, tmp_workflow_dir: Path) -> None:
+        """Test backward compat: no input_mapping forwards parent workflow.input.*."""
+        _write_yaml(
+            tmp_workflow_dir / "sub.yaml",
+            """\
+            workflow:
+              name: sub-wf
+              entry_point: inner
+              runtime:
+                provider: copilot
+              input:
+                topic:
+                  type: string
+                  required: false
+                  default: "default"
+              limits:
+                max_iterations: 5
+            agents:
+              - name: inner
+                prompt: "Work on {{ workflow.input.topic }}"
+                routes:
+                  - to: "$end"
+            output:
+              topic: "{{ workflow.input.topic }}"
+            """,
+        )
+
+        parent_path = tmp_workflow_dir / "parent.yaml"
+        parent_path.write_text("dummy", encoding="utf-8")
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="sub_wf",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="sub_wf",
+                    type="workflow",
+                    workflow="sub.yaml",
+                    # No input_mapping — should forward parent's workflow.input.*
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"topic": "{{ sub_wf.output.topic }}"},
+        )
+
+        def mock_handler(agent, prompt, context):
+            return {"result": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        engine = WorkflowEngine(config, provider, workflow_path=parent_path)
+        result = await engine.run({"topic": "Python"})
+
+        # Parent's workflow.input.topic should be forwarded to child
+        assert result["topic"] == "Python"
+
+    @pytest.mark.asyncio
+    async def test_empty_input_mapping_passes_nothing(self, tmp_workflow_dir: Path) -> None:
+        """Test that input_mapping: {} means 'pass no inputs' (not default forwarding)."""
+        _write_yaml(
+            tmp_workflow_dir / "sub.yaml",
+            """\
+            workflow:
+              name: sub-wf
+              entry_point: inner
+              runtime:
+                provider: copilot
+              input:
+                topic:
+                  type: string
+                  required: false
+                  default: "fallback"
+              limits:
+                max_iterations: 5
+            agents:
+              - name: inner
+                prompt: "Work on {{ workflow.input.topic }}"
+                routes:
+                  - to: "$end"
+            output:
+              topic: "{{ workflow.input.topic }}"
+            """,
+        )
+
+        parent_path = tmp_workflow_dir / "parent.yaml"
+        parent_path.write_text("dummy", encoding="utf-8")
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="sub_wf",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="sub_wf",
+                    type="workflow",
+                    workflow="sub.yaml",
+                    input_mapping={},  # Explicitly empty — pass nothing
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"topic": "{{ sub_wf.output.topic }}"},
+        )
+
+        def mock_handler(agent, prompt, context):
+            return {"result": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        engine = WorkflowEngine(config, provider, workflow_path=parent_path)
+        result = await engine.run({"topic": "Python"})
+
+        # Empty input_mapping = no inputs passed, child should use its default
+        assert result["topic"] == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_input_mapping_error_includes_key_name(self, tmp_workflow_dir: Path) -> None:
+        """Test that template errors include the failing key name."""
+        _write_yaml(
+            tmp_workflow_dir / "sub.yaml",
+            """\
+            workflow:
+              name: sub-wf
+              entry_point: inner
+              runtime:
+                provider: copilot
+              input:
+                value:
+                  type: string
+                  required: true
+              limits:
+                max_iterations: 5
+            agents:
+              - name: inner
+                prompt: "Use {{ workflow.input.value }}"
+                routes:
+                  - to: "$end"
+            output:
+              result: "done"
+            """,
+        )
+
+        parent_path = tmp_workflow_dir / "parent.yaml"
+        parent_path.write_text("dummy", encoding="utf-8")
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="sub_wf",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="sub_wf",
+                    type="workflow",
+                    workflow="sub.yaml",
+                    input_mapping={
+                        "value": "{{ nonexistent_agent.output.missing }}",
+                    },
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+
+        mock_provider = MagicMock()
+        engine = WorkflowEngine(config, mock_provider, workflow_path=parent_path)
+
+        with pytest.raises(ExecutionError, match="input_mapping key 'value'"):
+            await engine.run({})
+
+    @pytest.mark.asyncio
+    async def test_no_parent_context_leaks_to_child(self, tmp_workflow_dir: Path) -> None:
+        """Test that parent agent outputs are NOT injected into child context."""
+        _write_yaml(
+            tmp_workflow_dir / "sub.yaml",
+            """\
+            workflow:
+              name: sub-wf
+              entry_point: inner
+              runtime:
+                provider: copilot
+              input:
+                data:
+                  type: string
+                  required: true
+              limits:
+                max_iterations: 5
+            agents:
+              - name: inner
+                prompt: "Use {{ workflow.input.data }}"
+                routes:
+                  - to: "$end"
+            output:
+              result: "{{ inner.output.result }}"
+            """,
+        )
+
+        parent_path = tmp_workflow_dir / "parent.yaml"
+        parent_path.write_text("dummy", encoding="utf-8")
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="setup",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="setup",
+                    prompt="Setup",
+                    routes=[RouteDef(to="sub_wf")],
+                ),
+                AgentDef(
+                    name="sub_wf",
+                    type="workflow",
+                    workflow="sub.yaml",
+                    input_mapping={"data": "{{ setup.output.value }}"},
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"result": "{{ sub_wf.output.result }}"},
+        )
+
+        child_contexts: list[dict] = []
+
+        def mock_handler(agent, prompt, context):
+            if agent.name == "setup":
+                return {"value": "hello"}
+            # Capture what the child's inner agent can see
+            child_contexts.append(dict(context))
+            return {"result": "done"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        engine = WorkflowEngine(config, provider, workflow_path=parent_path)
+        await engine.run({})
+
+        # Parent's "setup" agent should NOT appear in child's context
+        assert len(child_contexts) == 1
+        assert "setup" not in child_contexts[0]

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -181,7 +181,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.77.0,<1.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "github-copilot-sdk", specifier = ">=0.2.2" },
+    { name = "github-copilot-sdk", specifier = ">=0.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mcp", specifier = ">=1.0.0" },
@@ -366,19 +366,19 @@ wheels = [
 
 [[package]]
 name = "github-copilot-sdk"
-version = "0.2.2"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/15/51c75638d5c662d109be53fca1f42de373d02be505f336c02a2b3db10b26/github_copilot_sdk-0.2.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:75bcd2ed3cc1b6a63c140c3c86850b9fb97b8d595a238f26be67db54bf037c6b", size = 58290616, upload-time = "2026-04-10T09:03:14.187Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2e/228bd47c424cb423430842fa3836559018346a514776417ae04da3d9ba23/github_copilot_sdk-0.2.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a5a679a8afcec901092855c9abd906d06e83407b54008a78a8e980f44464a2d2", size = 55043721, upload-time = "2026-04-10T09:03:17.845Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/13/d28af1baef7e194ea54d895e2e8f1ce061d85a9f38282fe8f3679a3f919f/github_copilot_sdk-0.2.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:19a2ae280b550fbc4fcdce8293afe4dc4a822ec987ee353ce6a7d218577a5b3b", size = 61236750, upload-time = "2026-04-10T09:03:21.358Z" },
-    { url = "https://files.pythonhosted.org/packages/99/21/9658979f0c694e0a7393c555cf41dd0a6bc6be6e52aed85e8d2a5fe698f8/github_copilot_sdk-0.2.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:06cf4c14acba2a32d28adae85c26b2b6324c1d29d8cf57c7eb73babcdc052558", size = 59414326, upload-time = "2026-04-10T09:03:24.932Z" },
-    { url = "https://files.pythonhosted.org/packages/36/be/dfd87b372ada6b4aa96a1333784e0df7eabe9da40db560b211358d6b98d9/github_copilot_sdk-0.2.2-py3-none-win_amd64.whl", hash = "sha256:887553330d92b266d45cbde5d6d480809471ae23c5f0e3762a7b73ff2c75e34c", size = 53874015, upload-time = "2026-04-10T09:03:28.804Z" },
-    { url = "https://files.pythonhosted.org/packages/89/cf/fb3ffda1967a8fb71f0ec32b099ef858b0342851f11cd4fc8b89bd8df10a/github_copilot_sdk-0.2.2-py3-none-win_arm64.whl", hash = "sha256:7d76badbed12e012a811552e91f29a79bdca3e597fd876869d313399fd27c5ad", size = 51806384, upload-time = "2026-04-10T09:03:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d7/3d71064646a24d633c9dec035ff8b5b6d72c11d3aad765e54efd71737f0f/github_copilot_sdk-0.3.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:ed8f27989158824c754d7febb473bdf25744a1e6bc07a06f114f7e7deebd2c22", size = 58566984, upload-time = "2026-04-24T16:05:37.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/439854722b951a2f213c23cc731e9a31d46c8b1e2f1b1de080745c03c798/github_copilot_sdk-0.3.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7e241d9b00ebf8bb4d10b2d6101c75fcef38de04d144d729e07fa48394270ee1", size = 55318729, upload-time = "2026-04-24T16:05:41.734Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/931a65b17ad36d3b8987d8cb9bd2835f759c79ae1799fdc34d1252c38b6f/github_copilot_sdk-0.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:f4d98a67b8f038885ddd38bd7033d1ac20c3010f04c72ee0fc74ba4984b69ffa", size = 61452705, upload-time = "2026-04-24T16:05:45.225Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e5/7e275fc76a7f9cc3240da393ed631d9647c346a36d6392ea4b0ed56326f6/github_copilot_sdk-0.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b591546d789f9f8243fb59ca71b08cb0bb1dbec818fbef060c3830c6787de2c8", size = 59646875, upload-time = "2026-04-24T16:05:48.832Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/67/00e3bf21842b0c418aad6ce233ec8cd7e8ca91859e4f7e571fc47c682ed9/github_copilot_sdk-0.3.0-py3-none-win_amd64.whl", hash = "sha256:c5712d57a2c6291b805c79e039c55c48d858034b1a37fc8e1653925403a028e9", size = 54165496, upload-time = "2026-04-24T16:05:52.712Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1c/76bb5159018a1c0d44b17ded340c91085fb48dd3dc912eb349781c54c200/github_copilot_sdk-0.3.0-py3-none-win_arm64.whl", hash = "sha256:93b07c46f60cebbbb003d5bddba22eab886849b1d052b98037b52b6434a5bc07", size = 52103138, upload-time = "2026-04-24T16:05:56.329Z" },
 ]
 
 [[package]]
@@ -868,11 +868,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an optional `input_mapping` field to `type: workflow` agents, enabling parameterized sub-workflow invocation. Each key maps a sub-workflow input name to a Jinja2 expression evaluated in the parent's context.

Closes #101

## Example

```yaml
agents:
  - name: plan_issue
    type: workflow
    workflow: ./plan-and-review.yaml
    input_mapping:
      work_item_id: "{{ task_manager.output.current_issue_id }}"
      title: "{{ task_manager.output.current_issue_title }}"
```

Without `input_mapping`, parent's `workflow.input.*` is forwarded (existing behavior preserved).

## Changes

- Schema: `input_mapping: dict[str, str] | None` on `AgentDef`, validated only for `type: workflow`
- Engine: render `input_mapping` templates against parent context in `_execute_subworkflow`
- Tests included

## Dependency

Foundation for #102 (for_each with workflows) and #103 (self-referential workflows).