### PR TITLE
fix(install): run uv tool update-shell so conductor is on PATH for new shells

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -138,6 +138,24 @@ try {
     }
 
     Write-Ok "Conductor $tagName installed"
+
+    # --- Ensure uv's tool bin directory is on the persistent user PATH ---
+    # `uv tool install` only modifies the *current* process PATH. New terminals,
+    # sub-processes, CI agents, and IDE extensions inherit PATH from the user
+    # registry (HKCU\Environment\Path) and won't find `conductor` unless we run
+    # `uv tool update-shell`, which writes the bin dir to the registry. See #115.
+    Write-Info "Ensuring conductor is on PATH for new shells…"
+    try {
+        & uv tool update-shell 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok "PATH updated (restart your terminal to pick up the change)"
+        } else {
+            Write-Info "Could not update user PATH automatically. Run 'uv tool update-shell' manually."
+        }
+    } catch {
+        Write-Info "Could not update user PATH automatically. Run 'uv tool update-shell' manually."
+    }
+
     Write-Host ""
     Write-Host "  Run 'conductor --help' to get started."
     Write-Host "  Run 'conductor update' to check for future updates."

--- a/install.sh
+++ b/install.sh
@@ -157,6 +157,19 @@ main() {
         -c "${tmpdir}/constraints.txt"
 
     success "Conductor ${tag_name} installed"
+
+    # Ensure uv's tool bin directory is on PATH for new shells. `uv tool install`
+    # only modifies the current process PATH; new terminals, sub-processes, CI
+    # agents, and IDE extensions inherit PATH from shell rc files. Running
+    # `uv tool update-shell` adds the bin dir to ~/.bashrc, ~/.zshrc, etc.
+    # (idempotent). See #115.
+    info "Ensuring conductor is on PATH for new shells…"
+    if uv tool update-shell >/dev/null 2>&1; then
+        success "PATH updated (restart your shell to pick up the change)"
+    else
+        info "Could not update shell PATH automatically. Run 'uv tool update-shell' manually."
+    fi
+
     printf '\n  Run \033[1mconductor --help\033[0m to get started.\n'
     printf '  Run \033[1mconductor update\033[0m to check for future updates.\n\n'
 }


### PR DESCRIPTION
## Summary

`uv tool install` only modifies the *current process* PATH. New terminals, sub-processes, CI agents, and IDE extensions inherit PATH from the user registry (Windows `HKCU\Environment\Path`) or shell rc files (Unix), so they cannot find `conductor` after a fresh install.

This PR runs `uv tool update-shell` after a successful install in both `install.ps1` and `install.sh`. The command is the [documented uv mechanism](https://docs.astral.sh/uv/concepts/tools/#tool-executables) for adding the executable directory to the persistent PATH and is idempotent.

## Changes

- **`install.ps1`** — call `uv tool update-shell` after `uv tool install` succeeds, with try/catch fallback that prints a manual-fix hint if it fails.
- **`install.sh`** — same change for Unix (edits `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`).

Failures in `update-shell` are non-fatal: the install itself succeeded, and the user gets a clear message telling them to run `uv tool update-shell` manually.

## Why

Closes #115. The reporter validated that running `uv tool update-shell` resolves the bug on Windows 11. The same root cause affects Unix when the user's shell rc isn't pre-configured for `~/.local/bin`.

The official uv installer itself does this automatically, so this matches the ecosystem norm.

## Testing

- `bash -n install.sh` — syntax check passes.
- No installer tests exist in the repo.
- Behavior on Unix verified against uv docs (idempotent shell rc edit).