### PR TITLE
feat(engine): auto-parse script agent JSON stdout into output fields

### DIFF
--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -1455,6 +1455,13 @@ class WorkflowEngine:
                             try:
                                 parsed = json.loads(script_output.stdout)
                                 if isinstance(parsed, dict):
+                                    shadowed = set(parsed.keys()) & set(output_content.keys())
+                                    if shadowed:
+                                        logger.debug(
+                                            "Script '%s' JSON output shadows built-in fields: %s",
+                                            agent.name,
+                                            ", ".join(sorted(shadowed)),
+                                        )
                                     output_content.update(parsed)
                             except (json.JSONDecodeError, ValueError):
                                 pass

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -1448,6 +1448,16 @@ class WorkflowEngine:
                                 "stderr": script_output.stderr,
                                 "exit_code": script_output.exit_code,
                             }
+                            # Auto-parse JSON stdout: if stdout is valid JSON
+                            # object, merge its fields into output so they're
+                            # accessible as output.field_name in templates and
+                            # route conditions (like LLM structured outputs).
+                            try:
+                                parsed = json.loads(script_output.stdout)
+                                if isinstance(parsed, dict):
+                                    output_content.update(parsed)
+                            except (json.JSONDecodeError, ValueError):
+                                pass
                             self.context.store(agent.name, output_content)
                             self.limits.record_execution(agent.name)
                             self.limits.check_timeout()

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -1463,7 +1463,7 @@ class WorkflowEngine:
                                             ", ".join(sorted(shadowed)),
                                         )
                                     output_content.update(parsed)
-                            except (json.JSONDecodeError, ValueError):
+                            except json.JSONDecodeError:
                                 pass
                             self.context.store(agent.name, output_content)
                             self.limits.record_execution(agent.name)

--- a/tests/test_engine/test_script_workflow.py
+++ b/tests/test_engine/test_script_workflow.py
@@ -470,3 +470,132 @@ class TestScriptInParallelRejected:
 
         with pytest.raises(ConfigurationError, match="script step"):
             validate_workflow_config(config)
