### PR TITLE
fix(pricing): prevent cross-family fuzzy match + warn on fallback

### DIFF
--- a/src/conductor/engine/pricing.py
+++ b/src/conductor/engine/pricing.py
@@ -6,7 +6,38 @@ and functions to calculate costs based on token usage.
 
 from __future__ import annotations
 
+import logging
+import re
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Track models that have already triggered a fuzzy-match warning so we only log
+# once per process per unknown model name. See #137.
+_FUZZY_MATCH_WARNED: set[str] = set()
+
+
+def _warn_fuzzy_match(requested: str, matched_key: str, strategy: str) -> None:
+    """Emit a one-time warning when ``get_pricing`` falls back to a non-exact match.
+
+    Args:
+        requested: The model name the caller asked for.
+        matched_key: The key in ``DEFAULT_PRICING`` that was returned.
+        strategy: How the match was made (e.g. ``"longest-prefix"``,
+            ``"suffix-strip"``, ``"suffix-strip+longest-prefix"``).
+    """
+    if requested in _FUZZY_MATCH_WARNED:
+        return
+    _FUZZY_MATCH_WARNED.add(requested)
+    logger.warning(
+        "Pricing for model %r resolved via %s fallback to %r. "
+        "Cost and context_window metadata may be inaccurate. "
+        "Add %r to DEFAULT_PRICING or pass an override to silence this warning.",
+        requested,
+        strategy,
+        matched_key,
+        requested,
+    )
 
 
 @dataclass(frozen=True)
