### PR TITLE
fix(copilot): pass streaming=True to SDK to prevent tool-call truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.10...HEAD)
 
+### Added
+- `metadata` dict on workflow definitions, settable statically in YAML or
+  dynamically via `--metadata` / `-m` CLI flags. Merged metadata is
+  included in the `workflow_started` event for downstream consumers
+  ([#107](https://github.com/microsoft/conductor/pull/107)).
+- `input_mapping` field on `type: workflow` agents, enabling Jinja2-templated
+  per-call inputs to sub-workflows evaluated against the parent context.
+  When omitted, the parent's `workflow.input.*` is forwarded as before
+  ([#109](https://github.com/microsoft/conductor/pull/109)).
+
 ### Fixed
 - Pass `streaming=True` to the Copilot SDK's `create_session` to prevent
   silent truncation of large tool-call arguments. In non-streaming mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.10] - 2026-04-30
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.10...HEAD)
+
+### Fixed
+- Pass `streaming=True` to the Copilot SDK's `create_session` to prevent
+  silent truncation of large tool-call arguments. In non-streaming mode
+  the model's per-turn output budget is exhausted mid-JSON for large
+  arguments (e.g., `create` with multi-KB `file_text`), the CLI executes
+  the partial tool call, and the agent loops on the broken call until
+  the wall-clock session limit fires ([#129](https://github.com/microsoft/conductor/pull/129)).
+
+## [0.1.10](https://github.com/microsoft/conductor/compare/v0.1.9...v0.1.10) - 2026-04-30
 
 ### Added
 - Sub-workflow composition support: `workflow`-type agents can now be used
   inside `for_each` groups, with dynamic per-iteration `input_mapping`
-  ([#101], [#102]).
+  ([#101](https://github.com/microsoft/conductor/pull/101), [#102](https://github.com/microsoft/conductor/pull/102)).
 
 ### Changed
 - Bumped `github-copilot-sdk` to `>=0.3.0`. The SDK ships a bundled `copilot`
@@ -22,9 +32,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Suppressed noisy PowerShell stderr output from `uv tool install` during
-  Windows self-update ([#99]).
-
-[#99]: https://github.com/microsoft/conductor/pull/99
-[#101]: https://github.com/microsoft/conductor/pull/101
-[#102]: https://github.com/microsoft/conductor/pull/102
-[0.1.10]: https://github.com/microsoft/conductor/compare/v0.1.9...v0.1.10
+  Windows self-update ([#99](https://github.com/microsoft/conductor/pull/99)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-call inputs to sub-workflows evaluated against the parent context.
   When omitted, the parent's `workflow.input.*` is forwarded as before
   ([#109](https://github.com/microsoft/conductor/pull/109)).
+- `type: workflow` agents are now allowed inside `for_each` groups, enabling
+  dynamic fan-out to sub-workflows with per-iteration `input_mapping`. Each
+  iteration emits its own `subworkflow_started` / `subworkflow_completed`
+  events ([#110](https://github.com/microsoft/conductor/pull/110)).
+- Self-referential sub-workflows are now allowed; depth is bounded by the
+  global `MAX_SUBWORKFLOW_DEPTH` plus an optional per-agent `max_depth`
+  field on `AgentDef` ([#111](https://github.com/microsoft/conductor/pull/111)).
+
+### Changed
+- The dashboard's "context window remaining" bar now sources
+  `context_window_max` from each provider's SDK at runtime instead of a
+  hand-maintained static table. Values now reflect the actual cap the SDK
+  enforces (e.g. `claude-opus-4.6` reports 200K rather than the theoretical
+  1M; `gpt-5.x` reports 128K rather than 400K). The `context_window` field
+  on `ModelPricing` has been removed; pricing data continues to be
+  hand-maintained for cost calculation only
+  ([#144](https://github.com/microsoft/conductor/pull/144)).
 
 ### Fixed
 - Pass `streaming=True` to the Copilot SDK's `create_session` to prevent
@@ -24,6 +41,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments (e.g., `create` with multi-KB `file_text`), the CLI executes
   the partial tool call, and the agent loops on the broken call until
   the wall-clock session limit fires ([#129](https://github.com/microsoft/conductor/pull/129)).
+- Build the Copilot prompt schema recursively from nested `output:`
+  definitions instead of flattening to top-level fields only. Nested object
+  properties, required keys, and array item schemas are now included in the
+  prompt-facing schema used for initial guidance and parse recovery
+  ([#100](https://github.com/microsoft/conductor/pull/100)).
+- Coerce Python literal `"True"` / `"False"` / `"None"` strings produced by
+  Jinja's default `str(bool)` rendering into native Python types when
+  building workflow output. Previously, `output: { matched: "{{ a == b }}" }`
+  produced the string `"False"` (truthy), causing downstream `when:`
+  comparisons against `false` to silently misbehave
+  ([#139](https://github.com/microsoft/conductor/pull/139)).
+- Pricing fuzzy match no longer silently inherits values across model
+  families. Names sharing a textual prefix with a known key (e.g.
+  `claude-opus-4.7` previously matched `claude-opus-4`) now require a `-`
+  delimiter; non-matching names return `None` and the dashboard hides the
+  cost field. A one-time warning is emitted per requested name on any
+  non-exact match ([#143](https://github.com/microsoft/conductor/pull/143)).
+- Run `uv tool update-shell` after `uv tool install` in both `install.ps1`
+  and `install.sh` so `conductor` is available on PATH in new shells, CI
+  agents, and IDE extensions after a fresh install
+  ([#142](https://github.com/microsoft/conductor/pull/142)).
 
 ## [0.1.10](https://github.com/microsoft/conductor/compare/v0.1.9...v0.1.10) - 2026-04-30
 

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -515,11 +515,24 @@ class CopilotProvider(AgentProvider):
             )
 
         try:
-            # Build session kwargs for the SDK
+            # Build session kwargs for the SDK.
+            #
+            # ``streaming=True`` is required: in non-streaming mode the model
+            # must emit its entire turn (text + tool_use blocks + arguments)
+            # under a single per-turn output budget. For agents that issue
+            # large tool-call arguments (e.g., ``create`` with multi-KB
+            # ``file_text``), that budget is exhausted mid-JSON and the CLI
+            # silently executes the partial tool call (e.g. ``{"path": "..."}``
+            # with ``file_text`` missing). The model sees the tool succeed
+            # with no content, retries the same broken call, and loops until
+            # the wall-clock session limit fires. The interactive ``copilot``
+            # CLI defaults to streaming, which is why the same model + tool
+            # combination works there but not via the SDK without this flag.
             session_kwargs: dict[str, Any] = {
                 "model": model,
                 "on_permission_request": self._default_permission_handler,
                 "working_directory": os.getcwd(),
+                "streaming": True,
             }
 
             # Note: Copilot SDK >=0.2.0 does not support temperature as a

--- a/tests/test_integration/test_copilot_large_write.py
+++ b/tests/test_integration/test_copilot_large_write.py
@@ -1,0 +1,177 @@
+"""Real-API integration test that reproduces tool-call argument truncation.
+
+This test exercises the actual failure mode reported by users: when an agent
+asks the Copilot model to emit a tool call with a large argument (e.g.,
+``create`` with multi-KB ``file_text``) under the SDK's default non-streaming
+mode, the model's per-turn output budget is exhausted mid-JSON and the CLI
+silently executes the partial tool call. The model sees the tool succeed
+with no content, retries the same broken call, and loops indefinitely until
+the wall clock fires.
+
+This is the empirical regression test for the ``streaming=True`` fix in
+``CopilotProvider`` (see ``src/conductor/providers/copilot.py``).
+
+Run with:
+    pytest -m real_api tests/test_integration/test_copilot_large_write.py
+
+The test is opt-in (``real_api`` marker, deselected by default) because:
+- It requires the bundled or user-installed ``copilot`` CLI to be present
+  and authenticated (no separate API key — uses the user's GitHub Copilot
+  entitlement).
+- It makes real model calls (consumes Copilot quota).
+- It can take 5-10 minutes per case (success path runs to ~5 min;
+  failure path is capped by ``max_session_seconds``).
+
+Empirically verified red→green on this repo:
+- Without ``streaming=True``: 9m08s wall-clock failure, 0 bytes written
+  (``ProviderError: tool 'create' was executing``).
+- With ``streaming=True``: 4m57s success, 62 KB written in a single
+  ``create`` call.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from conductor.config.schema import (
+    AgentDef,
+    OutputField,
+    RouteDef,
+    RuntimeConfig,
+    WorkflowConfig,
+    WorkflowDef,
+)
+from conductor.engine.workflow import WorkflowEngine
+from conductor.providers.copilot import CopilotProvider
+
+# Lower bound on the file we expect the agent to produce. Empirically the
+# bug starts to bite reliably above ~30 KB of intended content; below that,
+# the per-turn output budget is usually large enough to fit the tool call
+# even without streaming, so the test would not be a true regression
+# guard. See module docstring for the measured red→green numbers.
+_MIN_BYTES_WRITTEN = 30 * 1024
+
+# Wall-clock cap for the agent. Long enough to allow the success case
+# (~5 min in our measurements) and short enough to fail fast when the
+# bug is present (vs. the 1800s default).
+_MAX_SESSION_SECONDS = 480.0
+
+
+def _has_copilot_cli() -> bool:
+    """Return True if a ``copilot`` CLI binary appears reachable.
+
+    The SDK ships its own bundled binary, so this is a coarse check — we
+    treat the test as runnable if either a user-installed ``copilot`` is
+    on PATH or the bundled SDK binary exists on disk.
+    """
+    if shutil.which("copilot"):
+        return True
+    try:
+        import copilot as _copilot_pkg
+
+        bundled = Path(_copilot_pkg.__file__).parent / "bin" / "copilot"
+        return bundled.exists()
+    except Exception:
+        return False
+
+
+def _build_large_write_workflow(target_path: Path) -> WorkflowConfig:
+    """Build a workflow that asks an agent to write a ~50 KB file in one call.
+
+    The prompt explicitly forbids splitting across multiple tool calls so
+    the agent is forced into the single-large-tool-call shape that
+    triggers the truncation bug under non-streaming.
+    """
+    prompt = (
+        f"Write a comprehensive ~50 KB markdown document about "
+        f"{{{{ workflow.input.topic }}}} and save it to ``{target_path}`` "
+        "using the ``create`` tool in a SINGLE call. Do not split the "
+        "write across multiple tool calls.\n\n"
+        "The document must include:\n"
+        "- A title and a multi-paragraph introduction (at least 4 paragraphs).\n"
+        "- At least 20 numbered sections, each with 4-6 substantive paragraphs.\n"
+        "- At least three markdown tables.\n"
+        "- At least eight bulleted lists.\n"
+        "- Inline code examples or pseudocode in at least 5 sections.\n"
+        "- A detailed conclusion section (at least 4 paragraphs).\n\n"
+        "Aim for substantive content of approximately 50,000 characters. "
+        "Do not produce placeholder text or 'lorem ipsum' — write real, "
+        "detailed content about the topic.\n\n"
+        "After the file is written, return the absolute path and the "
+        "approximate byte count as your output."
+    )
+    return WorkflowConfig(
+        workflow=WorkflowDef(
+            name="copilot-large-write-regression",
+            description=(
+                "Forces a single large `create` tool call to exercise the "
+                "tool-argument truncation bug guarded by streaming=True."
+            ),
+            entry_point="writer",
+            runtime=RuntimeConfig(provider="copilot"),
+        ),
+        agents=[
+            AgentDef(
+                name="writer",
+                model="claude-opus-4.7-1m-internal",
+                prompt=prompt,
+                output={
+                    "file_path": OutputField(type="string"),
+                    "bytes_written": OutputField(type="number"),
+                },
+                routes=[RouteDef(to="$end")],
+                max_session_seconds=_MAX_SESSION_SECONDS,
+            )
+        ],
+    )
+
+
+@pytest.mark.real_api
+@pytest.mark.asyncio
+async def test_large_create_tool_call_does_not_truncate(tmp_path: Path) -> None:
+    """An agent must be able to write a multi-tens-of-KB file in one ``create``.
+
+    Empirical regression guard for the ``streaming=True`` fix.
+
+    Without the fix, this test fails with one of:
+    - ``ProviderError`` ("Session exceeded maximum duration ... tool 'create'
+      was executing"), or
+    - the produced file being absent or far smaller than ``_MIN_BYTES_WRITTEN``
+      because the model's tool-call ``file_text`` argument was truncated.
+
+    With the fix, the file exists and is at least ``_MIN_BYTES_WRITTEN``.
+    """
+    if not _has_copilot_cli():
+        pytest.skip("Copilot CLI not available — skipping real-API test")
+
+    target = tmp_path / "large-write-test.md"
+    workflow = _build_large_write_workflow(target)
+
+    provider = CopilotProvider()
+    try:
+        engine = WorkflowEngine(workflow, provider)
+        await engine.run({"topic": "the architecture of multi-agent workflow systems"})
+    finally:
+        await provider.close()
+
+    assert target.exists(), (
+        f"Expected the writer agent to create {target} via the `create` tool, "
+        "but it does not exist. This is the symptom of tool-call argument "
+        "truncation: the model emitted a partial tool_use block, the CLI "
+        "executed it without (or with a truncated) `file_text` arg, and "
+        "nothing valid was written. Likely cause: `streaming=True` was not "
+        "passed to `CopilotClient.create_session`."
+    )
+
+    bytes_written = target.stat().st_size
+    assert bytes_written >= _MIN_BYTES_WRITTEN, (
+        f"File was created but is only {bytes_written} bytes (expected "
+        f"at least {_MIN_BYTES_WRITTEN}). This is consistent with the "
+        "model's tool-call argument being truncated mid-stream, leaving "
+        "only a tiny prefix of the intended `file_text` payload. Likely "
+        "cause: `streaming=True` was not passed to "
+        "`CopilotClient.create_session`."
+    )

--- a/tests/test_providers/test_copilot_streaming.py
+++ b/tests/test_providers/test_copilot_streaming.py
@@ -1,0 +1,122 @@
+"""Tests for streaming kwarg behavior in CopilotProvider session creation.
+
+This module verifies the fix for tool-call argument truncation that occurs
+when the Copilot SDK is configured WITHOUT streaming.
+
+Background
+----------
+The Copilot SDK's ``create_session`` accepts a ``streaming`` parameter that
+the conductor provider previously did not set, causing the SDK to default to
+non-streaming mode. In non-streaming mode the model must emit its entire
+turn (text + tool_use blocks + arguments) under a single per-turn output
+budget. For agents that issue large tool-call arguments (e.g., ``create``
+with multi-KB ``file_text``), that budget is exhausted mid-JSON and the CLI
+silently executes the partial tool call (e.g. ``{"path": "..."}`` with
+``file_text`` missing). The model sees the tool succeed with no content,
+retries the same broken call, and loops indefinitely until the wall clock
+fires.
+
+The interactive ``copilot`` CLI defaults to streaming, which is why the
+same model + tool combination works there but not via the SDK without
+this flag.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from conductor.config.schema import AgentDef
+from conductor.providers.copilot import CopilotProvider
+
+
+def _make_agent(name: str = "writer") -> AgentDef:
+    return AgentDef(name=name, model="claude-opus-4.7-1m-internal", prompt="Write a file")
+
+
+def _build_mocked_provider() -> tuple[CopilotProvider, AsyncMock]:
+    """Construct a CopilotProvider with a mocked SDK client.
+
+    Returns the provider and the mock client (so callers can inspect the
+    kwargs passed to ``create_session``).
+    """
+    mock_session = AsyncMock()
+    mock_session.session_id = "sess-test"
+    mock_session.disconnect = AsyncMock()
+
+    def _fake_on(callback: Any) -> None:
+        mock_session._callback = callback
+
+    mock_session.on = _fake_on
+
+    async def _fake_send(_msg: Any) -> None:
+        # Resolve the session immediately so _send_and_wait returns.
+        evt = MagicMock()
+        evt.type = MagicMock()
+        evt.type.value = "session.idle"
+        mock_session._callback(evt)
+
+    mock_session.send = _fake_send
+
+    mock_client = AsyncMock()
+    mock_client.create_session = AsyncMock(return_value=mock_session)
+    mock_client.start = AsyncMock()
+
+    provider = CopilotProvider()
+    provider._client = mock_client
+    provider._started = True
+    return provider, mock_client
+
+
+@pytest.mark.asyncio
+async def test_create_session_called_with_streaming_true() -> None:
+    """``create_session`` must be invoked with ``streaming=True``.
+
+    Without this kwarg the SDK falls back to non-streaming, which causes
+    tool-call argument truncation under output-budget pressure (see module
+    docstring).
+    """
+    provider, mock_client = _build_mocked_provider()
+
+    with (
+        patch("conductor.providers.copilot.CopilotProvider._log_event_verbose"),
+        patch("conductor.cli.app.is_verbose", return_value=False),
+        patch("conductor.cli.app.is_full", return_value=False),
+    ):
+        await provider.execute(_make_agent(), {}, "Write a comprehensive document")
+
+    mock_client.create_session.assert_called_once()
+    kwargs = mock_client.create_session.call_args.kwargs
+
+    assert "streaming" in kwargs, (
+        "create_session must be called with an explicit `streaming` kwarg; "
+        "without it the SDK falls back to non-streaming mode and large "
+        "tool-call arguments get silently truncated."
+    )
+    assert kwargs["streaming"] is True, (
+        f"streaming must be True (got {kwargs['streaming']!r}). Non-streaming "
+        "causes the model's per-turn output budget to be exhausted mid-JSON "
+        "for large tool calls (e.g. `create` with multi-KB `file_text`)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_session_preserves_existing_kwargs() -> None:
+    """Adding ``streaming`` must not displace other session kwargs."""
+    provider, mock_client = _build_mocked_provider()
+
+    with (
+        patch("conductor.providers.copilot.CopilotProvider._log_event_verbose"),
+        patch("conductor.cli.app.is_verbose", return_value=False),
+        patch("conductor.cli.app.is_full", return_value=False),
+    ):
+        await provider.execute(_make_agent(), {}, "Write a comprehensive document")
+
+    kwargs = mock_client.create_session.call_args.kwargs
+    # These three are the existing required kwargs; the streaming fix
+    # must not regress them.
+    assert kwargs.get("model") == "claude-opus-4.7-1m-internal"
+    assert "on_permission_request" in kwargs
+    assert "working_directory" in kwargs


### PR DESCRIPTION
## Summary

The Copilot SDK's `create_session` accepts a `streaming` parameter that defaults to false. In non-streaming mode the model must emit its entire turn (text + tool_use blocks + arguments) under a single per-turn output budget. For agents that issue large tool-call arguments — most commonly `create` with multi-KB `file_text` — that budget is exhausted mid-JSON and the CLI silently executes the partial tool call (path only, no `file_text`). The model sees the tool succeed with no content, retries the same broken call, and loops indefinitely until the wall-clock session limit fires (default 1800s).

The interactive `copilot` CLI defaults to streaming, which is why the same model + tool combination works there but not via the SDK without this flag.

## Symptom (before fix)

Users hit this when an agent (e.g., a planning/architect agent on Claude Opus 4.7) is asked to write a large markdown file in one shot:

```
Workflow failed: Session exceeded maximum duration of 1800s.
Last activity: tool 'create' was executing. Last real event 186s ago.
```

Inspection of the JSONL event log shows multiple consecutive 89-byte `create` calls with only `{"path": "..."}` and no `file_text` — the JSON arg was truncated mid-stream and the CLI executed the partial call.

## Fix

One line: pass `streaming=True` when constructing the SDK session in `CopilotProvider`. Plus an explanatory comment so the next person doesn't undo it by mistake.

## Verification (red→green, same workflow + model)

Same example workflow that asks for a single ~50 KB `create` call, model `claude-opus-4.7-1m-internal`:

| | Without `streaming=True` | With `streaming=True` |
|---|---|---|
| Duration | **9m08s — wall-clock failure** | **4m57s — completed** |
| File written | **0 bytes (file not created)** | **62,401 bytes** |
| Result | `ProviderError: tool 'create' was executing` | clean exit, valid JSON output |

## Tests

- `tests/test_providers/test_copilot_streaming.py` — unit test that asserts `create_session` is invoked with `streaming=True` and that the existing required kwargs (`model`, `on_permission_request`, `working_directory`) are preserved.
- `tests/test_integration/test_copilot_large_write.py` — opt-in (`real_api` marker) integration test that builds the workflow inline, runs it against the real Copilot SDK + CLI, and asserts the file is at least 30 KB. Skips automatically when no copilot CLI is available.

## Test plan

- [x] `uv run ruff check src tests` — passes
- [x] `uv run ruff format --check src tests` — passes
- [x] `uv run pytest -m "not real_api and not performance"` — 1966 passed, 1 skipped
- [x] Manual red→green on `claude-opus-4.7-1m-internal` (numbers above)
- [ ] `uv run pytest -m real_api tests/test_integration/test_copilot_large_write.py` — to be run by reviewer with copilot CLI available