+
+
+class TestScriptJsonStdout:
+    """Tests for auto-parsing script stdout as JSON into output fields.
+
+    See PR #122. When a script's stdout is a valid JSON object, parsed fields
+    are merged into output_content alongside stdout/stderr/exit_code so they
+    are accessible as `output.field_name` in templates and route conditions
+    (matching LLM structured-output behavior).
+    """
+
+    @staticmethod
+    def _single_script_config(args: list[str]) -> WorkflowConfig:
+        """Build a minimal single-script workflow config."""
+        return WorkflowConfig(
+            workflow=WorkflowDef(
+                name="json-script",
+                entry_point="detector",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="detector",
+                    type="script",
+                    command=sys.executable,
+                    args=args,
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_json_object_parsed_with_field_routing(self) -> None:
+        """Happy path: JSON object stdout is parsed and fields drive routing."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="json-script",
+                entry_point="detector",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="detector",
+                    type="script",
+                    command=sys.executable,
+                    args=[
+                        "-c",
+                        "import json;"
+                        ' print(json.dumps({"plan_exists": True, "route": "planning"}))',
+                    ],
+                    routes=[
+                        RouteDef(to="planner", when="route == 'planning'"),
+                        RouteDef(to="$end"),
+                    ],
+                ),
+                AgentDef(
+                    name="planner",
+                    type="script",
+                    command=sys.executable,
+                    args=["-c", "print('done')"],
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        det = engine.context.agent_outputs["detector"]
+        assert det["plan_exists"] is True
+        assert det["route"] == "planning"
+        # Backward compat: built-in fields still present
+        assert "stdout" in det
+        assert det["exit_code"] == 0
+        # Routing reached planner via parsed field
+        assert "planner" in engine.context.agent_outputs
+
+    @pytest.mark.asyncio
+    async def test_non_json_stdout_preserved_no_extra_fields(self) -> None:
+        """Non-JSON stdout: output.stdout preserved, no extra fields, no exception."""
+        config = self._single_script_config(args=["-c", "print('hello world')"])
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        out = engine.context.agent_outputs["detector"]
+        assert "hello world" in out["stdout"]
+        assert set(out.keys()) == {"stdout", "stderr", "exit_code"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "stdout_payload",
+        ["[1, 2, 3]", "42", '"a string"', "true"],
+        ids=["array", "int", "string", "bool"],
+    )
+    async def test_json_non_object_ignored(self, stdout_payload: str) -> None:
+        """JSON arrays/scalars are not merged (only dict objects are)."""
+        config = self._single_script_config(args=["-c", f"print({stdout_payload!r})"])
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        out = engine.context.agent_outputs["detector"]
+        assert set(out.keys()) == {"stdout", "stderr", "exit_code"}
+
+    @pytest.mark.asyncio
+    async def test_json_field_shadows_builtin(self) -> None:
+        """Parsed JSON value wins over built-in field of the same name (PR #122 contract)."""
+        config = self._single_script_config(
+            args=["-c", 'import json; print(json.dumps({"exit_code": "ok"}))'],
+        )
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        out = engine.context.agent_outputs["detector"]
+        assert out["exit_code"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_empty_stdout_no_crash(self) -> None:
+        """Empty stdout: doesn't crash, no extra fields merged."""
+        config = self._single_script_config(args=["-c", "pass"])
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        out = engine.context.agent_outputs["detector"]
+        assert set(out.keys()) == {"stdout", "stderr", "exit_code"}
+        assert out["stdout"] == ""

--- a/tests/test_engine/test_workflow.py
+++ b/tests/test_engine/test_workflow.py
@@ -298,6 +298,46 @@ class TestWorkflowEngineContextModes:
         # Workflow.input.goal should not be in agent2's context since it's not in input list
         assert "other" not in agent2_context.get("workflow", {}).get("input", {})
 
+    @pytest.mark.asyncio
+    async def test_script_json_stdout_parsed_into_output(self) -> None:
+        """Test that script stdout containing JSON is auto-parsed into output fields."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="json-script", entry_point="detector"),
+            agents=[
+                AgentDef(
+                    name="detector",
+                    type="script",
+                    command="pwsh",
+                    args=[
+                        "-Command",
+                        'Write-Output \'{"plan_exists": true, "route": "planning"}\'; exit 0',
+                    ],
+                    routes=[
+                        RouteDef(to="planner", when="route == 'planning'"),
+                        RouteDef(to="$end"),
+                    ],
+                ),
+                AgentDef(
+                    name="planner",
+                    type="script",
+                    command="pwsh",
+                    args=["-Command", "Write-Output 'done'; exit 0"],
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+
+        provider = CopilotProvider(mock_handler=lambda a, p, c: {})
+        engine = WorkflowEngine(config, provider)
+        await engine.run({})
+
+        det = engine.context.agent_outputs["detector"]
+        assert det["plan_exists"] is True
+        assert det["route"] == "planning"
+        assert "stdout" in det
+        assert det["exit_code"] == 0
+        assert "planner" in engine.context.agent_outputs
+
 
 class TestWorkflowEngineRouting:
     """Tests for workflow routing."""

--- a/tests/test_engine/test_workflow.py
+++ b/tests/test_engine/test_workflow.py
@@ -298,46 +298,6 @@ class TestWorkflowEngineContextModes:
         # Workflow.input.goal should not be in agent2's context since it's not in input list
         assert "other" not in agent2_context.get("workflow", {}).get("input", {})
 
-    @pytest.mark.asyncio
-    async def test_script_json_stdout_parsed_into_output(self) -> None:
-        """Test that script stdout containing JSON is auto-parsed into output fields."""
-        config = WorkflowConfig(
-            workflow=WorkflowDef(name="json-script", entry_point="detector"),
-            agents=[
-                AgentDef(
-                    name="detector",
-                    type="script",
-                    command="pwsh",
-                    args=[
-                        "-Command",
-                        'Write-Output \'{"plan_exists": true, "route": "planning"}\'; exit 0',
-                    ],
-                    routes=[
-                        RouteDef(to="planner", when="route == 'planning'"),
-                        RouteDef(to="$end"),
-                    ],
-                ),
-                AgentDef(
-                    name="planner",
-                    type="script",
-                    command="pwsh",
-                    args=["-Command", "Write-Output 'done'; exit 0"],
-                    routes=[RouteDef(to="$end")],
-                ),
-            ],
-        )
-
-        provider = CopilotProvider(mock_handler=lambda a, p, c: {})
-        engine = WorkflowEngine(config, provider)
-        await engine.run({})
-
-        det = engine.context.agent_outputs["detector"]
-        assert det["plan_exists"] is True
-        assert det["route"] == "planning"
-        assert "stdout" in det
-        assert det["exit_code"] == 0
-        assert "planner" in engine.context.agent_outputs
-
 
 class TestWorkflowEngineRouting:
     """Tests for workflow routing."""


### PR DESCRIPTION
## Summary

When a script agent's stdout is valid JSON, the parsed fields are now merged into the output dict alongside `stdout`/`stderr`/`exit_code`. This makes parsed fields accessible in route conditions and downstream templates as `output.field_name` — matching LLM structured output behavior.

## Motivation

Script agents are the deterministic workhorses of conductor workflows (P8). They emit structured data via JSON stdout, but currently that data is only accessible as a raw string (`output.stdout`). Routing on specific fields requires opaque exit codes instead of readable field-based conditions.

**Before:**
```yaml
# Must use exit codes for routing
routes:
  - to: planner
    when: "exit_code == 20"  # What does 20 mean?
```

**After:**
```yaml
# Route on parsed JSON fields directly
routes:
  - to: planner
    when: "route == 'planning'"  # Self-documenting
```

## Changes

- `src/conductor/engine/workflow.py`: After capturing script output, attempt `json.loads(stdout)`. If it parses as a dict, merge fields into `output_content` (7 lines).
- `tests/test_engine/test_workflow.py`: End-to-end test verifying JSON parsing, field access, and field-based routing.

## Design decisions

- **Backward compatible** — `stdout`, `stderr`, `exit_code` always present. Non-JSON stdout is unchanged. JSON arrays/scalars are ignored (only objects merged).
- **No schema changes** — parsed fields are dynamic, not declared. This matches how script output is already untyped.
- **Merge semantics** — parsed fields could theoretically shadow `stdout`/`stderr`/`exit_code` if a script outputs those as JSON keys. This is intentional: scripts that output `{"exit_code": 42}` probably want the JSON value to win over the raw field.

## Testing

- 75 workflow engine tests pass (including new JSON parsing test)
- Test covers: field parsing, backward compat (stdout still present), field-based routing