@@ -244,21 +275,23 @@ def get_pricing(
     sorted_keys = sorted(DEFAULT_PRICING.keys(), key=lambda k: len(k), reverse=True)
     for known_model in sorted_keys:
         if model.startswith(known_model):
+            _warn_fuzzy_match(model, known_model, "longest-prefix")
             return DEFAULT_PRICING[known_model]
 
     # Try removing date suffix patterns for common formats
     # e.g., "claude-3-5-sonnet-20241022" -> "claude-3-5-sonnet"
     # e.g., "claude-3-5-sonnet-latest" -> "claude-3-5-sonnet"
-    import re
 
     # Remove common suffixes like -20241022, -latest, -preview
     simplified = re.sub(r"-(\d{8}|latest|preview)$", "", model)
     if simplified in DEFAULT_PRICING:
+        _warn_fuzzy_match(model, simplified, "suffix-strip")
         return DEFAULT_PRICING[simplified]
 
     # Try matching simplified version against known models
     for known_model in sorted_keys:
         if simplified.startswith(known_model):
+            _warn_fuzzy_match(model, known_model, "suffix-strip+longest-prefix")
             return DEFAULT_PRICING[known_model]
 
     return None

--- a/src/conductor/engine/pricing.py
+++ b/src/conductor/engine/pricing.py
@@ -7,7 +7,6 @@ and functions to calculate costs based on token usage.
 from __future__ import annotations
 
 import logging
-import re
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -248,10 +247,16 @@ def get_pricing(
 ) -> ModelPricing | None:
     """Get pricing for a model.
 
-    Checks user-provided overrides first, then falls back to
-    the default pricing table. Supports fuzzy matching for
-    versioned model names (e.g., "claude-sonnet-4-20250514"
-    matches "claude-sonnet-4").
+    Checks user-provided overrides first, then falls back to the default
+    pricing table. Supports a narrow form of fuzzy matching for versioned
+    model names — the requested name must equal a known key, or extend it
+    with a ``-`` delimiter (e.g. ``claude-sonnet-4-20250514`` matches
+    ``claude-sonnet-4``). Names that share a textual prefix without the
+    delimiter (e.g. ``claude-opus-4.7-high`` against ``claude-opus-4``)
+    are *not* matched and will return ``None``, so callers don't silently
+    inherit metadata from a sibling model family.
+
+    Non-exact matches log a one-time warning per requested name (see #137).
 
     Args:
         model: The model name to look up.
@@ -260,38 +265,22 @@ def get_pricing(
     Returns:
         ModelPricing if found, None otherwise.
     """
-    # Check overrides first
+    # Check overrides first (treated as user intent — never warn).
     if overrides and model in overrides:
         return overrides[model]
 
-    # Try exact match
+    # Exact match.
     if model in DEFAULT_PRICING:
         return DEFAULT_PRICING[model]
 
-    # Try fuzzy matching for versioned model names
-    # e.g., "claude-sonnet-4-20250514" -> "claude-sonnet-4"
-    # e.g., "gpt-4o-2024-08-06" -> "gpt-4o"
-    # Sort keys longest-first so "o1-mini" matches before "o1"
+    # Versioned-name match: requested name must extend a known key with a
+    # `-` delimiter. Sort keys longest-first so e.g. `o1-mini` matches before
+    # `o1`. The delimiter check prevents cross-family bleed like
+    # `claude-opus-4.7-high` matching `claude-opus-4` (#137).
     sorted_keys = sorted(DEFAULT_PRICING.keys(), key=lambda k: len(k), reverse=True)
     for known_model in sorted_keys:
-        if model.startswith(known_model):
-            _warn_fuzzy_match(model, known_model, "longest-prefix")
-            return DEFAULT_PRICING[known_model]
-
-    # Try removing date suffix patterns for common formats
-    # e.g., "claude-3-5-sonnet-20241022" -> "claude-3-5-sonnet"
-    # e.g., "claude-3-5-sonnet-latest" -> "claude-3-5-sonnet"
-
-    # Remove common suffixes like -20241022, -latest, -preview
-    simplified = re.sub(r"-(\d{8}|latest|preview)$", "", model)
-    if simplified in DEFAULT_PRICING:
-        _warn_fuzzy_match(model, simplified, "suffix-strip")
-        return DEFAULT_PRICING[simplified]
-
-    # Try matching simplified version against known models
-    for known_model in sorted_keys:
-        if simplified.startswith(known_model):
-            _warn_fuzzy_match(model, known_model, "suffix-strip+longest-prefix")
+        if model.startswith(known_model + "-"):
+            _warn_fuzzy_match(model, known_model, "versioned-suffix")
             return DEFAULT_PRICING[known_model]
 
     return None

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -134,37 +134,46 @@ class TestFuzzyMatchWarnings:
         assert caplog.records == []
 
     def test_unknown_model_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
-        # Names with no prefix overlap return None and should not warn.
+        # Names with no matching prefix return None and should not warn.
         with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
             result = get_pricing("totally-unknown-xyz")
         assert result is None
         assert caplog.records == []
 
-    def test_longest_prefix_match_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_cross_family_name_returns_none_no_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Repro from #137: these names share a textual prefix with claude-opus-4
+        # but are different model families. The delimiter check should reject
+        # the match entirely (returning None and degrading gracefully) rather
+        # than silently inheriting claude-opus-4's pricing/context-window.
         with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
-            get_pricing("claude-opus-4-1m-internal")
+            assert get_pricing("claude-opus-4.7") is None
+            assert get_pricing("claude-opus-4.7-high") is None
+            assert get_pricing("claude-opus-4.7-xhigh") is None
+            assert get_pricing("claude-opus-4.7-1m-internal") is None
+        assert caplog.records == []
+
+    def test_versioned_suffix_match_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Real versioned name (date suffix) should still match and warn.
+        with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
+            pricing = get_pricing("claude-sonnet-4-20250514")
+        assert pricing is not None
         assert len(caplog.records) == 1
         msg = caplog.records[0].getMessage()
-        assert "claude-opus-4-1m-internal" in msg
-        assert "longest-prefix" in msg
-        assert "claude-opus-4" in msg
-
-    # Note: the suffix-strip code paths in get_pricing() are unreachable in
-    # practice today because longest-prefix runs first and catches anything
-    # that suffix-stripping would simplify to. The warning hooks are present
-    # in those branches in case the matching order is ever reorganized.
+        assert "claude-sonnet-4-20250514" in msg
+        assert "versioned-suffix" in msg
+        assert "claude-sonnet-4" in msg
 
     def test_warning_emitted_only_once_per_model(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
-            get_pricing("claude-opus-4-1m-internal")
-            get_pricing("claude-opus-4-1m-internal")
-            get_pricing("claude-opus-4-1m-internal")
+            get_pricing("claude-sonnet-4-20250514")
+            get_pricing("claude-sonnet-4-20250514")
+            get_pricing("claude-sonnet-4-20250514")
         assert len(caplog.records) == 1
 
     def test_different_models_each_warn_once(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
-            get_pricing("claude-opus-4-1m-internal")
-            get_pricing("claude-opus-4-high")
+            get_pricing("claude-sonnet-4-20250514")
+            get_pricing("claude-3-5-sonnet-latest")
         assert len(caplog.records) == 2
 
 

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -112,6 +112,62 @@ class TestGetPricing:
             assert model in DEFAULT_PRICING, f"Expected {model} in DEFAULT_PRICING"
 
 
+class TestFuzzyMatchWarnings:
+    """Tests for the fuzzy-match warning behavior (#137)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_warned(self) -> None:
+        """Clear the per-process warning de-dupe set between tests."""
+        from conductor.engine.pricing import _FUZZY_MATCH_WARNED
+
+        _FUZZY_MATCH_WARNED.clear()
+
+    def test_exact_match_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
+            get_pricing("gpt-4o")
+        assert caplog.records == []
+
+    def test_override_match_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        overrides = {"my-model": ModelPricing(input_per_mtok=1.0, output_per_mtok=2.0)}
+        with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
+            get_pricing("my-model", overrides=overrides)
+        assert caplog.records == []
+
+    def test_unknown_model_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Names with no prefix overlap return None and should not warn.
+        with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
+            result = get_pricing("totally-unknown-xyz")
+        assert result is None
+        assert caplog.records == []
+
+    def test_longest_prefix_match_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
+            get_pricing("claude-opus-4-1m-internal")
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].getMessage()
+        assert "claude-opus-4-1m-internal" in msg
+        assert "longest-prefix" in msg
+        assert "claude-opus-4" in msg
+
+    # Note: the suffix-strip code paths in get_pricing() are unreachable in
+    # practice today because longest-prefix runs first and catches anything
+    # that suffix-stripping would simplify to. The warning hooks are present
+    # in those branches in case the matching order is ever reorganized.
+
+    def test_warning_emitted_only_once_per_model(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
+            get_pricing("claude-opus-4-1m-internal")
+            get_pricing("claude-opus-4-1m-internal")
+            get_pricing("claude-opus-4-1m-internal")
+        assert len(caplog.records) == 1
+
+    def test_different_models_each_warn_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
+            get_pricing("claude-opus-4-1m-internal")
+            get_pricing("claude-opus-4-high")
+        assert len(caplog.records) == 2
+
+
 class TestCalculateCost:
     """Tests for the calculate_cost function."""
 


### PR DESCRIPTION
## Summary

Closes #137. Two related changes to `get_pricing()`:

### 1. Boundary check on prefix matching
The longest-prefix fallback now requires a `-` delimiter after the matched key (`model.startswith(known_model + "-")`). Without it, names that share a textual prefix with a known key but belong to a different model family silently inherited the wrong `context_window` and pricing. The four repro names from #137 now correctly return `None` and degrade gracefully (dashboard hides the bar; cost is `null`) rather than reporting confidently wrong data:

| Requested | Before | After |
|---|---|---|
| `claude-opus-4.7` | matched `claude-opus-4` (200K) ❌ | `None` ✓ |
| `claude-opus-4.7-high` | matched `claude-opus-4` (200K) ❌ | `None` ✓ |
| `claude-opus-4.7-xhigh` | matched `claude-opus-4` (200K) ❌ | `None` ✓ |
| `claude-opus-4.7-1m-internal` | matched `claude-opus-4` (200K) ❌ | `None` ✓ |
| `claude-sonnet-4-20250514` | matched `claude-sonnet-4` ✓ | matched `claude-sonnet-4` ✓ |
| `claude-3-5-sonnet-latest` | matched `claude-3-5-sonnet` ✓ | matched `claude-3-5-sonnet` ✓ |

### 2. One-time warning on non-exact match
When a versioned-suffix match still happens (legitimate dated/`-latest` names), `get_pricing()` now emits a one-time `logging.warning` per requested name, naming the requested model, the matched key, and the strategy. Exact matches, overrides, and unknown models (returning `None`) do not warn. De-duped via a module-level `set` so hot-loop callers don't spam logs.

### 3. Dead code removal
The suffix-strip branches in `get_pricing()` were unreachable — longest-prefix runs first and catches anything they would have simplified. Removed for clarity.

## Behavior change note

This is technically a behavior change: any caller relying on the loose prefix matching (e.g. a hypothetical `gpt-5.4-mini` silently inheriting `gpt-5` pricing) will now get `None` instead. That's the asymmetric "unknown name degrades gracefully" path the issue reporter explicitly prefers — and matches the spirit of one of the alternatives proposed in #137 ("drop the longest-prefix step"; this is a softer version that preserves the dated-version use case).

All existing tests pass unchanged, including `tests/test_providers/test_context_window.py::TestPrefixMatch`.

## Changes

- **`src/conductor/engine/pricing.py`**
  - Added module-level `logger`, `_FUZZY_MATCH_WARNED: set[str]` for de-dupe.
  - New `_warn_fuzzy_match()` helper.
  - Tightened prefix match with `+ "-"` delimiter check.
  - Removed unreachable suffix-strip branches.
  - Updated the docstring to describe the new, narrower matching semantics.
- **`tests/test_engine/test_pricing.py`** — new `TestFuzzyMatchWarnings` class (7 tests):
  - exact match / override / unknown model → no warn
  - cross-family names from the issue → return `None`, no warn
  - versioned-suffix match → warns once with model name, matched key, strategy
  - same model called repeatedly → warns once
  - different fuzzy-matched models → each warns once

## Testing

```
$ uv run pytest tests/test_engine/test_pricing.py -q
27 passed in 3.41s

$ uv run pytest tests/test_engine/ -q
466 passed in 26.90s

$ uv run pytest tests/test_providers/test_context_window.py -q
18 passed in 0.58s

$ uv run ruff check src/conductor/engine/pricing.py tests/test_engine/test_pricing.py
All checks passed!
```