### PR TITLE
docs: add comprehensive MCP tools documentation and fix outdated references

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,11 +122,9 @@ workflow:
 
 **Note**: This is output tokens, not context window (200K separate limit)
 
-## Copilot-Specific Configuration
+## MCP Servers
 
-### MCP Servers
-
-Configure Model Context Protocol servers for tool access:
+Configure [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers for tool access. Both the Copilot and Claude providers support MCP tools.
 
 ```yaml
 workflow:
@@ -144,7 +142,9 @@ workflow:
         tools: ["*"]
 ```
 
-**Note**: MCP servers not available with Claude provider in Phase 1
+> **Provider note:** The Claude provider supports `stdio` servers only. HTTP and SSE servers are Copilot-only.
+
+For full details on server types, tool filtering, environment variables, and OAuth authentication, see the [MCP Tools guide](mcp-tools.md).
 
 ## Context Configuration
 
@@ -358,18 +358,13 @@ default_model: claude-sonnet-4.5
 default_model: claude-3.5-sonnet  # Wrong: dot instead of dash
 ```
 
-### "MCP servers not supported" (Claude)
+### MCP servers not working (Claude)
 
-Remove `mcp_servers` when using Claude provider (Phase 1):
-
-```yaml
-runtime:
-  provider: claude
-  # Remove mcp_servers section
-```
+The Claude provider only supports `stdio` MCP servers. If you are using `http` or `sse` servers, switch to the Copilot provider or use a stdio-based server instead. See the [MCP Tools guide](mcp-tools.md) for provider-specific details.
 
 ## See Also
 
+- [MCP Tools](mcp-tools.md)
 - [Claude Provider Documentation](providers/claude.md)
 - [Provider Comparison](providers/comparison.md)
 - [Migration Guide](providers/migration.md)

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -171,6 +171,41 @@ mcp_servers:
 
 Environment variables are resolved at runtime from the current process environment, not at YAML load time. This allows sensitive values like API keys to remain outside the workflow file.
 
+### Passing values from the command line
+
+You can pass configuration to MCP servers at runtime by setting environment variables before running the workflow:
+
+```bash
+# Pass an API key to the MCP server
+MY_API_KEY=sk-abc123 uv run conductor run workflow.yaml --input.question="test"
+
+# Or export first
+export MY_API_KEY=sk-abc123
+uv run conductor run workflow.yaml --input.question="test"
+```
+
+```yaml
+# workflow.yaml
+workflow:
+  runtime:
+    mcp_servers:
+      my-server:
+        command: node
+        args: ["server.js"]
+        env:
+          API_KEY: ${MY_API_KEY}            # Resolved from OS environment at runtime
+          ENDPOINT: ${API_ENDPOINT:-https://api.example.com}
+```
+
+On Windows (PowerShell):
+
+```powershell
+$env:MY_API_KEY = "sk-abc123"
+uv run conductor run workflow.yaml --input.question="test"
+```
+
+> **Note:** Workflow inputs (`--input.*`) and MCP server environment variables are separate systems. `--input.*` values are available in Jinja2 templates (agent prompts, routes) as `{{ workflow.input.name }}`, while MCP server `env` values come from OS environment variables via `${VAR}` syntax.
+
 > **Known issue (Copilot provider):** The Copilot SDK has a bug where `env` variables in MCP server configs are not passed to MCP server subprocesses. As a workaround, you can inline env vars into the command using shell syntax:
 > ```yaml
 > mcp_servers:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,310 @@
+# MCP Tools
+
+Conductor supports [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, enabling agents to use external tools such as web search, code execution, file operations, and custom API integrations.
+
+MCP servers are configured at the workflow level and made available to all agents. Each agent can optionally filter which tools it uses.
+
+## Quick Start
+
+Add an MCP server to your workflow's `runtime` section:
+
+```yaml
+workflow:
+  name: research-workflow
+  entry_point: researcher
+  runtime:
+    provider: copilot
+    mcp_servers:
+      web-search:
+        command: npx
+        args: ["-y", "open-websearch@latest"]
+        tools: ["*"]
+```
+
+The agent can now use tools provided by the `web-search` MCP server.
+
+## Server Types
+
+Conductor supports three MCP server transport types:
+
+### stdio (default)
+
+Spawns a local process and communicates over stdin/stdout. This is the most common type.
+
+```yaml
+mcp_servers:
+  web-search:
+    type: stdio          # default, can be omitted
+    command: npx
+    args: ["-y", "open-websearch@latest"]
+    env:
+      MODE: stdio
+    tools: ["*"]
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `type` | No | `"stdio"` (default) |
+| `command` | **Yes** | Command to run (e.g., `npx`, `node`, `python`) |
+| `args` | No | Command-line arguments (list of strings) |
+| `env` | No | Environment variables for the subprocess |
+| `tools` | No | Tool filter list; `["*"]` = all tools (default) |
+| `timeout` | No | Timeout in milliseconds |
+
+### http
+
+Connects to a remote MCP server over HTTP with streamable transport.
+
+```yaml
+mcp_servers:
+  remote-tools:
+    type: http
+    url: https://mcp.example.com/tools
+    headers:
+      X-Api-Key: ${API_KEY}
+    tools: ["*"]
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `type` | **Yes** | `"http"` |
+| `url` | **Yes** | Server URL |
+| `headers` | No | HTTP headers (e.g., API keys) |
+| `tools` | No | Tool filter list; `["*"]` = all tools (default) |
+| `timeout` | No | Timeout in milliseconds |
+
+### sse
+
+Connects to a remote MCP server over Server-Sent Events (SSE).
+
+```yaml
+mcp_servers:
+  streaming-tools:
+    type: sse
+    url: https://mcp.example.com/sse
+    headers:
+      Authorization: Bearer ${TOKEN}
+    tools: ["*"]
+```
+
+The configuration fields are the same as `http`.
+
+> **Provider note:** The Claude provider only supports `stdio` servers. The `http` and `sse` types are supported by the Copilot provider only.
+
+## Configuration Reference
+
+### Full Schema
+
+```yaml
+workflow:
+  runtime:
+    mcp_servers:
+      <server-name>:           # Unique name (used as tool prefix)
+        type: stdio | http | sse   # Transport type (default: stdio)
+        
+        # stdio fields
+        command: <string>      # Command to run (required for stdio)
+        args: [<string>, ...]  # Command arguments
+        env:                   # Environment variables
+          KEY: value
+        
+        # http/sse fields
+        url: <string>          # Server URL (required for http/sse)
+        headers:               # HTTP headers
+          Header-Name: value
+        
+        # Common fields
+        tools: ["*"]           # Tool filter (default: all)
+        timeout: <int>         # Timeout in milliseconds
+```
+
+### Tool Naming
+
+Tools from MCP servers are prefixed with the server name to avoid collisions:
+
+```
+{server-name}__{tool-name}
+```
+
+For example, a server named `web-search` providing a tool called `search` becomes `web-search__search`.
+
+### Tool Filtering
+
+You can control which tools are available at two levels:
+
+**Per-server filtering** — limit which tools from a server are exposed:
+
+```yaml
+mcp_servers:
+  web-search:
+    command: npx
+    args: ["-y", "open-websearch@latest"]
+    tools: ["search"]  # Only expose the "search" tool, not all tools
+```
+
+**Per-agent filtering** — limit which tools a specific agent can use:
+
+```yaml
+agents:
+  - name: researcher
+    tools:
+      - web-search__search      # Only this MCP tool
+    prompt: "Research the topic..."
+```
+
+When an agent specifies a `tools` list, only matching MCP tools are included in its requests. If `tools` is omitted or `null`, all available tools are passed.
+
+## Environment Variables
+
+MCP server environment variables support `${VAR}` and `${VAR:-default}` syntax for runtime resolution:
+
+```yaml
+mcp_servers:
+  my-server:
+    command: node
+    args: ["server.js"]
+    env:
+      API_KEY: ${MY_API_KEY}              # Required — fails if not set
+      DEBUG: ${DEBUG_MODE:-false}          # Optional — defaults to "false"
+      REGION: ${AWS_REGION:-us-east-1}    # Optional — defaults to "us-east-1"
+```
+
+Environment variables are resolved at runtime from the current process environment, not at YAML load time. This allows sensitive values like API keys to remain outside the workflow file.
+
+> **Known issue (Copilot provider):** The Copilot SDK has a bug where `env` variables in MCP server configs are not passed to MCP server subprocesses. As a workaround, you can inline env vars into the command using shell syntax:
+> ```yaml
+> mcp_servers:
+>   web-search:
+>     command: sh
+>     args: ["-c", "MODE=stdio exec npx -y open-websearch@latest"]
+> ```
+> See [copilot-sdk#163](https://github.com/github/copilot-sdk/issues/163) for status.
+
+## OAuth Authentication (HTTP/SSE)
+
+For HTTP and SSE servers that require OAuth, Conductor can automatically discover OAuth requirements and fetch Azure AD tokens.
+
+**How it works:**
+
+1. Conductor checks `{server-url}/.well-known/oauth-protected-resource/` for OAuth metadata
+2. If the server requires OAuth and no `Authorization` header is configured, Conductor extracts the required scope
+3. An Azure AD token is fetched using the Azure CLI (`az account get-access-token`)
+4. The token is added as a `Bearer` token in the `Authorization` header
+
+**Prerequisites:**
+- Azure CLI installed and authenticated (`az login`)
+- The MCP server must expose a `.well-known/oauth-protected-resource/` endpoint
+
+**Manual auth:** If you prefer to manage tokens yourself, set the `Authorization` header directly:
+
+```yaml
+mcp_servers:
+  secure-server:
+    type: http
+    url: https://mcp.example.com
+    headers:
+      Authorization: Bearer ${MY_TOKEN}
+```
+
+## Provider Support
+
+| Feature | Copilot | Claude |
+|---|---|---|
+| stdio servers | ✅ | ✅ |
+| http servers | ✅ | ❌ |
+| sse servers | ✅ | ❌ |
+| Tool filtering | ✅ | ✅ |
+| OAuth auto-auth | ✅ | N/A |
+| env var passing | ⚠️ Bug ([#163](https://github.com/github/copilot-sdk/issues/163)) | ✅ |
+
+### Copilot Provider
+
+The Copilot provider passes MCP server configurations directly to the Copilot SDK, which handles server lifecycle, tool discovery, and tool execution internally. All three transport types (`stdio`, `http`, `sse`) are supported.
+
+### Claude Provider
+
+The Claude provider uses Conductor's built-in `MCPManager` to spawn and manage MCP server connections. It:
+
+- Connects to `stdio` servers only
+- Converts MCP tools to Claude's native tool format
+- Routes tool calls through the MCP session
+- Runs an agentic loop: Claude decides when to call tools, Conductor executes them and returns results
+
+HTTP and SSE servers are not supported with the Claude provider. If configured, a warning is logged and the server is skipped.
+
+## Examples
+
+### Web Search
+
+```yaml
+workflow:
+  name: web-research
+  entry_point: researcher
+  runtime:
+    provider: copilot
+    mcp_servers:
+      web-search:
+        command: sh
+        args: ["-c", "MODE=stdio DEFAULT_SEARCH_ENGINE=bing exec npx -y open-websearch@latest"]
+        tools: ["search"]
+
+agents:
+  - name: researcher
+    prompt: "Search the web for: {{ workflow.input.query }}"
+    routes:
+      - to: $end
+```
+
+### Multiple MCP Servers
+
+```yaml
+workflow:
+  name: multi-tool
+  entry_point: assistant
+  runtime:
+    provider: copilot
+    mcp_servers:
+      web-search:
+        command: npx
+        args: ["-y", "open-websearch@latest"]
+        tools: ["*"]
+      context7:
+        command: npx
+        args: ["-y", "@upstash/context7-mcp@latest"]
+        tools: ["*"]
+
+agents:
+  - name: assistant
+    prompt: "Help the user with their request: {{ workflow.input.question }}"
+    routes:
+      - to: $end
+```
+
+### Claude with MCP Tools
+
+```yaml
+workflow:
+  name: claude-with-tools
+  entry_point: researcher
+  runtime:
+    provider: claude
+    default_model: claude-sonnet-4-5
+    mcp_servers:
+      web-search:
+        command: npx
+        args: ["-y", "open-websearch@latest"]
+        env:
+          MODE: stdio
+
+agents:
+  - name: researcher
+    prompt: "Research the following topic: {{ workflow.input.topic }}"
+    routes:
+      - to: $end
+```
+
+## See Also
+
+- [Workflow Syntax Reference](workflow-syntax.md) — agent `tools` field
+- [Configuration Guide](configuration.md) — runtime configuration
+- [Provider Comparison](providers/comparison.md) — feature comparison

--- a/docs/providers/comparison.md
+++ b/docs/providers/comparison.md
@@ -11,7 +11,7 @@ This guide helps you choose between GitHub Copilot and Anthropic Claude provider
 | **Setup** | GitHub auth | API key | Copilot (easier) |
 | **Model Selection** | GPT-5.2, o1 | Haiku, Sonnet, Opus | Tie |
 | **Streaming** | Yes | No (Phase 1) | Copilot |
-| **Tool Support** | Yes (MCP) | No (Phase 1) | Copilot |
+| **Tool Support** | Yes (MCP, all types) | Yes (MCP, stdio only) | Copilot |
 | **Speed** | Fast | Fast | Tie |
 | **Output Quality** | Excellent | Excellent | Tie |
 | **Cost Predictability** | High (flat rate) | Variable (usage-based) | Copilot |
@@ -229,16 +229,18 @@ agents:
 ### Tool Support (MCP)
 
 **Copilot**:
-- ✅ Full MCP support
+- ✅ Full MCP support (stdio, http, sse)
 - Web search, code execution, file ops
 - Workflow-level and agent-level tools
 
 **Claude**:
-- ❌ Not available in Phase 1
-- Deferred to Phase 2
-- Research needed for compatibility
+- ✅ MCP support for stdio servers
+- Uses Conductor's built-in MCPManager
+- HTTP/SSE servers not supported
 
-**Winner**: Copilot (until Claude Phase 2+)
+**Winner**: Copilot (broader transport support)
+
+See the [MCP Tools guide](../mcp-tools.md) for details.
 
 ## Migration Path
 

--- a/docs/providers/migration.md
+++ b/docs/providers/migration.md
@@ -108,39 +108,35 @@ workflow:
 **Key changes**:
 - `max_tokens` now controls output length (different from Copilot's context trimming)
 
-### Step 5: Remove Copilot-Specific Features
+### Step 5: Adjust MCP Server Configuration
 
-**MCP Servers** (tools) are not supported in Claude Phase 1:
+The Claude provider supports `stdio` MCP servers. If your workflow uses `http` or `sse` servers, those must be removed or replaced with `stdio` equivalents when migrating to Claude.
 
 ```yaml
-# Before (Copilot)
+# Copilot — all transport types work
 workflow:
   runtime:
     mcp_servers:
       web-search:
-        command: npx
+        command: npx                      # stdio — works with both providers
         args: ["-y", "open-websearch@latest"]
         tools: ["*"]
+      remote-api:
+        type: http                        # http — Copilot only
+        url: https://mcp.example.com
 
-# After (Claude) - Remove this section
+# Claude — keep stdio servers, remove http/sse
 workflow:
   runtime:
-    # mcp_servers not supported in Phase 1
+    mcp_servers:
+      web-search:
+        command: npx                      # stdio — works with Claude
+        args: ["-y", "open-websearch@latest"]
+        tools: ["*"]
+      # remote-api removed (http not supported by Claude)
 ```
 
-**Agent tools** must also be removed:
-
-```yaml
-# Before (Copilot)
-agents:
-  - name: researcher
-    tools: [web_search, code_exec]
-
-# After (Claude)
-agents:
-  - name: researcher
-    # Remove tools field
-```
+See the [MCP Tools guide](../mcp-tools.md) for full provider support details.
 
 ### Complete Example
 
@@ -175,12 +171,16 @@ workflow:
     default_model: claude-sonnet-4.5
     temperature: 0.7
     max_tokens: 4096
-    # Remove mcp_servers
+    mcp_servers:
+      web-search:
+        command: npx                      # stdio servers work with Claude
+        args: ["-y", "open-websearch@latest"]
+        tools: ["*"]
 
 agents:
   - name: researcher
     model: claude-sonnet-4.5
-    # Remove tools
+    tools: [web_search]                   # agent tools work with Claude
     prompt: "Research {{ topic }}"
 ```
 
@@ -325,20 +325,19 @@ agents:
 2. Use Haiku models (3-5x faster)
 3. Break workflows into smaller agents
 
-### 6. Tool Calling (Not Available)
+### 6. Tool Calling
 
-**Copilot**: Full MCP tool support
-**Claude**: Phase 1 does NOT support tools/MCP
+**Copilot**: Full MCP tool support (stdio, http, sse)
+**Claude**: MCP tool support for stdio servers only
 
 **Impact**:
-- No web search, code execution, file operations
-- Cannot use external APIs via tools
-- Agents are isolated (no external data)
+- HTTP/SSE MCP servers are not available with Claude
+- stdio-based MCP servers (the most common type) work with both providers
 
-**Workarounds**:
-1. Pre-fetch data and pass as workflow input
-2. Split tool-dependent workflows into separate steps
-3. Wait for Phase 2 (tools support planned)
+**Migration notes**:
+1. Keep stdio MCP servers — they work with Claude
+2. Replace http/sse servers with stdio equivalents if available
+3. See the [MCP Tools guide](../mcp-tools.md) for details
 
 ## Testing Strategy
 
@@ -485,13 +484,14 @@ runtime:
   max_tokens: 8192
 ```
 
-### Pitfall 5: Expecting Tools to Work
+### Pitfall 5: HTTP/SSE MCP Servers Not Working
 
-**Error**: Workflow doesn't error but produces wrong results (no tool calls)
+**Error**: MCP server warning in logs, tools not available
 
-**Solution**: Remove tools from Phase 1 workflows:
+**Solution**: The Claude provider only supports `stdio` MCP servers. Replace `http`/`sse` servers with `stdio` equivalents:
 ```yaml
-# Remove mcp_servers and agent tools fields
+# Replace http/sse servers with stdio equivalents
+# See docs/mcp-tools.md for details
 ```
 
 ### Pitfall 6: Expecting Streaming
@@ -584,8 +584,8 @@ Use this checklist for each workflow:
 - [ ] Set `ANTHROPIC_API_KEY` environment variable
 - [ ] Map model names (GPT → Claude)
 - [ ] Understand `max_tokens` meaning change (context → output length)
-- [ ] Remove `mcp_servers` section
-- [ ] Remove agent `tools` fields
+- [ ] Remove `http`/`sse` MCP servers (Claude supports `stdio` only)
+- [ ] Keep `stdio` MCP servers and agent `tools` fields
 
 ### Testing
 - [ ] Validate YAML syntax

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -484,6 +484,28 @@ agents:
 
 **Note**: Tool implementation depends on your provider. See provider documentation for available tools.
 
+### MCP Servers
+
+Tools are typically provided by [MCP servers](mcp-tools.md) configured in the `workflow.runtime.mcp_servers` section. MCP tools are automatically made available to agents and can be filtered using the `tools` field above.
+
+```yaml
+workflow:
+  runtime:
+    mcp_servers:
+      web-search:
+        command: npx
+        args: ["-y", "open-websearch@latest"]
+        tools: ["*"]
+
+agents:
+  - name: researcher
+    tools:
+      - web-search__search    # Use specific MCP tool (server__tool format)
+    prompt: "Research the topic"
+```
+
+For full MCP configuration details, see the [MCP Tools guide](mcp-tools.md).
+
 ## External File References
 
 The `!file` YAML tag lets you reference external files from any YAML field value. The file content is transparently inlined during loading, keeping workflow files concise and enabling reuse of prompts, schemas, and configuration across workflows.


### PR DESCRIPTION
 Adds a dedicated MCP tools documentation page and fixes outdated references across existing docs that incorrectly stated Claude does not support MCP.

  Problem

   - No dedicated MCP documentation page existed — only a 5-line snippet in configuration.md
   - Multiple docs incorrectly stated Claude doesn't support MCP ("Phase 1" limitation), but the code shows the Claude provider has full MCP support via MCPManager for stdio 
  servers
   - workflow-syntax.md Tools section didn't mention MCP at all

  Changes

   1. Created docs/mcp-tools.md — comprehensive MCP guide covering:
    - All 3 server types (stdio, http, sse) with full configuration tables
    - Tool naming conventions (server__tool format)
    - Per-server and per-agent tool filtering
    - Environment variable syntax (${VAR}, ${VAR:-default})
    - OAuth auto-authentication for HTTP/SSE servers
    - Provider support matrix with known issues (Copilot SDK env var bug)
    - Working examples (web search, multiple servers, Claude with MCP)
   2. Fixed docs/configuration.md — moved MCP out of "Copilot-Specific Configuration", removed false Phase 1 disclaimer, updated troubleshooting
   3. Fixed docs/providers/comparison.md — updated comparison table and detail section to reflect Claude supports stdio MCP
   4. Fixed docs/providers/migration.md — replaced "remove MCP for Claude" advice with accurate guidance on stdio support, updated complete example and checklist
   5. Updated docs/workflow-syntax.md — added MCP Servers subsection in Tools section with example and link to the full guide