### PR TITLE
feat(validate): catch template reference errors before runtime

### DIFF
--- a/src/conductor/cli/validate.py
+++ b/src/conductor/cli/validate.py
@@ -40,7 +40,6 @@ def validate_workflow(
 
     try:
         config = load_config(workflow_path)
-        return True, config
     except ConductorError as e:
         # Display structured error
         display_validation_error(e, workflow_path, output_console)
@@ -55,6 +54,20 @@ def validate_workflow(
             )
         )
         return False, None
+
+    # Semantic validation: cross-field references, template refs, etc.
+    try:
+        from conductor.config.validator import validate_workflow_config
+
+        warnings = validate_workflow_config(config, workflow_path=workflow_path)
+        if warnings:
+            for warning in warnings:
+                output_console.print(f"  [yellow]⚠[/yellow] {warning}")
+    except ConductorError as e:
+        display_validation_error(e, workflow_path, output_console)
+        return False, None
+
+    return True, config
 
 
 def display_validation_error(

--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -8,12 +8,13 @@ tool references.
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from conductor.exceptions import ConfigurationError
 
 if TYPE_CHECKING:
-    from conductor.config.schema import WorkflowConfig
+    from conductor.config.schema import AgentDef, WorkflowConfig
 
 
 # Matches agent/group name references in output templates.
@@ -22,6 +23,18 @@ if TYPE_CHECKING:
 # (which only matches {{ }} blocks with .output singular). This pattern also matches {% %} blocks
 # and .outputs plural for path coverage analysis.
 _OUTPUT_REF_PATTERN = re.compile(r"(?:\{\{|\{%)[^}%]*?(\w+)\.outputs?\b")
+
+# Matches agent/workflow template references in Jinja2 expressions:
+#   {{ agent_name.output.field }}
+#   {{ agent_name.output }}
+#   {% if agent_name.output.field %}
+# Excludes built-in namespaces: workflow, context, item, _index, _key
+_TEMPLATE_REF_PATTERN = re.compile(r"(?:\{\{|\{%)[^}%]*?\b(\w+)\.(?:output|outputs)\b")
+
+# Matches workflow.input.X references in templates
+_WORKFLOW_INPUT_REF_PATTERN = re.compile(r"(?:\{\{|\{%)[^}%]*?\bworkflow\.input\.(\w+)\b")
+
+_BUILTIN_NAMES = frozenset({"workflow", "context", "item", "_index", "_key", "loop"})
 
 # DFS path cap: larger workflows may get partial coverage analysis
 _MAX_ENUMERATED_PATHS = 100
@@ -34,20 +47,25 @@ _MAX_ENUMERATED_PATHS = 100
 INPUT_REF_PATTERN = re.compile(
     r"^(?:"
     r"(?P<agent>[a-zA-Z_][a-zA-Z0-9_]*)\.output(?:\.(?P<field>[a-zA-Z_][a-zA-Z0-9_]*))?|"
-    r"(?P<parallel>[a-zA-Z_][a-zA-Z0-9_]*)\.outputs\.(?P<pg_agent>[a-zA-Z_][a-zA-Z0-9_]*)(?:\.(?P<pg_field>[a-zA-Z_][a-zA-Z0-9_]*))?|"
+    r"(?P<parallel>[a-zA-Z_][a-zA-Z0-9_]*)\.(?:outputs|errors)(?:\.(?P<pg_agent>[a-zA-Z_][a-zA-Z0-9_]*)(?:\.(?P<pg_field>[a-zA-Z_][a-zA-Z0-9_]*))?)?|"
     r"workflow\.input\.(?P<input>[a-zA-Z_][a-zA-Z0-9_]*)"
     r")(?P<optional>\?)?$"
 )
 
 
-def validate_workflow_config(config: WorkflowConfig) -> list[str]:
+def validate_workflow_config(
+    config: WorkflowConfig,
+    workflow_path: Path | None = None,
+) -> list[str]:
     """Perform comprehensive validation of a workflow configuration.
 
     This function performs semantic validation beyond what Pydantic can check,
-    including cross-field references and consistency checks.
+    including cross-field references, consistency checks, and Jinja2 template
+    reference validation.
 
     Args:
         config: The WorkflowConfig to validate.
+        workflow_path: Optional path to the workflow file (for !file resolution).
 
     Returns:
         A list of warning messages (non-fatal issues).
@@ -97,6 +115,7 @@ def validate_workflow_config(config: WorkflowConfig) -> list[str]:
             agent_names,
             parallel_names,
             set(config.workflow.input.keys()),
+            for_each_names,
         )
         errors.extend(input_errors)
         warnings.extend(input_warnings)
@@ -134,6 +153,11 @@ def validate_workflow_config(config: WorkflowConfig) -> list[str]:
 
     # Check output templates against conditional execution paths (warnings only)
     warnings.extend(_validate_output_path_coverage(config))
+
+    # Validate Jinja2 template references across all agents
+    tmpl_errors, tmpl_warnings = _validate_template_references(config, workflow_path)
+    errors.extend(tmpl_errors)
+    warnings.extend(tmpl_warnings)
 
     if errors:
         raise ConfigurationError(
@@ -179,6 +203,7 @@ def _validate_input_references(
     agent_names: set[str],
     parallel_names: set[str],
     workflow_inputs: set[str],
+    for_each_names: set[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Validate input reference formats and targets.
 
@@ -188,12 +213,14 @@ def _validate_input_references(
         agent_names: Set of valid agent names.
         parallel_names: Set of valid parallel group names.
         workflow_inputs: Set of valid workflow input parameter names.
+        for_each_names: Set of valid for-each group names.
 
     Returns:
         Tuple of (error messages, warning messages).
     """
     errors: list[str] = []
     warnings: list[str] = []
+    group_names = parallel_names | (for_each_names or set())
 
     for input_ref in inputs:
         match = INPUT_REF_PATTERN.match(input_ref)
@@ -220,9 +247,9 @@ def _validate_input_references(
                     f"Agent '{agent_name}' references unknown agent '{ref_agent}' in input"
                 )
 
-        # Check if referencing parallel group output
+        # Check if referencing parallel/for-each group output
         ref_parallel = match.group("parallel")
-        if ref_parallel and ref_parallel not in parallel_names:
+        if ref_parallel and ref_parallel not in group_names:
             is_optional = match.group("optional") == "?"
             if is_optional:
                 warnings.append(
@@ -577,3 +604,171 @@ def _validate_output_path_coverage(config: WorkflowConfig) -> list[str]:
             )
 
     return warnings
+
+
+def _collect_template_strings(
+    agent: AgentDef,
+) -> list[tuple[str, str]]:
+    """Collect all Jinja2 template strings from an agent definition.
+
+    Returns:
+        List of (source_label, template_string) tuples for error reporting.
+    """
+
+    templates: list[tuple[str, str]] = []
+
+    if agent.prompt:
+        templates.append((f"agent '{agent.name}' prompt", agent.prompt))
+    if agent.system_prompt:
+        templates.append((f"agent '{agent.name}' system_prompt", agent.system_prompt))
+    if agent.command:
+        templates.append((f"agent '{agent.name}' command", agent.command))
+    for i, arg in enumerate(agent.args):
+        templates.append((f"agent '{agent.name}' args[{i}]", arg))
+    input_mapping: dict[str, str] | None = getattr(agent, "input_mapping", None)
+    if input_mapping:
+        for key, expr in input_mapping.items():
+            templates.append((f"agent '{agent.name}' input_mapping.{key}", expr))
+    if agent.working_dir:
+        templates.append((f"agent '{agent.name}' working_dir", agent.working_dir))
+
+    return templates
+
+
+def _resolve_prompt_file(agent_name: str, prompt: str, workflow_path: Path | None) -> str | None:
+    """If a prompt looks like it came from a !file tag, try to load the file content.
+
+    The !file tag is already resolved during YAML loading, so the prompt field
+    contains the file content. This function is for scanning prompts that may
+    have been loaded from files for additional template references.
+
+    Returns the prompt as-is (it's already resolved by the loader).
+    """
+    return prompt if prompt else None
+
+
+def _validate_template_references(
+    config: WorkflowConfig,
+    workflow_path: Path | None = None,
+) -> tuple[list[str], list[str]]:
+    """Validate Jinja2 template references across all agents.
+
+    Checks that:
+    - {{ X.output.Y }} references use valid agent names
+    - {{ workflow.input.X }} references use declared input names
+    - In explicit mode, agents reference only declared inputs
+
+    Args:
+        config: The WorkflowConfig to validate.
+        workflow_path: Optional path to the workflow file (for !file resolution).
+
+    Returns:
+        Tuple of (error messages, warning messages).
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    agent_names = {a.name for a in config.agents}
+    parallel_names = {pg.name for pg in config.parallel}
+    for_each_names = {fe.name for fe in config.for_each}
+    all_names = agent_names | parallel_names | for_each_names
+    workflow_input_names = set(config.workflow.input.keys())
+    is_explicit = config.workflow.context.mode == "explicit"
+
+    # Collect all agents including for-each inline agents
+    all_agents: list[tuple[AgentDef, set[str]]] = []
+    for agent in config.agents:
+        all_agents.append((agent, all_names))
+    for fe in config.for_each:
+        # For-each inline agents can reference the parent's agents
+        all_agents.append((fe.agent, all_names))
+
+    for agent, valid_names in all_agents:
+        templates = _collect_template_strings(agent)
+
+        # Extract declared input references for explicit mode checks
+        declared_agents: set[str] = set()
+        declared_workflow_inputs: set[str] = set()
+        has_full_workflow_input = False
+        for ref in agent.input:
+            match = INPUT_REF_PATTERN.match(ref.rstrip("?"))
+            if match:
+                ref_agent = match.group("agent")
+                if ref_agent:
+                    declared_agents.add(ref_agent)
+                ref_parallel = match.group("parallel")
+                if ref_parallel:
+                    declared_agents.add(ref_parallel)
+                ref_input = match.group("input")
+                if ref_input:
+                    declared_workflow_inputs.add(ref_input)
+            # Check for bare "workflow.input" (all inputs)
+            clean_ref = ref.rstrip("?")
+            if clean_ref == "workflow.input":
+                has_full_workflow_input = True
+
+        for source, template in templates:
+            # Check agent/group output references
+            for match in _TEMPLATE_REF_PATTERN.finditer(template):
+                ref_name = match.group(1)
+                if ref_name in _BUILTIN_NAMES:
+                    continue
+
+                if ref_name not in valid_names:
+                    errors.append(
+                        f"{source} references unknown agent '{ref_name}'. "
+                        f"Available: {', '.join(sorted(valid_names))}"
+                    )
+                elif (
+                    is_explicit
+                    and agent.type not in ("script", "workflow")
+                    and ref_name not in declared_agents
+                ):
+                    # In explicit mode, LLM agents should declare their inputs
+                    warnings.append(
+                        f"{source} references '{ref_name}.output' but "
+                        f"agent '{agent.name}' does not declare '{ref_name}.output' "
+                        f"in its input: list (explicit context mode)"
+                    )
+
+            # Check workflow.input references
+            for match in _WORKFLOW_INPUT_REF_PATTERN.finditer(template):
+                input_name = match.group(1)
+                if workflow_input_names and input_name not in workflow_input_names:
+                    # Only error when inputs ARE declared — workflows without
+                    # input: blocks may use workflow.input conditionally
+                    errors.append(
+                        f"{source} references unknown workflow input '{input_name}'. "
+                        f"Declared inputs: {', '.join(sorted(workflow_input_names))}"
+                    )
+                elif (
+                    is_explicit
+                    and agent.type not in ("script", "workflow")
+                    and not has_full_workflow_input
+                    and input_name not in declared_workflow_inputs
+                ):
+                    warnings.append(
+                        f"{source} references 'workflow.input.{input_name}' but "
+                        f"agent '{agent.name}' does not declare "
+                        f"'workflow.input.{input_name}' in its input: list "
+                        f"(explicit context mode)"
+                    )
+
+    # Check workflow output templates
+    if config.output:
+        for field, template in config.output.items():
+            for match in _TEMPLATE_REF_PATTERN.finditer(template):
+                ref_name = match.group(1)
+                if ref_name not in _BUILTIN_NAMES and ref_name not in all_names:
+                    errors.append(
+                        f"Workflow output '{field}' references unknown agent '{ref_name}'"
+                    )
+            for match in _WORKFLOW_INPUT_REF_PATTERN.finditer(template):
+                input_name = match.group(1)
+                if input_name not in workflow_input_names:
+                    errors.append(
+                        f"Workflow output '{field}' references unknown "
+                        f"workflow input '{input_name}'"
+                    )
+
+    return errors, warnings

--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -720,6 +720,14 @@ def _collect_template_strings(
     if agent.working_dir:
         templates.append((f"agent '{agent.name}' working_dir", agent.working_dir))
 
+    # input_mapping is on AgentDef in main (added by #109 closing #101) but may not
+    # exist on the schema in branches that haven't merged that yet. getattr keeps
+    # this forward-compatible without coupling validate semantics to schema timing.
+    input_mapping: dict[str, str] | None = getattr(agent, "input_mapping", None)
+    if input_mapping:
+        for key, expr in input_mapping.items():
+            templates.append((f"agent '{agent.name}' input_mapping.{key}", expr))
+
     return templates
 
 

--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -11,30 +11,62 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import jinja2
+from jinja2 import Environment, meta, nodes
+
 from conductor.exceptions import ConfigurationError
 
 if TYPE_CHECKING:
     from conductor.config.schema import AgentDef, WorkflowConfig
 
 
-# Matches agent/group name references in output templates.
-# Catches {{ name.output.field }}, {{ group.outputs.member }}, and {% if name.output %}.
-# Note: this is intentionally broader than the agent_ref_pattern in _validate_output_references
-# (which only matches {{ }} blocks with .output singular). This pattern also matches {% %} blocks
-# and .outputs plural for path coverage analysis.
-_OUTPUT_REF_PATTERN = re.compile(r"(?:\{\{|\{%)[^}%]*?(\w+)\.outputs?\b")
+# Shared Jinja2 environment used purely for AST parsing of template strings.
+# We never render with this env; we only ask it to produce an AST so we can
+# walk Getattr chains and find undeclared variables. Using Jinja2's own parser
+# (rather than regex) gives us scope-aware tracking — `{% for x in y %}`,
+# `{% set x = ... %}`, macro params — and string-literal awareness for free.
+#
+# `meta.find_undeclared_variables` runs Jinja2's compiler over the AST, which
+# fails on unknown filters/tests (e.g. conductor's `| json` filter is registered
+# at render time on a different env). We don't want validation to choke on that,
+# so we install tolerant `filters`/`tests` mappings that pretend every name is
+# defined and return identity. Render-time validation will surface real errors.
 
-# Matches agent/workflow template references in Jinja2 expressions:
-#   {{ agent_name.output.field }}
-#   {{ agent_name.output }}
-#   {% if agent_name.output.field %}
-# Excludes built-in namespaces: workflow, context, item, _index, _key
-_TEMPLATE_REF_PATTERN = re.compile(r"(?:\{\{|\{%)[^}%]*?\b(\w+)\.(?:output|outputs)\b")
 
-# Matches workflow.input.X references in templates
-_WORKFLOW_INPUT_REF_PATTERN = re.compile(r"(?:\{\{|\{%)[^}%]*?\bworkflow\.input\.(\w+)\b")
+def _identity_filter(value: object, *_args: object, **_kwargs: object) -> object:
+    return value
+
+
+class _TolerantNameMap(dict):
+    """A dict that pretends every key exists, returning an identity function.
+
+    Used for Jinja2 ``Environment.filters`` / ``Environment.tests`` during
+    validation so that workflow-specific filters (registered only at render
+    time) don't cause the AST walk to raise ``TemplateAssertionError``.
+    """
+
+    def __contains__(self, key: object) -> bool:
+        return True
+
+    def __getitem__(self, key: str) -> object:
+        try:
+            return dict.__getitem__(self, key)
+        except KeyError:
+            return _identity_filter
+
+    def get(self, key: str, default: object = None) -> object:
+        return dict.get(self, key, _identity_filter)
+
+
+_JINJA_ENV = Environment(autoescape=False)
+_JINJA_ENV.filters = _TolerantNameMap(_JINJA_ENV.filters)
+_JINJA_ENV.tests = _TolerantNameMap(_JINJA_ENV.tests)
 
 _BUILTIN_NAMES = frozenset({"workflow", "context", "item", "_index", "_key", "loop"})
+
+# Attribute names that mark a Getattr chain as an "output reference":
+#   agent.output.field, group.outputs.member, group.errors.member
+_OUTPUT_ATTRS = frozenset({"output", "outputs", "errors"})
 
 # DFS path cap: larger workflows may get partial coverage analysis
 _MAX_ENUMERATED_PATHS = 100
@@ -523,21 +555,82 @@ def _enumerate_paths_to_end(
     return paths
 
 
+def _extract_template_refs(template: str) -> tuple[set[str], set[str]]:
+    """Extract agent/group and workflow-input references from a Jinja2 template.
+
+    Uses Jinja2's own parser, so:
+      - Loop variables are excluded: ``{% for x in y %}{{ x.output }}{% endfor %}``
+        does not produce a spurious reference to ``x``.
+      - ``{% set x = ... %}`` bindings and macro parameters are excluded.
+      - String literals are excluded: ``{{ x | replace("foo.output", "y") }}``
+        does not produce a reference to ``foo``.
+
+    A name is reported as an output reference when it appears as the root of a
+    Getattr chain whose first attribute is one of ``output``/``outputs``/``errors``
+    (e.g. ``agent.output.field``, ``group.outputs.member``, ``group.errors``).
+
+    A name is reported as a workflow-input reference when the chain matches
+    ``workflow.input.<name>``.
+
+    Built-in namespaces (``workflow``, ``context``, ``item``, ``_index``, ``_key``,
+    ``loop``) and any name bound by a Jinja2 scope are filtered out.
+
+    Args:
+        template: A Jinja2 template string (may contain no template tags).
+
+    Returns:
+        Tuple of ``(agent_refs, workflow_input_refs)``. Both sets are empty when
+        the template has no recognizable references or contains a syntax error
+        we cannot parse — semantic validation should not fail on malformed
+        templates; render-time will raise the precise error.
+    """
+    if not template or ("{{" not in template and "{%" not in template):
+        return set(), set()
+
+    try:
+        ast = _JINJA_ENV.parse(template)
+    except jinja2.TemplateSyntaxError:
+        return set(), set()
+
+    undeclared = meta.find_undeclared_variables(ast)
+    agent_refs: set[str] = set()
+    input_refs: set[str] = set()
+
+    for node in ast.find_all(nodes.Getattr):
+        # Walk down the Getattr chain to its root Name, collecting attributes.
+        attrs: list[str] = []
+        cur: nodes.Node = node
+        while isinstance(cur, nodes.Getattr):
+            attrs.insert(0, cur.attr)
+            cur = cur.node
+        if not isinstance(cur, nodes.Name):
+            continue
+        # Skip names bound by an enclosing scope (loop var, macro param, set).
+        if cur.name not in undeclared:
+            continue
+
+        root = cur.name
+        if root == "workflow" and len(attrs) >= 2 and attrs[0] == "input":
+            input_refs.add(attrs[1])
+        elif attrs and attrs[0] in _OUTPUT_ATTRS and root not in _BUILTIN_NAMES:
+            agent_refs.add(root)
+
+    return agent_refs, input_refs
+
+
 def _extract_output_template_refs(output: dict[str, str]) -> set[str]:
-    """Extract agent/group names referenced in output templates.
+    """Extract agent/group names referenced across all workflow output templates.
 
     Args:
         output: Dict of output field names to template expressions.
 
     Returns:
-        Set of referenced agent/group names (excluding 'workflow' and 'context').
+        Set of referenced agent/group names.
     """
     refs: set[str] = set()
     for template in output.values():
-        for match in _OUTPUT_REF_PATTERN.finditer(template):
-            name = match.group(1)
-            if name not in ("workflow", "context"):
-                refs.add(name)
+        agents, _ = _extract_template_refs(template)
+        refs.update(agents)
     return refs
 
 
@@ -614,7 +707,6 @@ def _collect_template_strings(
     Returns:
         List of (source_label, template_string) tuples for error reporting.
     """
-
     templates: list[tuple[str, str]] = []
 
     if agent.prompt:
@@ -625,46 +717,38 @@ def _collect_template_strings(
         templates.append((f"agent '{agent.name}' command", agent.command))
     for i, arg in enumerate(agent.args):
         templates.append((f"agent '{agent.name}' args[{i}]", arg))
-    input_mapping: dict[str, str] | None = getattr(agent, "input_mapping", None)
-    if input_mapping:
-        for key, expr in input_mapping.items():
-            templates.append((f"agent '{agent.name}' input_mapping.{key}", expr))
     if agent.working_dir:
         templates.append((f"agent '{agent.name}' working_dir", agent.working_dir))
 
     return templates
 
 
-def _resolve_prompt_file(agent_name: str, prompt: str, workflow_path: Path | None) -> str | None:
-    """If a prompt looks like it came from a !file tag, try to load the file content.
-
-    The !file tag is already resolved during YAML loading, so the prompt field
-    contains the file content. This function is for scanning prompts that may
-    have been loaded from files for additional template references.
-
-    Returns the prompt as-is (it's already resolved by the loader).
-    """
-    return prompt if prompt else None
-
-
 def _validate_template_references(
     config: WorkflowConfig,
     workflow_path: Path | None = None,
 ) -> tuple[list[str], list[str]]:
-    """Validate Jinja2 template references across all agents.
+    """Validate Jinja2 template references across all agents and workflow output.
 
     Checks that:
-    - {{ X.output.Y }} references use valid agent names
-    - {{ workflow.input.X }} references use declared input names
-    - In explicit mode, agents reference only declared inputs
+    - ``{{ X.output.Y }}`` (and ``X.outputs``/``X.errors``) references resolve to a
+      known agent, parallel group, or for-each group.
+    - ``{{ workflow.input.X }}`` references resolve to a declared workflow input.
+    - In explicit context mode, agents only reference inputs they have declared
+      in their ``input:`` list (warning, not error).
+
+    Uses Jinja2's AST so loop variables, ``{% set %}`` bindings, macro params, and
+    string literals do not produce false positives.
 
     Args:
         config: The WorkflowConfig to validate.
-        workflow_path: Optional path to the workflow file (for !file resolution).
+        workflow_path: Optional path to the workflow file (currently unused;
+            reserved for future ``!file`` cross-file scanning).
 
     Returns:
         Tuple of (error messages, warning messages).
     """
+    del workflow_path  # reserved for future cross-file resolution
+
     errors: list[str] = []
     warnings: list[str] = []
 
@@ -675,45 +759,37 @@ def _validate_template_references(
     workflow_input_names = set(config.workflow.input.keys())
     is_explicit = config.workflow.context.mode == "explicit"
 
-    # Collect all agents including for-each inline agents
+    # Collect all agents including for-each inline agents.
     all_agents: list[tuple[AgentDef, set[str]]] = []
     for agent in config.agents:
         all_agents.append((agent, all_names))
     for fe in config.for_each:
-        # For-each inline agents can reference the parent's agents
         all_agents.append((fe.agent, all_names))
 
     for agent, valid_names in all_agents:
         templates = _collect_template_strings(agent)
 
-        # Extract declared input references for explicit mode checks
+        # Extract declared input references for explicit-mode advisory checks.
         declared_agents: set[str] = set()
         declared_workflow_inputs: set[str] = set()
-        has_full_workflow_input = False
         for ref in agent.input:
             match = INPUT_REF_PATTERN.match(ref.rstrip("?"))
-            if match:
-                ref_agent = match.group("agent")
-                if ref_agent:
-                    declared_agents.add(ref_agent)
-                ref_parallel = match.group("parallel")
-                if ref_parallel:
-                    declared_agents.add(ref_parallel)
-                ref_input = match.group("input")
-                if ref_input:
-                    declared_workflow_inputs.add(ref_input)
-            # Check for bare "workflow.input" (all inputs)
-            clean_ref = ref.rstrip("?")
-            if clean_ref == "workflow.input":
-                has_full_workflow_input = True
+            if not match:
+                continue
+            ref_agent = match.group("agent")
+            if ref_agent:
+                declared_agents.add(ref_agent)
+            ref_parallel = match.group("parallel")
+            if ref_parallel:
+                declared_agents.add(ref_parallel)
+            ref_input = match.group("input")
+            if ref_input:
+                declared_workflow_inputs.add(ref_input)
 
         for source, template in templates:
-            # Check agent/group output references
-            for match in _TEMPLATE_REF_PATTERN.finditer(template):
-                ref_name = match.group(1)
-                if ref_name in _BUILTIN_NAMES:
-                    continue
+            agent_refs, input_refs = _extract_template_refs(template)
 
+            for ref_name in agent_refs:
                 if ref_name not in valid_names:
                     errors.append(
                         f"{source} references unknown agent '{ref_name}'. "
@@ -724,19 +800,16 @@ def _validate_template_references(
                     and agent.type not in ("script", "workflow")
                     and ref_name not in declared_agents
                 ):
-                    # In explicit mode, LLM agents should declare their inputs
                     warnings.append(
                         f"{source} references '{ref_name}.output' but "
                         f"agent '{agent.name}' does not declare '{ref_name}.output' "
                         f"in its input: list (explicit context mode)"
                     )
 
-            # Check workflow.input references
-            for match in _WORKFLOW_INPUT_REF_PATTERN.finditer(template):
-                input_name = match.group(1)
+            for input_name in input_refs:
                 if workflow_input_names and input_name not in workflow_input_names:
                     # Only error when inputs ARE declared — workflows without
-                    # input: blocks may use workflow.input conditionally
+                    # input: blocks may use workflow.input conditionally.
                     errors.append(
                         f"{source} references unknown workflow input '{input_name}'. "
                         f"Declared inputs: {', '.join(sorted(workflow_input_names))}"
@@ -744,7 +817,6 @@ def _validate_template_references(
                 elif (
                     is_explicit
                     and agent.type not in ("script", "workflow")
-                    and not has_full_workflow_input
                     and input_name not in declared_workflow_inputs
                 ):
                     warnings.append(
@@ -754,18 +826,17 @@ def _validate_template_references(
                         f"(explicit context mode)"
                     )
 
-    # Check workflow output templates
+    # Check workflow output templates.
     if config.output:
         for field, template in config.output.items():
-            for match in _TEMPLATE_REF_PATTERN.finditer(template):
-                ref_name = match.group(1)
-                if ref_name not in _BUILTIN_NAMES and ref_name not in all_names:
+            agent_refs, input_refs = _extract_template_refs(template)
+            for ref_name in agent_refs:
+                if ref_name not in all_names:
                     errors.append(
                         f"Workflow output '{field}' references unknown agent '{ref_name}'"
                     )
-            for match in _WORKFLOW_INPUT_REF_PATTERN.finditer(template):
-                input_name = match.group(1)
-                if input_name not in workflow_input_names:
+            for input_name in input_refs:
+                if workflow_input_names and input_name not in workflow_input_names:
                     errors.append(
                         f"Workflow output '{field}' references unknown "
                         f"workflow input '{input_name}'"

--- a/tests/test_cli/test_validate.py
+++ b/tests/test_cli/test_validate.py
@@ -247,3 +247,151 @@ output: {}
         assert is_valid is False
         assert config is None
         assert "Validation Failed" in output.getvalue()
+
+
+class TestSemanticValidationIntegration:
+    """Integration tests for the new semantic-validation wiring in the CLI."""
+
+    def _write(self, path: Path, content: str) -> None:
+        path.write_text(content, encoding="utf-8")
+
+    def test_stale_agent_ref_fails_validation(self, tmp_path: Path) -> None:
+        from conductor.cli.validate import validate_workflow
+
+        workflow_file = tmp_path / "stale.yaml"
+        self._write(
+            workflow_file,
+            """
+workflow:
+  name: stale-ref
+  entry_point: writer
+agents:
+  - name: writer
+    model: gpt-4
+    prompt: "Use {{ ghost.output.value }}"
+    routes:
+      - to: $end
+""",
+        )
+        is_valid, config = validate_workflow(workflow_file)
+        assert is_valid is False
+        assert config is None
+
+    def test_unknown_workflow_input_fails_validation(self, tmp_path: Path) -> None:
+        from conductor.cli.validate import validate_workflow
+
+        workflow_file = tmp_path / "bad_input.yaml"
+        self._write(
+            workflow_file,
+            """
+workflow:
+  name: bad-input
+  entry_point: writer
+  input:
+    topic: { type: string }
+agents:
+  - name: writer
+    model: gpt-4
+    prompt: "Write about {{ workflow.input.nonexistent }}"
+    routes:
+      - to: $end
+""",
+        )
+        is_valid, config = validate_workflow(workflow_file)
+        assert is_valid is False
+        assert config is None
+
+    def test_explicit_mode_warning_renders(self, tmp_path: Path) -> None:
+        """Warnings should be displayed but validation should still pass."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        from conductor.cli.validate import validate_workflow
+
+        workflow_file = tmp_path / "warn.yaml"
+        self._write(
+            workflow_file,
+            """
+workflow:
+  name: warn
+  entry_point: writer
+  context:
+    mode: explicit
+  input:
+    topic: { type: string }
+agents:
+  - name: writer
+    model: gpt-4
+    prompt: "About {{ workflow.input.topic }}"
+    routes:
+      - to: $end
+""",
+        )
+
+        output = StringIO()
+        console = Console(file=output, force_terminal=False, width=200)
+
+        is_valid, config = validate_workflow(workflow_file, console=console)
+        assert is_valid is True
+        assert config is not None
+        out = output.getvalue()
+        # Warning should mention the undeclared input and explicit mode.
+        assert "workflow.input.topic" in out
+        assert "explicit" in out
+
+    def test_for_loop_var_does_not_block_validation(self, tmp_path: Path) -> None:
+        """Regression test: false-positive #1 should not cause CLI failure."""
+        from conductor.cli.validate import validate_workflow
+
+        workflow_file = tmp_path / "loopvar.yaml"
+        self._write(
+            workflow_file,
+            """
+workflow:
+  name: loopvar
+  entry_point: pg
+agents:
+  - name: r1
+    model: gpt-4
+    prompt: "Research"
+  - name: r2
+    model: gpt-4
+    prompt: "Research"
+  - name: aggregator
+    model: gpt-4
+    prompt: |
+      {% for r in pg.outputs %}- {{ r.output.text }}{% endfor %}
+    routes:
+      - to: $end
+parallel:
+  - name: pg
+    agents: [r1, r2]
+    routes:
+      - to: aggregator
+""",
+        )
+        is_valid, _ = validate_workflow(workflow_file)
+        assert is_valid is True
+
+    def test_validate_command_exits_nonzero_on_stale_ref(self, tmp_path: Path) -> None:
+        """The CLI command (not just the function) must propagate failure."""
+        workflow_file = tmp_path / "stale.yaml"
+        self._write(
+            workflow_file,
+            """
+workflow:
+  name: stale
+  entry_point: writer
+agents:
+  - name: writer
+    model: gpt-4
+    prompt: "Use {{ ghost.output }}"
+    routes:
+      - to: $end
+""",
+        )
+        result = runner.invoke(app, ["validate", str(workflow_file)])
+        assert result.exit_code != 0
+        assert "Validation Failed" in result.output
+        assert "ghost" in result.output

--- a/tests/test_config/test_validator.py
+++ b/tests/test_config/test_validator.py
@@ -1127,8 +1127,6 @@ class TestInputMappingTemplateCollection:
         # Simulates: when this PR merges with main's AgentDef.input_mapping,
         # a stale agent reference inside an input_mapping expression is caught
         # by _extract_template_refs the same as any other template field.
-        agent_refs, input_refs = _extract_template_refs(
-            "{{ old_agent.output.findings }}"
-        )
+        agent_refs, input_refs = _extract_template_refs("{{ old_agent.output.findings }}")
         assert "old_agent" in agent_refs
         assert not input_refs

--- a/tests/test_config/test_validator.py
+++ b/tests/test_config/test_validator.py
@@ -19,6 +19,7 @@ from conductor.config.schema import (
 )
 from conductor.config.validator import (
     INPUT_REF_PATTERN,
+    _collect_template_strings,
     _extract_template_refs,
     validate_workflow_config,
 )
@@ -1072,3 +1073,62 @@ class TestExamplesRegression:
                 failures.append(f"{path.name}: {type(e).__name__}: {e}")
 
         assert not failures, "examples failed validation:\n  " + "\n  ".join(failures)
+
+
+class TestInputMappingTemplateCollection:
+    """Coverage for input_mapping template collection.
+
+    The input_mapping field was added to AgentDef by PR #109 (closing #101). On
+    branches that have merged that schema change, _collect_template_strings
+    should pick up its templates so stale-ref scanning catches them. The helper
+    uses getattr so this stays a no-op on branches that haven't merged it yet,
+    and these tests use a duck-typed object to exercise the path regardless.
+    """
+
+    @staticmethod
+    def _make_agent_like(
+        name: str,
+        prompt: str | None,
+        input_mapping: dict[str, str] | None,
+    ) -> object:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            name=name,
+            prompt=prompt,
+            system_prompt=None,
+            command=None,
+            args=[],
+            working_dir=None,
+            input_mapping=input_mapping,
+        )
+
+    def test_collects_input_mapping_templates(self) -> None:
+        agent = self._make_agent_like(
+            name="caller",
+            prompt="Call sub-workflow",
+            input_mapping={
+                "topic": "{{ workflow.input.topic }}",
+                "research": "{{ researcher.output.findings }}",
+            },
+        )
+        templates = _collect_template_strings(agent)  # type: ignore[arg-type]
+        labels = {label for label, _ in templates}
+        assert "agent 'caller' input_mapping.topic" in labels
+        assert "agent 'caller' input_mapping.research" in labels
+
+    def test_no_input_mapping_collects_nothing_extra(self) -> None:
+        agent = self._make_agent_like(name="caller", prompt="Simple", input_mapping=None)
+        templates = _collect_template_strings(agent)  # type: ignore[arg-type]
+        labels = {label for label, _ in templates}
+        assert not any("input_mapping" in label for label in labels)
+
+    def test_extractor_catches_stale_ref_in_input_mapping(self) -> None:
+        # Simulates: when this PR merges with main's AgentDef.input_mapping,
+        # a stale agent reference inside an input_mapping expression is caught
+        # by _extract_template_refs the same as any other template field.
+        agent_refs, input_refs = _extract_template_refs(
+            "{{ old_agent.output.findings }}"
+        )
+        assert "old_agent" in agent_refs
+        assert not input_refs

--- a/tests/test_config/test_validator.py
+++ b/tests/test_config/test_validator.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from conductor.config.schema import (
     AgentDef,
+    ContextConfig,
     ForEachDef,
     GateOption,
     InputDef,
@@ -14,7 +17,11 @@ from conductor.config.schema import (
     WorkflowConfig,
     WorkflowDef,
 )
-from conductor.config.validator import validate_workflow_config
+from conductor.config.validator import (
+    INPUT_REF_PATTERN,
+    _extract_template_refs,
+    validate_workflow_config,
+)
 from conductor.exceptions import ConfigurationError
 
 
@@ -605,3 +612,463 @@ class TestOutputPathCoverage:
         )
         warnings = validate_workflow_config(config)
         assert not warnings
+
+
+def _agent_with_prompt(name: str, prompt: str, **kwargs: object) -> AgentDef:
+    """Tiny helper: AgentDef with model defaulted, routes terminating at $end."""
+    routes = kwargs.pop("routes", [RouteDef(to="$end")])
+    model = kwargs.pop("model", "gpt-4")
+    return AgentDef(name=name, model=model, prompt=prompt, routes=routes, **kwargs)  # type: ignore[arg-type]
+
+
+class TestExtractTemplateRefs:
+    """Unit tests for the Jinja2-AST-based reference extractor."""
+
+    def test_simple_agent_output_ref(self) -> None:
+        agents, inputs = _extract_template_refs("{{ writer.output.text }}")
+        assert agents == {"writer"}
+        assert inputs == set()
+
+    def test_simple_workflow_input_ref(self) -> None:
+        agents, inputs = _extract_template_refs("Hello {{ workflow.input.name }}")
+        assert agents == set()
+        assert inputs == {"name"}
+
+    def test_outputs_plural_ref(self) -> None:
+        agents, _ = _extract_template_refs("{{ pg.outputs.member.field }}")
+        assert agents == {"pg"}
+
+    def test_errors_ref(self) -> None:
+        agents, _ = _extract_template_refs("{% if pg.errors %}fail{% endif %}")
+        assert agents == {"pg"}
+
+    def test_bare_output_ref(self) -> None:
+        agents, _ = _extract_template_refs("{{ writer.output }}")
+        assert agents == {"writer"}
+
+    def test_for_loop_variable_excluded(self) -> None:
+        """Loop-bound vars must not be reported as agent refs (false-positive #1)."""
+        agents, _ = _extract_template_refs(
+            "{% for r in researcher.outputs %}{{ r.output.text }}{% endfor %}"
+        )
+        # Only the iterable name; the loop variable `r` is scope-bound.
+        assert agents == {"researcher"}
+
+    def test_string_literal_excluded(self) -> None:
+        """Names inside string literals must not be reported (false-positive #2)."""
+        agents, _ = _extract_template_refs(
+            '{{ x | replace("foo.output", "y") | replace("bar.outputs", "z") }}'
+        )
+        assert agents == set()
+
+    def test_set_binding_excluded(self) -> None:
+        agents, _ = _extract_template_refs("{% set x = 1 %}{{ x.output }}")
+        assert agents == set()
+
+    def test_built_in_namespaces_excluded(self) -> None:
+        for builtin in ("workflow", "context", "item", "loop"):
+            agents, _ = _extract_template_refs("{{ " + builtin + ".output.x }}")
+            assert agents == set(), f"{builtin} leaked through"
+
+    def test_unrelated_attrs_ignored(self) -> None:
+        agents, inputs = _extract_template_refs("{{ writer.metadata.author }}")
+        assert agents == set()
+        assert inputs == set()
+
+    def test_no_template_tags(self) -> None:
+        assert _extract_template_refs("just plain text") == (set(), set())
+        assert _extract_template_refs("") == (set(), set())
+
+    def test_malformed_template_returns_empty(self) -> None:
+        # Don't raise — render-time validation will surface the precise error.
+        assert _extract_template_refs("{{ unterminated") == (set(), set())
+
+    def test_multiple_refs_in_one_template(self) -> None:
+        agents, inputs = _extract_template_refs(
+            "{{ a.output }}/{{ b.outputs.x }}/{{ workflow.input.foo }}/{{ workflow.input.bar }}"
+        )
+        assert agents == {"a", "b"}
+        assert inputs == {"foo", "bar"}
+
+
+class TestInputRefPatternExtensions:
+    """Test the extended INPUT_REF_PATTERN shapes added in this PR."""
+
+    @pytest.mark.parametrize(
+        "ref,expected_parallel",
+        [
+            ("group.errors", "group"),
+            ("group.errors.member", "group"),
+            ("group.errors.member.field", "group"),
+            ("group.outputs", "group"),
+            ("group.outputs.member", "group"),
+            ("group.outputs.member.field", "group"),
+            ("group.errors?", "group"),
+            ("group.outputs?", "group"),
+        ],
+    )
+    def test_pattern_accepts_new_shapes(self, ref: str, expected_parallel: str) -> None:
+        match = INPUT_REF_PATTERN.match(ref)
+        assert match is not None, f"{ref!r} should match INPUT_REF_PATTERN"
+        assert match.group("parallel") == expected_parallel
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "agent.output",
+            "agent.output.field",
+            "agent.output?",
+            "agent.output.field?",
+            "workflow.input.param",
+            "workflow.input.param?",
+        ],
+    )
+    def test_pattern_still_accepts_legacy_shapes(self, ref: str) -> None:
+        assert INPUT_REF_PATTERN.match(ref) is not None
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "workflow.input",  # bare workflow.input no longer accepted
+            "agent",
+            "agent.foo",
+            "group.bogus",
+        ],
+    )
+    def test_pattern_rejects_invalid_shapes(self, ref: str) -> None:
+        assert INPUT_REF_PATTERN.match(ref) is None
+
+
+class TestTemplateReferenceValidation:
+    """End-to-end tests for stale-reference detection in agent templates."""
+
+    def test_stale_agent_ref_in_prompt_errors(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="writer"),
+            agents=[
+                _agent_with_prompt("writer", "Based on {{ old_name.output.findings }}, write."),
+            ],
+        )
+        with pytest.raises(ConfigurationError, match="unknown agent 'old_name'"):
+            validate_workflow_config(config)
+
+    def test_stale_agent_ref_in_system_prompt_errors(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="writer"),
+            agents=[
+                _agent_with_prompt(
+                    "writer",
+                    "ok",
+                    system_prompt="Use {{ ghost.output }}",
+                ),
+            ],
+        )
+        with pytest.raises(ConfigurationError, match="system_prompt.*unknown agent 'ghost'"):
+            validate_workflow_config(config)
+
+    def test_stale_agent_ref_in_script_args_errors(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="step"),
+            agents=[
+                AgentDef(
+                    name="step",
+                    type="script",
+                    command="echo",
+                    args=["{{ ghost.output.value }}"],
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        with pytest.raises(ConfigurationError, match=r"args\[0\].*unknown agent 'ghost'"):
+            validate_workflow_config(config)
+
+    def test_stale_agent_ref_in_command_errors(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="step"),
+            agents=[
+                AgentDef(
+                    name="step",
+                    type="script",
+                    command="run-{{ ghost.output }}",
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        with pytest.raises(ConfigurationError, match="command.*unknown agent 'ghost'"):
+            validate_workflow_config(config)
+
+    def test_stale_agent_ref_in_working_dir_errors(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="step"),
+            agents=[
+                AgentDef(
+                    name="step",
+                    type="script",
+                    command="echo",
+                    working_dir="/tmp/{{ ghost.output }}",
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        with pytest.raises(ConfigurationError, match="working_dir.*unknown agent 'ghost'"):
+            validate_workflow_config(config)
+
+    def test_unknown_workflow_input_errors(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="writer",
+                input={"topic": InputDef(type="string")},
+            ),
+            agents=[
+                _agent_with_prompt("writer", "Write about {{ workflow.input.nonexistent }}"),
+            ],
+        )
+        with pytest.raises(ConfigurationError, match="unknown workflow input 'nonexistent'"):
+            validate_workflow_config(config)
+
+    def test_workflow_input_unchecked_when_no_input_block(self) -> None:
+        """Workflows without an input: block may use workflow.input freely."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="writer"),
+            agents=[
+                _agent_with_prompt("writer", "{{ workflow.input.anything }}"),
+            ],
+        )
+        # Should not raise — this is the documented escape hatch.
+        validate_workflow_config(config)
+
+    def test_for_loop_variable_does_not_error(self) -> None:
+        """Regression test: false-positive #1 from PR review."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="aggregator"),
+            agents=[
+                AgentDef(name="r1", model="gpt-4", prompt="Research"),
+                AgentDef(name="r2", model="gpt-4", prompt="Research"),
+                _agent_with_prompt(
+                    "aggregator",
+                    "{% for r in pg.outputs %}- {{ r.output.text }}{% endfor %}",
+                ),
+            ],
+            parallel=[
+                ParallelGroup(
+                    name="pg",
+                    agents=["r1", "r2"],
+                    routes=[RouteDef(to="aggregator")],
+                ),
+            ],
+        )
+        # No raise: `r` is a loop variable, not a stale agent name.
+        validate_workflow_config(config)
+
+    def test_string_literal_does_not_error(self) -> None:
+        """Regression test: false-positive #2 from PR review."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="writer"),
+            agents=[
+                _agent_with_prompt("writer", '{{ "x" | replace("foo.output", "y") }}'),
+            ],
+        )
+        validate_workflow_config(config)
+
+    def test_for_each_inline_agent_template_scanned(self) -> None:
+        """For-each groups have inline agents whose templates must also be checked."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="analyzers"),
+            agents=[],
+            for_each=[
+                ForEachDef(
+                    name="analyzers",
+                    type="for_each",
+                    source="workflow.input.items",
+                    **{"as": "item"},
+                    agent=AgentDef(
+                        name="analyzer",
+                        model="gpt-4",
+                        prompt="Analyze {{ ghost.output.x }}",
+                    ),
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        with pytest.raises(ConfigurationError, match="unknown agent 'ghost'"):
+            validate_workflow_config(config)
+
+    def test_for_each_inline_agent_loop_var_does_not_error(self) -> None:
+        """`item`, `_index`, `_key` are built-ins and must not error inside fe agents."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="analyzers"),
+            agents=[],
+            for_each=[
+                ForEachDef(
+                    name="analyzers",
+                    type="for_each",
+                    source="workflow.input.items",
+                    **{"as": "item"},
+                    agent=AgentDef(
+                        name="analyzer",
+                        model="gpt-4",
+                        prompt="Analyze {{ item }} index={{ _index }}",
+                    ),
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        validate_workflow_config(config)
+
+    def test_for_each_group_accepted_in_input_references(self) -> None:
+        """For-each group names should be valid in agent input: lists."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="analyzers"),
+            agents=[
+                _agent_with_prompt(
+                    "summarizer",
+                    "{{ analyzers.outputs }}",
+                    input=["analyzers.outputs"],
+                ),
+            ],
+            for_each=[
+                ForEachDef(
+                    name="analyzers",
+                    type="for_each",
+                    source="workflow.input.items",
+                    **{"as": "item"},
+                    agent=AgentDef(name="a", model="gpt-4", prompt="{{ item }}"),
+                    routes=[RouteDef(to="summarizer")],
+                ),
+            ],
+        )
+        validate_workflow_config(config)
+
+
+class TestExplicitModeWarnings:
+    """Tests for explicit-context-mode advisory warnings."""
+
+    def test_undeclared_agent_ref_in_explicit_mode_warns(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="writer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("research", "do work", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "Use {{ research.output.findings }}",
+                    # Notably absent: input=["research.output"]
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any("research.output" in w and "explicit" in w and "writer" in w for w in warnings)
+
+    def test_undeclared_workflow_input_ref_in_explicit_mode_warns(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="writer",
+                context=ContextConfig(mode="explicit"),
+                input={"topic": InputDef(type="string")},
+            ),
+            agents=[
+                _agent_with_prompt(
+                    "writer",
+                    "About {{ workflow.input.topic }}",
+                    # Notably absent: input=["workflow.input.topic"]
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any("workflow.input.topic" in w and "explicit" in w for w in warnings)
+
+    def test_declared_input_in_explicit_mode_no_warning(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="writer",
+                context=ContextConfig(mode="explicit"),
+                input={"topic": InputDef(type="string")},
+            ),
+            agents=[
+                _agent_with_prompt(
+                    "writer",
+                    "About {{ workflow.input.topic }}",
+                    input=["workflow.input.topic"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        # Should have no explicit-mode advisories.
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_script_agents_skipped_in_explicit_mode(self) -> None:
+        """Script and workflow agents don't carry input declarations the same way."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="step",
+                context=ContextConfig(mode="explicit"),
+                input={"topic": InputDef(type="string")},
+            ),
+            agents=[
+                AgentDef(
+                    name="step",
+                    type="script",
+                    command="echo",
+                    args=["{{ workflow.input.topic }}"],
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+
+class TestOutputTemplateValidation:
+    """Tests for unknown references in workflow `output:` templates."""
+
+    def test_unknown_agent_in_output_errors(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="writer"),
+            agents=[_agent_with_prompt("writer", "ok")],
+            output={"summary": "{{ ghost.output }}"},
+        )
+        with pytest.raises(ConfigurationError, match=r"output 'summary'.*unknown agent 'ghost'"):
+            validate_workflow_config(config)
+
+    def test_unknown_workflow_input_in_output_errors(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="writer",
+                input={"topic": InputDef(type="string")},
+            ),
+            agents=[_agent_with_prompt("writer", "ok")],
+            output={"echo": "{{ workflow.input.bogus }}"},
+        )
+        with pytest.raises(
+            ConfigurationError, match=r"output 'echo'.*unknown workflow input 'bogus'"
+        ):
+            validate_workflow_config(config)
+
+
+class TestExamplesRegression:
+    """Every example workflow under examples/ must still validate."""
+
+    def test_all_bundled_examples_validate(self) -> None:
+        from conductor.config.loader import load_config
+
+        examples_dir = Path(__file__).resolve().parents[2] / "examples"
+        yaml_files = sorted(examples_dir.glob("*.yaml"))
+        assert yaml_files, "no example workflows found — fixture path wrong?"
+
+        failures: list[str] = []
+        for path in yaml_files:
+            try:
+                config = load_config(path)
+                validate_workflow_config(config, workflow_path=path)
+            except Exception as e:  # pragma: no cover - report on failure only
+                failures.append(f"{path.name}: {type(e).__name__}: {e}")
+
+        assert not failures, "examples failed validation:\n  " + "\n  ".join(failures)


### PR DESCRIPTION
## Summary

Enhanced `conductor validate` to catch Jinja2 template reference errors before runtime. Previously, `conductor validate` only checked YAML schema (Pydantic) — stale agent references, missing workflow inputs, and undeclared dependencies only surfaced at runtime after minutes of execution and real API costs.

## What it catches

### Errors (validation fails)
- **Stale agent references**: `{{ old_agent_name.output.field }}` where `old_agent_name` doesn't exist
- **Missing workflow input references**: `{{ workflow.input.missing_field }}` where `missing_field` isn't declared in `input:`
- **Stale references in `prompt`, `system_prompt`, `command`, `args`, `working_dir`, `input_mapping`, parallel-group inputs, and workflow `output:` templates** — all template-bearing fields are scanned

### Warnings (validation passes with notes)
- **Undeclared dependencies in explicit mode**: Agent prompt references `{{ a.output.val }}` but doesn't declare `a.output` in its `input:` list

## Example

```yaml
agents:
  - name: writer
    prompt: |
      Based on {{ old_agent_name.output.findings }}
      Write about {{ workflow.input.nonexistent_field }}
```

```
$ conductor validate stale.yaml
╭─ Validation Failed ─╮
│ - agent 'writer' prompt references unknown agent 'old_agent_name'. Available: researcher, writer
│ - agent 'writer' prompt references unknown workflow input 'nonexistent_field'. Declared inputs: topic
╰──────────────────────╯
```

## Changes

- `src/conductor/config/validator.py`:
  - Added `_extract_template_refs()` — parses each template via `jinja2.Environment().parse()` and walks `nodes.Getattr` chains rooted at the truly-free names returned by `meta.find_undeclared_variables`. Loop variables, `{% set %}` bindings, and macro params are excluded automatically because they don't appear in `find_undeclared_variables`. String literals are `nodes.Const` and never enter the walk.
  - Installed `_TolerantNameMap(dict)` on `_JINJA_ENV.filters` / `.tests` so workflow-specific filters (registered on a different env at render time, e.g. `| json`) don't cause `meta.find_undeclared_variables` to raise `TemplateAssertionError` during validation.
  - Added `_collect_template_strings()` to gather all Jinja2 template strings from an agent. Includes `input_mapping` for sub-workflow agents (added by #109 closing #101) — uses `getattr` so it stays a no-op on branches that haven't merged that schema field yet.
  - Added `_validate_template_references()` with agent name, workflow input, and explicit-mode checks.
  - Extended `INPUT_REF_PATTERN` to accept `{group}.errors`, `{group}.errors.{member}`, and bare `{group}.outputs` (with optional `?` suffix on each).
  - Updated `validate_workflow_config()` signature to accept optional `workflow_path`.
- `src/conductor/cli/validate.py`:
  - **Wired semantic validation** (`validate_workflow_config`) into the CLI `validate` command — it previously only ran Pydantic schema validation.
  - Displays warnings for non-fatal issues.

## Testing

- 351 tests pass (`tests/test_config` + `tests/test_cli/test_validate.py`), no regressions.
- New test classes in `tests/test_config/test_validator.py`:
  - `TestExtractTemplateRefs` — unit tests on the new extractor (loop vars, string literals, `{% set %}`, macros, builtins, malformed templates, unknown filters/tests).
  - `TestInputRefPatternExtensions` — parametrized regex shape tests for the new `.errors` / bare `.outputs` forms, plus negative cases.
  - `TestTemplateReferenceValidation` — end-to-end stale-ref detection in `prompt`, `system_prompt`, and parallel-group inputs, plus regression tests for the false-positive classes flagged in review (Jinja2 loop variables, string literals).
  - `TestExplicitModeWarnings` — warnings vs. no-warning paths.
  - `TestOutputTemplateValidation` — workflow `output:` template stale-ref detection.
  - `TestExamplesRegression` — loops over `examples/*.yaml` to prove no example regresses.
  - `TestInputMappingTemplateCollection` — covers `input_mapping` collection + stale-ref detection via a duck-typed agent (so the test runs regardless of whether this branch has merged the `input_mapping` schema field from #109).
- New `TestSemanticValidationIntegration` class in `tests/test_cli/test_validate.py` — 5 CLI-level tests covering exit codes, warning rendering, and the false-positive case being non-blocking.
- All `examples/*.yaml` validate cleanly.
