### PR TITLE
fix(install): show uv output on Windows install failure and use correct Defender cmdlet

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -108,6 +108,7 @@ try {
     # --- Install (with retry for Windows Defender file locking) ---
     $maxRetries = 3
     $installed = $false
+    $lastOutput = $null
     for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
         if ($attempt -eq 1) {
             Write-Info "Installing Conductor $tagName…"
@@ -121,6 +122,7 @@ try {
         } catch {
             # PowerShell treats native stderr as errors when ErrorActionPreference=Stop
         }
+        $lastOutput = $output
         if ($LASTEXITCODE -eq 0) {
             $installed = $true
             break
@@ -129,10 +131,19 @@ try {
 
     if (-not $installed) {
         Write-Host ""
-        Write-Info "Install failed after $maxRetries attempts. This is often caused by"
-        Write-Info "Windows Defender scanning files during install. Try:"
-        Write-Info "  1. Add a Defender exclusion: Add-MpExclusion -Path `"$env:LOCALAPPDATA\uv`""
-        Write-Info "  2. Re-run this installer"
+        Write-Host "  ── uv tool install output ──" -ForegroundColor Yellow
+        if ($lastOutput) {
+            $lastOutput | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+        } else {
+            Write-Host "  (no output captured)" -ForegroundColor DarkGray
+        }
+        Write-Host ""
+        Write-Info "Install failed after $maxRetries attempts."
+        Write-Info "If the output above mentions a locked file or 'access is denied',"
+        Write-Info "Windows Defender may be scanning the install directory. Try adding"
+        Write-Info "an exclusion (run PowerShell as Administrator):"
+        Write-Info "  Add-MpPreference -ExclusionPath `"$env:LOCALAPPDATA\uv`""
+        Write-Info "Then re-run this installer."
         Write-Host ""
         Write-Err "uv tool install failed"
     }


### PR DESCRIPTION
## Summary

Two bugs in `install.ps1` that combine to make Windows install failures essentially undebuggable:

### 1. `uv tool install` output was swallowed
The script captured each retry's combined stdout/stderr into `$output` and then **discarded it**. On failure, users saw only a generic 'this is often caused by Windows Defender' guess with no way to confirm or refute it.

### 2. Suggested mitigation cmdlet doesn't exist
The error path recommended `Add-MpExclusion -Path ...` — that cmdlet **does not exist in any version of PowerShell**. Users who tried to follow the advice hit `The term 'Add-MpExclusion' is not recognized`. The real cmdlet is `Add-MpPreference -ExclusionPath ...`, which additionally requires running PowerShell as Administrator on most Windows configurations.

## Changes

- Capture the **last attempt's** combined stdout/stderr into `$lastOutput` and print it under a labeled header before the failure summary, so users can see what `uv` actually said.
- Replace `Add-MpExclusion` with the correct `Add-MpPreference -ExclusionPath` form, noting the admin requirement.
- Reframe the Defender messaging as conditional on the actual error text ("if the output above mentions a locked file or 'access is denied'") rather than unconditional speculation.

## Out of scope

This PR does not try to detect or auto-resolve the underlying constrained-install failure that produced the bug report. With this fix, users (and the maintainers) can now see what `uv` printed and triage from there. A follow-up could add a constrained → unconstrained fallback with a warning, but that risks silently producing subtly broken installs and was deferred.

## Verification

- Successful-install path: unchanged (no behavior change in the success branch).
- Failure path (manual sanity check by reading the diff): `$lastOutput` is captured and printed; cmdlet name is correct.
- No backend code touched, no test impact.