### PR TITLE
fix(schema): forbid extra fields on AgentDef/ParallelGroup/ForEachDef/WorkflowConfig

### DIFF
--- a/examples/for-each-simple.yaml
+++ b/examples/for-each-simple.yaml
@@ -29,12 +29,12 @@ workflow:
   limits:
     max_iterations: 20
 
-# Optional input: if provided, items are used directly; otherwise generated
-input:
-  items:
-    type: string
-    required: false
-    description: JSON array of items to process (e.g. '["apple", "banana"]')
+  # Optional input: if provided, items are used directly; otherwise generated
+  input:
+    items:
+      type: string
+      required: false
+      description: JSON array of items to process (e.g. '["apple", "banana"]')
 
 # For-each group definition
 for_each:

--- a/src/conductor/cli/validate.py
+++ b/src/conductor/cli/validate.py
@@ -120,6 +120,8 @@ def display_validation_success(
     # Build summary info
     agent_count = len(config.agents)
     human_gate_count = sum(1 for a in config.agents if a.type == "human_gate")
+    parallel_group_count = len(config.parallel)
+    for_each_group_count = len(config.for_each)
 
     # Count conditional routes
     conditional_route_count = sum(1 for a in config.agents for r in a.routes if r.when)
@@ -163,6 +165,10 @@ def display_validation_success(
     table.add_row("Agents", str(agent_count))
     if human_gate_count > 0:
         table.add_row("Human Gates", str(human_gate_count))
+    if parallel_group_count > 0:
+        table.add_row("Parallel Groups", str(parallel_group_count))
+    if for_each_group_count > 0:
+        table.add_row("For-each Groups", str(for_each_group_count))
     table.add_row("Max Iterations", str(config.workflow.limits.max_iterations))
     timeout_val = config.workflow.limits.timeout_seconds
     table.add_row("Timeout", f"{timeout_val}s" if timeout_val else "unlimited")

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from conductor.providers.reasoning import ReasoningEffort
 
@@ -109,6 +109,8 @@ class RouteDef(BaseModel):
 class ParallelGroup(BaseModel):
     """Definition for a parallel agent execution group."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     """Unique identifier for this parallel group."""
 
@@ -159,6 +161,8 @@ class ForEachDef(BaseModel):
                 success: { type: boolean }
         ```
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     """Unique identifier for this for-each group."""
@@ -443,6 +447,8 @@ class ReasoningConfig(BaseModel):
 
 class AgentDef(BaseModel):
     """Definition for a single agent in the workflow."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     """Unique identifier for this agent."""
@@ -938,6 +944,8 @@ class WorkflowDef(BaseModel):
 
 class WorkflowConfig(BaseModel):
     """Complete workflow configuration file."""
+
+    model_config = ConfigDict(extra="forbid")
 
     workflow: WorkflowDef
     """Workflow-level settings."""

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -88,6 +88,8 @@ class OutputField(BaseModel):
 class RouteDef(BaseModel):
     """Definition for a routing rule."""
 
+    model_config = ConfigDict(extra="forbid")
+
     to: str
     """Target agent name, '$end', or human gate name."""
 
@@ -881,6 +883,8 @@ class RuntimeConfig(BaseModel):
 
 class WorkflowDef(BaseModel):
     """Top-level workflow configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     """Unique workflow identifier."""

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -1396,3 +1396,91 @@ class TestRuntimeConfigDefaultReasoningEffort:
         """Test that invalid effort values raise ValidationError."""
         with pytest.raises(ValidationError):
             RuntimeConfig(default_reasoning_effort=effort)  # type: ignore[arg-type]
+
+
+class TestExtraFieldsForbidden:
+    """Tests that workflow models reject unknown fields.
+
+    Regression tests for https://github.com/microsoft/conductor/issues/140 —
+    misnesting `parallel:` or `for_each:` inside an `agents:` item used to
+    silently drop the field, leaving a wrapper agent with no model/prompt
+    that failed obscurely at the provider.
+    """
+
+    def test_agentdef_misnested_parallel_rejected(self) -> None:
+        """An `agents:` item with a nested `parallel:` field is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentDef.model_validate(
+                {
+                    "name": "review_group",
+                    "parallel": ["technical_reviewer", "readability_reviewer"],
+                    "failure_mode": "fail_fast",
+                    "routes": [{"to": "$end"}],
+                }
+            )
+        errors = exc_info.value.errors()
+        # The unknown field must be reported by Pydantic's extra_forbidden
+        assert any(
+            err["type"] == "extra_forbidden" and "parallel" in err["loc"] for err in errors
+        ), f"Expected extra_forbidden error for 'parallel', got: {errors}"
+
+    def test_agentdef_misnested_for_each_rejected(self) -> None:
+        """An `agents:` item with a nested `for_each:` field is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentDef.model_validate(
+                {
+                    "name": "fanout",
+                    "for_each": [{"name": "x", "type": "for_each"}],
+                }
+            )
+        errors = exc_info.value.errors()
+        assert any(
+            err["type"] == "extra_forbidden" and "for_each" in err["loc"] for err in errors
+        ), f"Expected extra_forbidden error for 'for_each', got: {errors}"
+
+    def test_agentdef_typo_field_rejected(self) -> None:
+        """A typo'd field on an agent is rejected (e.g., `prmpt` instead of `prompt`)."""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentDef.model_validate(
+                {
+                    "name": "answerer",
+                    "model": "claude-haiku-4.5",
+                    "prmpt": "Answer the question.",
+                }
+            )
+        errors = exc_info.value.errors()
+        assert any(err["type"] == "extra_forbidden" and "prmpt" in err["loc"] for err in errors), (
+            f"Expected extra_forbidden error for 'prmpt', got: {errors}"
+        )
+
+    def test_parallel_group_extra_field_rejected(self) -> None:
+        """An unknown field on a ParallelGroup is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            from conductor.config.schema import ParallelGroup
+
+            ParallelGroup.model_validate(
+                {
+                    "name": "g",
+                    "agents": ["a", "b"],
+                    "fail_fast": True,  # typo: actually `failure_mode`
+                }
+            )
+        errors = exc_info.value.errors()
+        assert any(err["type"] == "extra_forbidden" for err in errors)
+
+    def test_workflow_config_top_level_extra_field_rejected(self) -> None:
+        """An unknown top-level workflow field is rejected (catches `agent:` typo etc.)."""
+        from conductor.config.schema import ParallelGroup  # noqa: F401
+
+        with pytest.raises(ValidationError) as exc_info:
+            WorkflowConfig.model_validate(
+                {
+                    "workflow": {"name": "x", "version": "1", "entry_point": "a"},
+                    "agents": [{"name": "a", "model": "m", "prompt": "p"}],
+                    "agnts": [],  # typo
+                }
+            )
+        errors = exc_info.value.errors()
+        assert any(err["type"] == "extra_forbidden" and "agnts" in err["loc"] for err in errors), (
+            f"Expected extra_forbidden error for 'agnts', got: {errors}"
+        )

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -1484,3 +1484,41 @@ class TestExtraFieldsForbidden:
         assert any(err["type"] == "extra_forbidden" and "agnts" in err["loc"] for err in errors), (
             f"Expected extra_forbidden error for 'agnts', got: {errors}"
         )
+
+    def test_workflowdef_typo_field_rejected(self) -> None:
+        """A typo'd field on the `workflow:` block is rejected.
+
+        Without `extra="forbid"` on WorkflowDef, typos like `entery_point:` or
+        `limts:` are silently dropped, leaving the user's intent ignored.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            WorkflowDef.model_validate(
+                {
+                    "name": "demo",
+                    "entry_point": "a",
+                    "entery_point": "b",  # typo
+                }
+            )
+        errors = exc_info.value.errors()
+        assert any(
+            err["type"] == "extra_forbidden" and "entery_point" in err["loc"] for err in errors
+        ), f"Expected extra_forbidden error for 'entery_point', got: {errors}"
+
+    def test_routedef_typo_when_rejected(self) -> None:
+        """A typo'd `when:` on a route is rejected.
+
+        Without `extra="forbid"` on RouteDef, `whn:` was silently dropped and
+        `route.when` defaulted to `None`, turning a conditional route into an
+        unconditional one — a workflow-semantics bug nearly impossible to debug.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            RouteDef.model_validate(
+                {
+                    "to": "next_agent",
+                    "whn": "output.score > 5",  # typo for `when`
+                }
+            )
+        errors = exc_info.value.errors()
+        assert any(err["type"] == "extra_forbidden" and "whn" in err["loc"] for err in errors), (
+            f"Expected extra_forbidden error for 'whn', got: {errors}"
+        )


### PR DESCRIPTION
Closes #140

## Problem

A user nesting `parallel:` or `for_each:` inside an `agents:` item used to have the misnested field silently dropped by Pydantic's default `extra="ignore"`. The wrapper became a regular `type: agent` with no `model` and no `prompt`, fell through to the Copilot provider's hard-coded `gpt-4o` default, and failed at runtime with:

```
ProviderError: ... Model "gpt-4o" is not available.
```

The error pointed at the provider model — three layers downstream of the actual schema mistake.

## Fix

### (a) `extra="forbid"` on key workflow models

Add `model_config = ConfigDict(extra="forbid")` to:

- `AgentDef` (primary culprit)
- `ParallelGroup`
- `ForEachDef`
- `WorkflowConfig`

The misnested YAML now fails at parse time with a clear Pydantic error pointing at the offending location:

```
2 validation errors for WorkflowConfig
agents.0.parallel
  Extra inputs are not permitted [type=extra_forbidden, ...]
agents.0.failure_mode
  Extra inputs are not permitted
```

This also catches field typos (e.g. `prmpt:` instead of `prompt:`, `agnts:` at top level instead of `agents:`).

### (c) Show parallel/for-each counts in `conductor validate` summary

Adds "Parallel Groups" and "For-each Groups" rows to the validate summary table when present. Their absence is now a visible signal that something the user thought they declared isn't being parsed as such.

### Bonus: fix `examples/for-each-simple.yaml`

This example was itself relying on the silent-drop behavior — it had a top-level `input:` block (every other example correctly nests it under `workflow:`). With `extra="forbid"` this would have failed, so this PR also moves `input:` under `workflow:` where it belongs. The example was previously not actually receiving the documented `items` workflow input.

## Skipped from issue

- (b) Validator rejecting agents with neither `prompt` nor `model` — (a) already catches the reported failure shape.
- (d) Provider hard-coded `gpt-4o` default — separate concern.

## Risk

Adding `extra="forbid"` is a breaking change for any user YAML that has typos that "happen to work." In-repo examples were audited (`make validate-examples`) and only `for-each-simple.yaml` was affected (and that case was a real bug, fixed in this PR).

## Tests

- New `TestExtraFieldsForbidden` test class with 5 regression tests covering misnested `parallel:`/`for_each:` on AgentDef, typo'd field on AgentDef, extra field on ParallelGroup, and extra top-level field on WorkflowConfig.
- Full test suite: 2376 passed, 1 unrelated integration timeout (`test_copilot_large_write` — real Copilot SDK session timeout).
- `make lint` ✓
- `make validate-examples` ✓

## Verification

The original repro from #140:

```yaml
agents:
  - name: review_group
    parallel:
      - technical_reviewer
      - readability_reviewer
```

Before: `Validation Successful` then a runtime `gpt-4o` model error.
After: clear schema error pointing at `agents.0.parallel`.