### PR TITLE
feat(instructions): polymorphic conventions + auto-discover .github/instructions/ with applyTo filtering

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -24,7 +24,7 @@ conductor run <workflow.yaml> [OPTIONS]
 | `--input NAME=VALUE` | `-i` | Workflow input (repeatable) |
 | `--input.NAME=VALUE` | | Alternative input syntax |
 | `--metadata KEY=VALUE` | `-m` | Workflow metadata (repeatable). Merged on top of YAML `metadata:` and surfaced in the `workflow_started` event. |
-| `--workspace-instructions` | | Auto-discover convention files (`AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`) by walking from CWD up to the git root. Concatenated and prepended to every agent's prompt. |
+| `--workspace-instructions` | | Auto-discover convention files (`AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, and `.github/instructions/**/*.instructions.md`) by walking from CWD up to the git root. Concatenated and prepended to every agent's prompt. See [Workspace Instructions](#workspace-instructions) below for details on the `.github/instructions/` directory convention. |
 | `--instructions PATH` | | Explicit path to an instructions file (repeatable). Combines with auto-discovered files when both flags are used. |
 | `--provider PROVIDER` | `-p` | Override provider (copilot, claude) |
 | `--dry-run` | | Show execution plan without running |
@@ -116,12 +116,50 @@ conductor run workflow.yaml --silent --log-file auto --skip-gates --input questi
 # Inject runtime metadata (visible in the workflow_started event)
 conductor run twig-sdlc.yaml --metadata work_item_id=1814 --metadata env=staging
 
-# Auto-discover and inject AGENTS.md / CLAUDE.md / copilot-instructions.md
+# Auto-discover and inject convention instruction files (see "Workspace Instructions" below)
 conductor run workflow.yaml --workspace-instructions
 
 # Combine auto-discovery with an explicit extra file
 conductor run workflow.yaml --workspace-instructions --instructions ./style-guide.md
 ```
+
+##### Workspace Instructions
+
+When `--workspace-instructions` is set, conductor walks from the current
+working directory up to the git root and discovers four conventions, in this
+order:
+
+| Convention | Type | Discovery |
+|---|---|---|
+| `AGENTS.md` | File | Closest-to-CWD wins |
+| `.github/copilot-instructions.md` | File | Closest-to-CWD wins |
+| `CLAUDE.md` | File | Closest-to-CWD wins |
+| `.github/instructions/**/*.instructions.md` | Directory (recursive) | Closest-to-CWD wins per relative path within the directory |
+
+The directory convention follows GitHub Copilot's documented format
+([GitHub docs](https://docs.github.com/en/copilot/customizing-copilot/about-customizing-github-copilot-chat-responses),
+[VS Code docs](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)):
+
+- Files must use the double `*.instructions.md` extension.
+- A YAML frontmatter block with `applyTo` controls activation:
+
+  ```markdown
+  ---
+  description: 'Coding conventions for the API layer'
+  applyTo: '**'
+  ---
+  Use four-space indentation.
+  ```
+
+- `applyTo: "**"` → loaded as always-on (matches Copilot's "always applied").
+- `applyTo: "<other glob>"` → **skipped** (the convention scopes these per-file
+  in the chat; conductor has no equivalent per-agent file scoping).
+- `applyTo` absent → **skipped** (the convention says these are manual-attach
+  only, never auto-applied).
+
+This conservative interpretation matches the documented semantics exactly. To
+include unscoped instructions today, use the explicit `--instructions PATH`
+flag.
 
 #### Complex Inputs
 

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -59,7 +59,7 @@ workflow:
 
 **Workflow metadata** is included verbatim in the `workflow_started` event and lets downstream consumers (dashboards, queue runners, observability tools) adapt without parsing the YAML. CLI `--metadata key=value` flags merge on top of YAML metadata (CLI wins on conflicts).
 
-**Instructions files** are loaded once and prepended to every agent's rendered prompt. They are inherited by sub-workflows and persisted in checkpoints so resume continues to use the same instructions. Use the YAML `instructions:` list for workflow-pinned context, or pass `--workspace-instructions` on the CLI to auto-discover `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` by walking from CWD up to the git root.
+**Instructions files** are loaded once and prepended to every agent's rendered prompt. They are inherited by sub-workflows and persisted in checkpoints so resume continues to use the same instructions. Use the YAML `instructions:` list for workflow-pinned context, or pass `--workspace-instructions` on the CLI to auto-discover `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, and `.github/instructions/**/*.instructions.md` (recursive; only files marked `applyTo: "**"` in YAML frontmatter are loaded — see the [Workspace Instructions section in the CLI reference](cli-reference.md#workspace-instructions) for full details) by walking from CWD up to the git root.
 
 ### Context Modes
 

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -311,9 +311,12 @@ def run(
         typer.Option(
             "--workspace-instructions",
             help=(
-                "Auto-discover workspace instruction files "
-                "(AGENTS.md, CLAUDE.md, .github/copilot-instructions.md) "
-                "and prepend them to all agent prompts."
+                "Auto-discover workspace instruction files and prepend them to "
+                "all agent prompts. Discovers AGENTS.md, CLAUDE.md, "
+                ".github/copilot-instructions.md, and "
+                ".github/instructions/**/*.instructions.md (recursive; only "
+                "files marked 'applyTo: \"**\"' in YAML frontmatter are "
+                "included)."
             ),
         ),
     ] = False,

--- a/src/conductor/config/instructions.py
+++ b/src/conductor/config/instructions.py
@@ -1,8 +1,18 @@
 """Workspace instruction file discovery and loading.
 
-This module discovers and loads workspace instruction files (AGENTS.md,
-CLAUDE.md, copilot-instructions.md, etc.) that provide context about a
-repository's conventions, coding style, and architecture to workflow agents.
+This module discovers and loads workspace instruction files that provide
+context about a repository's conventions, coding style, and architecture
+to workflow agents.
+
+Conductor recognises two convention shapes (see :data:`CONVENTIONS`):
+
+* **File conventions** (:class:`ConventionFile`) — single files at known paths,
+  e.g. ``AGENTS.md``, ``.github/copilot-instructions.md``, ``CLAUDE.md``.
+* **Directory conventions** (:class:`ConventionDirectory`) — directories that
+  contain multiple instruction files matching a glob, optionally filtered by
+  a frontmatter predicate. Today the only directory convention is GitHub
+  Copilot's ``.github/instructions/*.instructions.md`` (recursive, with
+  ``applyTo`` frontmatter filtering).
 
 The primary use case is enabling conductor workflows (which may live in
 distant skill directories) to automatically pick up the target repository's
@@ -11,18 +21,178 @@ instruction files when invoked from within that repo.
 
 from __future__ import annotations
 
+import fnmatch
 import logging
+import os
+import re
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from pathlib import Path
+
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 logger = logging.getLogger(__name__)
 
-# Convention instruction files to discover, in deterministic order.
-# Each entry is a relative path from a directory to check.
-CONVENTION_FILES: list[str] = [
-    "AGENTS.md",
-    ".github/copilot-instructions.md",
-    "CLAUDE.md",
+
+# ---------------------------------------------------------------------------
+# Convention types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConventionFile:
+    """A single-file convention.
+
+    Examples: ``AGENTS.md``, ``.github/copilot-instructions.md``, ``CLAUDE.md``.
+
+    Discovery: walk CWD → git root, closest-wins per ``path``. The match key
+    is local to this convention only — it does not collide with directory
+    convention keys.
+    """
+
+    path: str  # relative path from a candidate directory, e.g. "AGENTS.md"
+
+
+@dataclass(frozen=True)
+class ConventionDirectory:
+    """A directory-style convention.
+
+    Example: GitHub Copilot's ``.github/instructions/*.instructions.md``.
+
+    Discovery: walk CWD → git root. At each level, look for the convention
+    directory. If found, find files matching ``pattern`` (recursively when
+    ``recursive=True``), apply the optional ``include_file`` predicate, and
+    track surviving files keyed by their *relative path within the convention
+    directory*. Closest-wins per relative-path key — local to this convention.
+
+    Symlink policy: directory traversal does NOT follow symlinked directories
+    (``os.walk(followlinks=False)``) to avoid loops and out-of-tree expansion.
+    Symlinked instruction *files* are read like regular files via
+    :meth:`Path.read_text` (which follows symlinks at the leaf).
+    """
+
+    path: str
+    pattern: str
+    include_file: Callable[[Path], bool] | None = None
+    recursive: bool = True
+
+
+Convention = ConventionFile | ConventionDirectory
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser for GitHub Copilot's `.github/instructions/` convention
+# ---------------------------------------------------------------------------
+
+# Tolerant regex: handles CRLF line endings, optional trailing whitespace on
+# delimiters, and a closing `---` at EOF without a trailing newline.
+_FRONTMATTER_RE = re.compile(
+    r"\A---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\Z)",
+    re.DOTALL,
+)
+
+# Module-level safe-mode YAML parser. ruamel.yaml's `typ="safe"` disables
+# custom tag constructors (no arbitrary code execution from user content).
+_yaml = YAML(typ="safe")
+
+
+def _parse_frontmatter(path: Path) -> dict[str, object] | None:
+    """Parse the YAML frontmatter block from a Markdown file, robustly.
+
+    This is a reusable primitive intended for any directory convention whose
+    files use ``--- ... ---`` YAML frontmatter (GitHub Copilot's
+    ``.github/instructions/``, hypothetical Cursor's ``.cursor/rules/``, etc.).
+
+    Returns:
+        - The parsed frontmatter as a ``dict`` if the file has valid YAML
+          frontmatter that parses to a mapping.
+        - ``None`` in every other case: missing frontmatter, unreadable file,
+          malformed YAML (logged at WARNING), or YAML that parses to a
+          non-mapping (list, scalar, empty).
+
+    Edge cases handled:
+        - CRLF line endings (Windows-authored files)
+        - UTF-8 BOM (transparently stripped via ``utf-8-sig`` encoding)
+        - Closing ``---`` at EOF without trailing newline
+        - Non-dict YAML (returns ``None`` rather than raising AttributeError)
+    """
+    try:
+        # 'utf-8-sig' transparently strips a leading UTF-8 BOM if present
+        text = path.read_text(encoding="utf-8-sig")
+    except (OSError, UnicodeDecodeError) as e:
+        logger.debug("Cannot read %s for frontmatter check: %s", path, e)
+        return None
+
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return None
+
+    try:
+        fm = _yaml.load(match.group(1))
+    except YAMLError as e:
+        logger.warning("Failed to parse frontmatter in %s: %s; skipping", path, e)
+        return None
+
+    # YAML may parse to a non-dict (empty doc, list, scalar). Caller-defined
+    # filters typically only make sense on mappings; normalise here.
+    if not isinstance(fm, dict):
+        return None
+
+    return fm
+
+
+def _is_always_on_instructions_file(path: Path) -> bool:
+    """Return True iff a ``.github/instructions/*.instructions.md`` file is
+    explicitly always-on per GitHub's documented convention semantics.
+
+    Per
+    https://docs.github.com/en/copilot/customizing-copilot/about-customizing-github-copilot-chat-responses
+    and https://code.visualstudio.com/docs/copilot/customization/custom-instructions:
+
+    * ``applyTo: "**"`` → "always applied" → INCLUDE in conductor preamble
+    * ``applyTo: "<other glob>"`` → scoped to matched files in chat → SKIP
+      (conductor has no per-agent file-scope concept)
+    * ``applyTo`` absent → "not applied automatically; you can still add them
+      manually to a chat request" → SKIP
+
+    Conductor's preamble is always-on for every agent prompt. To honor the
+    convention exactly, only files explicitly marked ``applyTo: "**"`` are
+    loaded.
+    """
+    fm = _parse_frontmatter(path)
+    if fm is None:
+        return False
+    return fm.get("applyTo") == "**"
+
+
+# ---------------------------------------------------------------------------
+# Convention registry
+# ---------------------------------------------------------------------------
+
+# The single source of truth for what conductor auto-discovers when
+# ``--workspace-instructions`` is enabled. Order is preserved in the discovery
+# output: file conventions first (in declaration order), then directory
+# conventions (each directory's files sorted by relative-path-within-dir).
+CONVENTIONS: list[Convention] = [
+    ConventionFile("AGENTS.md"),
+    ConventionFile(".github/copilot-instructions.md"),
+    ConventionFile("CLAUDE.md"),
+    ConventionDirectory(
+        path=".github/instructions",
+        pattern="*.instructions.md",
+        include_file=_is_always_on_instructions_file,
+        recursive=True,
+    ),
 ]
+
+
+# Backward-compat alias: ``CONVENTION_FILES`` was module-public (no leading
+# underscore) prior to the polymorphic refactor. It is not in ``__all__`` and
+# was always documented as an implementation detail, but downstream code
+# could import it directly. Keep it as an unconditional alias projecting only
+# the file conventions, so any such import keeps working.
+CONVENTION_FILES: list[str] = [c.path for c in CONVENTIONS if isinstance(c, ConventionFile)]
 
 # Warn when total instruction content exceeds this threshold (bytes).
 INSTRUCTION_SIZE_WARNING_THRESHOLD = 50 * 1024  # 50 KB
@@ -52,45 +222,102 @@ def _find_git_root(start_dir: Path) -> Path | None:
         current = parent
 
 
+def _walk_directory_convention(
+    base_dir: Path, convention: ConventionDirectory
+) -> Iterator[tuple[str, Path]]:
+    """Yield ``(relative_path, absolute_path)`` for files in ``base_dir``
+    matching ``convention.pattern`` and (if set) ``convention.include_file``.
+
+    The relative path is computed against ``base_dir`` and uses POSIX
+    separators for cross-platform deterministic ordering.
+
+    Symlinked directories are NOT traversed (``followlinks=False``); symlinked
+    files inside the tree are listed and read like regular files.
+    """
+    if convention.recursive:
+        for dirpath, _dirnames, filenames in os.walk(base_dir, followlinks=False):
+            for fname in fnmatch.filter(filenames, convention.pattern):
+                file_path = Path(dirpath) / fname
+                if convention.include_file is not None and not convention.include_file(file_path):
+                    continue
+                rel = file_path.relative_to(base_dir).as_posix()
+                yield rel, file_path
+    else:
+        try:
+            entries = list(os.scandir(base_dir))
+        except OSError as e:
+            logger.debug("Cannot scan %s: %s", base_dir, e)
+            return
+        for entry in entries:
+            # follow_symlinks=True so symlinked files are treated as regular files
+            try:
+                is_file = entry.is_file(follow_symlinks=True)
+            except OSError:
+                continue
+            if not is_file:
+                continue
+            if not fnmatch.fnmatch(entry.name, convention.pattern):
+                continue
+            file_path = Path(entry.path)
+            if convention.include_file is not None and not convention.include_file(file_path):
+                continue
+            yield entry.name, file_path
+
+
 def discover_workspace_instructions(start_dir: Path) -> list[Path]:
     """Discover convention instruction files by walking up to the git root.
 
-    Searches from ``start_dir`` up to the git repository root for known
-    convention files (AGENTS.md, .github/copilot-instructions.md, CLAUDE.md).
-    Files closer to ``start_dir`` take precedence when the same filename
-    exists at multiple levels.
+    Searches from ``start_dir`` up to the git repository root for each entry
+    in :data:`CONVENTIONS`. Files closer to ``start_dir`` take precedence
+    when the same logical match key exists at multiple levels (closest-wins).
 
-    Args:
-        start_dir: Directory to start discovery from (typically CWD).
+    Each convention has its own discovery state, so keys do not collide
+    across conventions (e.g., a hypothetical ``.cursor/rules/style.md`` would
+    not shadow ``.github/instructions/style.instructions.md``).
 
     Returns:
-        List of discovered instruction file paths in deterministic order,
-        grouped by convention file type.
+        List of discovered instruction file paths. File conventions appear
+        first in their :data:`CONVENTIONS` declaration order; directory
+        conventions follow with their files sorted by relative path within
+        the convention directory.
     """
     git_root = _find_git_root(start_dir)
     stop_at = git_root if git_root is not None else start_dir.resolve()
 
-    # Track which convention file names we've already found (closest wins).
-    found_names: set[str] = set()
-    discovered: dict[str, Path] = {}
+    result: list[Path] = []
+    for convention in CONVENTIONS:
+        # Per-convention state: closest-wins is local to this convention only.
+        discovered: dict[str, Path] = {}
 
-    current = start_dir.resolve()
-    while True:
-        for convention_file in CONVENTION_FILES:
-            if convention_file in found_names:
-                continue
-            candidate = current / convention_file
-            if candidate.is_file():
-                found_names.add(convention_file)
-                discovered[convention_file] = candidate
-                logger.debug("Discovered instruction file: %s", candidate)
+        current = start_dir.resolve()
+        while True:
+            if isinstance(convention, ConventionFile):
+                if convention.path not in discovered:
+                    candidate = current / convention.path
+                    if candidate.is_file():
+                        discovered[convention.path] = candidate
+                        logger.debug("Discovered instruction file: %s", candidate)
+            else:  # ConventionDirectory
+                base_dir = current / convention.path
+                if base_dir.is_dir():
+                    for rel, abs_path in _walk_directory_convention(base_dir, convention):
+                        if rel not in discovered:
+                            discovered[rel] = abs_path
+                            logger.debug("Discovered instruction file: %s", abs_path)
 
-        if current == stop_at or current.parent == current:
-            break
-        current = current.parent
+            if current == stop_at or current.parent == current:
+                break
+            current = current.parent
 
-    # Return in the deterministic order defined by CONVENTION_FILES
-    return [discovered[name] for name in CONVENTION_FILES if name in discovered]
+        # Append this convention's discoveries in deterministic order.
+        if isinstance(convention, ConventionFile):
+            if convention.path in discovered:
+                result.append(discovered[convention.path])
+        else:  # ConventionDirectory
+            for rel in sorted(discovered.keys()):
+                result.append(discovered[rel])
+
+    return result
 
 
 def load_instruction_files(paths: list[Path]) -> str:
@@ -109,7 +336,10 @@ def load_instruction_files(paths: list[Path]) -> str:
 
     for path in paths:
         try:
-            content = path.read_text(encoding="utf-8").strip()
+            # 'utf-8-sig' transparently strips a leading UTF-8 BOM. Without
+            # this, BOM-authored files (common from some Windows editors)
+            # would inject a leading \ufeff into the agent prompt.
+            content = path.read_text(encoding="utf-8-sig").strip()
             if content:
                 sections.append(f"# Instructions from: {path.name}\n\n{content}")
                 logger.debug("Loaded instruction file: %s (%d bytes)", path, len(content))

--- a/tests/test_config/test_instructions.py
+++ b/tests/test_config/test_instructions.py
@@ -1091,3 +1091,35 @@ class TestConventionDirectoryNonRecursive:
         conv = ConventionDirectory(path="rules", pattern="*.md", recursive=False)
         # No exception; empty iterator
         assert list(_walk_directory_convention(missing, conv)) == []
+
+    def test_non_recursive_skips_entries_whose_is_file_raises(self, tmp_path: Path) -> None:
+        """Defensive: ``entry.is_file()`` can raise OSError for broken symlinks
+        or permission errors. The walker swallows that exception and skips
+        the entry rather than crashing the whole discovery."""
+        from unittest.mock import patch
+
+        from conductor.config.instructions import (
+            ConventionDirectory,
+            _walk_directory_convention,
+        )
+
+        base = tmp_path / "rules"
+        base.mkdir()
+        (base / "good.md").write_text("ok", encoding="utf-8")
+        (base / "broken.md").write_text("ok", encoding="utf-8")
+
+        conv = ConventionDirectory(path="rules", pattern="*.md", recursive=False)
+
+        # Make is_file() raise OSError for the "broken" entry only
+        original_is_file = os.DirEntry.is_file
+
+        def patched_is_file(self, *, follow_symlinks=True):
+            if self.name == "broken.md":
+                raise OSError("simulated broken symlink")
+            return original_is_file(self, follow_symlinks=follow_symlinks)
+
+        with patch.object(os.DirEntry, "is_file", patched_is_file):
+            results = dict(_walk_directory_convention(base, conv))
+
+        assert "good.md" in results
+        assert "broken.md" not in results

--- a/tests/test_config/test_instructions.py
+++ b/tests/test_config/test_instructions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -654,3 +655,328 @@ class TestBgRunnerInstructionFlags:
                 assert len(instr_indices) == 2
                 assert cmd[instr_indices[0] + 1] == "AGENTS.md"
                 assert cmd[instr_indices[1] + 1] == "CLAUDE.md"
+
+
+# ---------------------------------------------------------------------------
+# Directory-convention discovery: .github/instructions/*.instructions.md
+# ---------------------------------------------------------------------------
+
+
+def _write_with_frontmatter(
+    path: Path,
+    *,
+    apply_to: str | None = "**",
+    body: str = "Coding rules.",
+    description: str | None = None,
+    no_frontmatter: bool = False,
+    raw: str | None = None,
+    encoding: str = "utf-8",
+) -> None:
+    """Helper: write a `.instructions.md` file with the given frontmatter setup.
+
+    * ``raw`` — write bytes/string verbatim (overrides everything)
+    * ``no_frontmatter`` — write ``body`` without any ``---`` block
+    * ``apply_to=None`` — emit a frontmatter block with no ``applyTo`` key
+    * ``apply_to="<glob>"`` — emit a frontmatter block with that ``applyTo`` value
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if raw is not None:
+        path.write_text(raw, encoding=encoding)
+        return
+    if no_frontmatter:
+        path.write_text(body, encoding=encoding)
+        return
+    lines = ["---"]
+    if description is not None:
+        lines.append(f"description: '{description}'")
+    if apply_to is not None:
+        lines.append(f"applyTo: '{apply_to}'")
+    lines.append("---")
+    lines.append(body)
+    path.write_text("\n".join(lines) + "\n", encoding=encoding)
+
+
+class TestDiscoverGithubInstructionsDir:
+    """Tests for `.github/instructions/*.instructions.md` directory discovery."""
+
+    def test_discovers_always_on_file(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "style.instructions.md"
+        _write_with_frontmatter(f, apply_to="**", body="Use four-space indents.")
+        result = discover_workspace_instructions(tmp_path)
+        assert any(p.name == "style.instructions.md" for p in result)
+
+    def test_skips_scoped_file(self, tmp_path: Path) -> None:
+        """`applyTo: '<other glob>'` is scoped per the docs and SHOULD NOT be loaded."""
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "ts-only.instructions.md"
+        _write_with_frontmatter(f, apply_to="**/*.ts", body="TS rules.")
+        result = discover_workspace_instructions(tmp_path)
+        assert not any(p.name == "ts-only.instructions.md" for p in result)
+
+    def test_skips_no_frontmatter(self, tmp_path: Path) -> None:
+        """Files without any frontmatter are 'manual-attach' per the docs → SKIP."""
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "plain.instructions.md"
+        _write_with_frontmatter(f, no_frontmatter=True, body="Plain markdown.")
+        result = discover_workspace_instructions(tmp_path)
+        assert not any(p.name == "plain.instructions.md" for p in result)
+
+    def test_skips_no_apply_to(self, tmp_path: Path) -> None:
+        """Frontmatter present but no `applyTo` key → manual-attach default → SKIP."""
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "desc-only.instructions.md"
+        _write_with_frontmatter(f, apply_to=None, description="Just description")
+        result = discover_workspace_instructions(tmp_path)
+        assert not any(p.name == "desc-only.instructions.md" for p in result)
+
+    def test_recursive_subdirs(self, tmp_path: Path) -> None:
+        """Files in nested subdirectories are discovered (recursive=True default)."""
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "lang" / "csharp.instructions.md"
+        _write_with_frontmatter(f, apply_to="**", body="C# rules.")
+        result = discover_workspace_instructions(tmp_path)
+        assert any(p.parent.name == "lang" and p.name == "csharp.instructions.md" for p in result)
+
+    def test_closest_wins_per_relative_path(self, tmp_path: Path) -> None:
+        """When the same relative path exists at multiple levels, closest wins."""
+        (tmp_path / ".git").mkdir()
+        # root-level instructions
+        _write_with_frontmatter(
+            tmp_path / ".github" / "instructions" / "lang" / "csharp.instructions.md",
+            apply_to="**",
+            body="ROOT_CSHARP",
+        )
+        _write_with_frontmatter(
+            tmp_path / ".github" / "instructions" / "style.instructions.md",
+            apply_to="**",
+            body="ROOT_STYLE",
+        )
+        # subproject-level overrides csharp only
+        sub = tmp_path / "subproject"
+        sub.mkdir()
+        _write_with_frontmatter(
+            sub / ".github" / "instructions" / "lang" / "csharp.instructions.md",
+            apply_to="**",
+            body="SUB_CSHARP",
+        )
+
+        result = discover_workspace_instructions(sub)
+        # Build a {rel-path-within-dir: file} map for easier assertion
+        by_rel = {}
+        for p in result:
+            # Find the .github/instructions ancestor
+            parts = p.parts
+            try:
+                idx = parts.index("instructions")
+            except ValueError:
+                continue
+            if idx >= 1 and parts[idx - 1] == ".github":
+                rel = "/".join(parts[idx + 1 :])
+                by_rel[rel] = p
+
+        # Subproject's csharp wins; root's style is loaded since no override
+        assert (
+            by_rel["lang/csharp.instructions.md"]
+            .read_text(encoding="utf-8")
+            .endswith("SUB_CSHARP\n")
+        )
+        assert by_rel["style.instructions.md"].read_text(encoding="utf-8").endswith("ROOT_STYLE\n")
+
+    def test_root_only_file_loads_when_subproject_missing(self, tmp_path: Path) -> None:
+        """When the subproject has no `.github/instructions/`, root's files load."""
+        (tmp_path / ".git").mkdir()
+        _write_with_frontmatter(
+            tmp_path / ".github" / "instructions" / "global.instructions.md",
+            apply_to="**",
+        )
+        sub = tmp_path / "subproject"
+        sub.mkdir()
+        result = discover_workspace_instructions(sub)
+        assert any(p.name == "global.instructions.md" for p in result)
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Symlink creation requires elevation on Windows",
+    )
+    def test_symlinked_directory_not_traversed(self, tmp_path: Path) -> None:
+        """Symlinked directories inside `.github/instructions/` are NOT traversed.
+
+        Prevents symlink loops and out-of-tree expansion. Symlinked instruction
+        FILES are still treated as regular files (different policy)."""
+        (tmp_path / ".git").mkdir()
+        instr_dir = tmp_path / ".github" / "instructions"
+        instr_dir.mkdir(parents=True)
+        # Real file directly under the convention dir
+        _write_with_frontmatter(instr_dir / "real.instructions.md", apply_to="**")
+        # Out-of-tree directory containing a tempting file
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        _write_with_frontmatter(outside / "leak.instructions.md", apply_to="**")
+        # Symlink the outside dir into the convention dir
+        os.symlink(outside, instr_dir / "outside_link", target_is_directory=True)
+
+        result = discover_workspace_instructions(tmp_path)
+        names = [p.name for p in result]
+        assert "real.instructions.md" in names
+        assert "leak.instructions.md" not in names
+
+    def test_directory_and_file_conventions_coexist(self, tmp_path: Path) -> None:
+        """File conventions (AGENTS.md) and directory conventions both load."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "AGENTS.md").write_text("agents content")
+        _write_with_frontmatter(
+            tmp_path / ".github" / "instructions" / "style.instructions.md",
+            apply_to="**",
+        )
+        result = discover_workspace_instructions(tmp_path)
+        names = [p.name for p in result]
+        assert "AGENTS.md" in names
+        assert "style.instructions.md" in names
+        # File conventions appear first (declaration order in CONVENTIONS).
+        assert names.index("AGENTS.md") < names.index("style.instructions.md")
+
+    def test_pattern_must_match(self, tmp_path: Path) -> None:
+        """Files in `.github/instructions/` that don't match the `*.instructions.md`
+        pattern are NOT picked up (e.g. plain `.md`)."""
+        (tmp_path / ".git").mkdir()
+        # Wrong extension: .md, not .instructions.md
+        _write_with_frontmatter(
+            tmp_path / ".github" / "instructions" / "foo.md",
+            apply_to="**",
+            body="should not load",
+        )
+        result = discover_workspace_instructions(tmp_path)
+        assert not any(p.name == "foo.md" for p in result)
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter robustness: edge cases for `_is_always_on_instructions_file`
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatterRobustness:
+    """Edge cases for the YAML frontmatter parser used by the directory convention."""
+
+    def test_crlf_line_endings(self, tmp_path: Path) -> None:
+        """Windows-authored files with CRLF are still parsed correctly."""
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "win.instructions.md"
+        f.parent.mkdir(parents=True)
+        f.write_bytes(b"---\r\napplyTo: '**'\r\n---\r\nWindows file.\r\n")
+        result = discover_workspace_instructions(tmp_path)
+        assert any(p.name == "win.instructions.md" for p in result)
+
+    def test_utf8_bom_handling(self, tmp_path: Path) -> None:
+        """A leading UTF-8 BOM does not break frontmatter parsing."""
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "bom.instructions.md"
+        f.parent.mkdir(parents=True)
+        # BOM (\xef\xbb\xbf) followed by frontmatter
+        f.write_bytes(b"\xef\xbb\xbf---\napplyTo: '**'\n---\nBOM file.\n")
+        result = discover_workspace_instructions(tmp_path)
+        assert any(p.name == "bom.instructions.md" for p in result)
+
+    def test_malformed_yaml_skipped_with_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Malformed YAML in frontmatter logs a warning and skips, not crashes."""
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "bad.instructions.md"
+        f.parent.mkdir(parents=True)
+        # Invalid YAML: unclosed quote
+        f.write_text("---\napplyTo: '**\n---\nBody.\n", encoding="utf-8")
+        with caplog.at_level(logging.WARNING):
+            result = discover_workspace_instructions(tmp_path)
+        assert not any(p.name == "bad.instructions.md" for p in result)
+        assert "Failed to parse frontmatter" in caplog.text
+
+    def test_non_dict_yaml_skipped(self, tmp_path: Path) -> None:
+        """Frontmatter that parses to a non-dict (list/scalar/empty) is skipped safely."""
+        (tmp_path / ".git").mkdir()
+        # Frontmatter that parses to a YAML list (not a dict)
+        list_fm = tmp_path / ".github" / "instructions" / "list.instructions.md"
+        list_fm.parent.mkdir(parents=True)
+        list_fm.write_text("---\n- a\n- b\n---\nBody.\n", encoding="utf-8")
+        # Frontmatter that parses to an empty doc
+        empty_fm = tmp_path / ".github" / "instructions" / "empty.instructions.md"
+        empty_fm.write_text("---\n\n---\nBody.\n", encoding="utf-8")
+        # Frontmatter that parses to a scalar
+        scalar_fm = tmp_path / ".github" / "instructions" / "scalar.instructions.md"
+        scalar_fm.write_text("---\nhello\n---\nBody.\n", encoding="utf-8")
+
+        result = discover_workspace_instructions(tmp_path)
+        names = [p.name for p in result]
+        assert "list.instructions.md" not in names
+        assert "empty.instructions.md" not in names
+        assert "scalar.instructions.md" not in names
+
+    def test_closing_delimiter_at_eof(self, tmp_path: Path) -> None:
+        """Frontmatter with closing `---` at EOF (no trailing newline) parses correctly.
+
+        Some authors do not end files with a trailing newline. The tolerant
+        regex handles both `\\Z` and `\\r?\\n` after the closing delimiter.
+        """
+        (tmp_path / ".git").mkdir()
+        f = tmp_path / ".github" / "instructions" / "eof.instructions.md"
+        f.parent.mkdir(parents=True)
+        # No body, no trailing newline
+        f.write_text("---\napplyTo: '**'\n---", encoding="utf-8")
+        result = discover_workspace_instructions(tmp_path)
+        assert any(p.name == "eof.instructions.md" for p in result)
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: CONVENTION_FILES alias
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    """Locks the public-import contract for downstream consumers of
+    ``CONVENTION_FILES`` predating the polymorphic refactor."""
+
+    def test_convention_files_remains_importable(self) -> None:
+        """`CONVENTION_FILES` was module-public before the refactor and must
+        keep working for any downstream code that imports it directly."""
+        from conductor.config.instructions import CONVENTION_FILES
+
+        assert CONVENTION_FILES == [
+            "AGENTS.md",
+            ".github/copilot-instructions.md",
+            "CLAUDE.md",
+        ]
+
+    def test_convention_files_projects_from_conventions(self) -> None:
+        """`CONVENTION_FILES` must reflect every `ConventionFile` entry in
+        `CONVENTIONS`, in the same order — so adding a new file convention
+        automatically updates the alias."""
+        from conductor.config.instructions import (
+            CONVENTION_FILES,
+            CONVENTIONS,
+            ConventionFile,
+        )
+
+        expected = [c.path for c in CONVENTIONS if isinstance(c, ConventionFile)]
+        assert expected == CONVENTION_FILES
+
+
+# ---------------------------------------------------------------------------
+# UTF-8 BOM handling in load_instruction_files
+# ---------------------------------------------------------------------------
+
+
+class TestLoadInstructionFilesBom:
+    """Locks BOM handling in the reader path (not just the frontmatter parser)."""
+
+    def test_bom_stripped_from_loaded_content(self, tmp_path: Path) -> None:
+        """A BOM-authored instruction file must not leak `\\ufeff` into the
+        prompt content emitted by `load_instruction_files()`.
+        """
+        from conductor.config.instructions import load_instruction_files
+
+        f = tmp_path / "AGENTS.md"
+        # BOM (\xef\xbb\xbf) followed by content
+        f.write_bytes(b"\xef\xbb\xbfAgent rules.\n")
+        result = load_instruction_files([f])
+        assert "\ufeff" not in result
+        assert "Agent rules." in result

--- a/tests/test_config/test_instructions.py
+++ b/tests/test_config/test_instructions.py
@@ -980,3 +980,114 @@ class TestLoadInstructionFilesBom:
         result = load_instruction_files([f])
         assert "\ufeff" not in result
         assert "Agent rules." in result
+
+
+# ---------------------------------------------------------------------------
+# Coverage: _parse_frontmatter exception path
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrontmatterExceptions:
+    """Locks the exception path of _parse_frontmatter (OSError on read)."""
+
+    def test_unreadable_file_returns_none(self, tmp_path: Path) -> None:
+        """When ``path.read_text`` raises (e.g., file is actually a directory),
+        the parser returns None and logs at DEBUG; never raises."""
+        from conductor.config.instructions import _parse_frontmatter
+
+        # Pass a directory path — read_text will raise an OSError (PermissionError
+        # on Windows, IsADirectoryError on POSIX). Both subclass OSError.
+        d = tmp_path / "not_a_file"
+        d.mkdir()
+        assert _parse_frontmatter(d) is None
+
+
+# ---------------------------------------------------------------------------
+# Coverage: non-recursive ConventionDirectory branch
+# ---------------------------------------------------------------------------
+
+
+class TestConventionDirectoryNonRecursive:
+    """Locks the ``recursive=False`` branch of _walk_directory_convention.
+
+    No production convention currently uses ``recursive=False``, but the
+    polymorphic shape supports it (e.g. for hypothetical Cline-style flat
+    directories like ``.clinerules/*.md``). These tests pin the behaviour
+    without waiting for a future convention to add it.
+    """
+
+    def test_non_recursive_skips_subdirectory_files(self, tmp_path: Path) -> None:
+        """With ``recursive=False``, files in subdirectories are NOT discovered."""
+        from conductor.config.instructions import (
+            ConventionDirectory,
+            _walk_directory_convention,
+        )
+
+        base = tmp_path / "rules"
+        base.mkdir()
+        (base / "top.md").write_text("top-level rule", encoding="utf-8")
+        sub = base / "lang"
+        sub.mkdir()
+        (sub / "csharp.md").write_text("nested rule", encoding="utf-8")
+
+        conv = ConventionDirectory(path="rules", pattern="*.md", recursive=False)
+        results = dict(_walk_directory_convention(base, conv))
+
+        assert "top.md" in results
+        assert "csharp.md" not in results
+        # Recursion suppressed — nested file path is not yielded
+        assert not any("lang" in k for k in results)
+
+    def test_non_recursive_applies_pattern(self, tmp_path: Path) -> None:
+        """Pattern filter applies in the non-recursive branch."""
+        from conductor.config.instructions import (
+            ConventionDirectory,
+            _walk_directory_convention,
+        )
+
+        base = tmp_path / "rules"
+        base.mkdir()
+        (base / "match.md").write_text("md", encoding="utf-8")
+        (base / "skip.txt").write_text("txt", encoding="utf-8")
+
+        conv = ConventionDirectory(path="rules", pattern="*.md", recursive=False)
+        results = dict(_walk_directory_convention(base, conv))
+
+        assert "match.md" in results
+        assert "skip.txt" not in results
+
+    def test_non_recursive_applies_include_file_predicate(self, tmp_path: Path) -> None:
+        """``include_file`` predicate applies in the non-recursive branch."""
+        from conductor.config.instructions import (
+            ConventionDirectory,
+            _walk_directory_convention,
+        )
+
+        base = tmp_path / "rules"
+        base.mkdir()
+        (base / "include.md").write_text("INCLUDE", encoding="utf-8")
+        (base / "skip.md").write_text("SKIP", encoding="utf-8")
+
+        conv = ConventionDirectory(
+            path="rules",
+            pattern="*.md",
+            recursive=False,
+            include_file=lambda p: "INCLUDE" in p.read_text(encoding="utf-8"),
+        )
+        results = dict(_walk_directory_convention(base, conv))
+
+        assert "include.md" in results
+        assert "skip.md" not in results
+
+    def test_non_recursive_missing_directory_yields_nothing(self, tmp_path: Path) -> None:
+        """If the convention directory does not exist, the walker logs at DEBUG
+        and yields nothing — never raises."""
+        from conductor.config.instructions import (
+            ConventionDirectory,
+            _walk_directory_convention,
+        )
+
+        missing = tmp_path / "does_not_exist"
+        conv = ConventionDirectory(path="rules", pattern="*.md", recursive=False)
+        # No exception; empty iterator
+        assert list(_walk_directory_convention(missing, conv)) == []


### PR DESCRIPTION
Closes microsoft/conductor#168

## What

1. Refactor `CONVENTION_FILES: list[str]` into a polymorphic `CONVENTIONS: list[Convention]` using a `Convention = ConventionFile | ConventionDirectory` type union. Each convention type has its own discovery state to prevent cross-convention key shadowing.

2. Add `.github/instructions/**/*.instructions.md` as a `ConventionDirectory` with `applyTo` frontmatter filtering — only files marked `applyTo: "**"` (always-on per GitHub Copilot's documented semantics) are loaded into the workspace preamble. Scoped (`applyTo: "<other glob>"`) and absent `applyTo` files are skipped, matching the convention's manual-attach default.

## Why polymorphic

Today's `CONVENTION_FILES` assumes every entry is a single relative file path checked with `Path.is_file()`. Adding `.github/instructions/` requires recursive directory walks, glob pattern matching, and per-file frontmatter filtering. Rather than fork the walker, the polymorphic shape lets future conventions (Cursor `.cursor/rules/`, Cline `.clinerules/`, etc.) be added as one filter function + one list entry — the walker centralises all discovery semantics in one place.

## Backward compatibility

- `CONVENTION_FILES` kept as an unconditional module-level alias projecting only `ConventionFile` entries; downstream `from conductor.config.instructions import CONVENTION_FILES` keeps working (locked by test).
- Repos without `.github/instructions/` see byte-identical behaviour.
- File convention output order unchanged.

## Robustness

- ruamel.yaml `typ="safe"` for frontmatter parsing (no PyYAML — uses conductor's existing dep declared at pyproject.toml:37).
- Tolerant regex handles CRLF line endings and EOF-without-trailing-newline.
- `utf-8-sig` encoding strips BOM at both frontmatter parse AND `load_instruction_files()` reader (BOM no longer leaks into prompts).
- Non-dict YAML, malformed YAML, and OS errors handled defensively.
- Symlinked directories NOT traversed (`os.walk(followlinks=False)`); symlinked files read normally.
- `_parse_frontmatter()` extracted as a reusable primitive so future conventions need only their own predicate (e.g. `alwaysApply: true`).

## Tests

- All 38 existing tests pass unchanged.
- 18 new tests across 4 new classes covering directory discovery (TestDiscoverGithubInstructionsDir), frontmatter robustness (TestFrontmatterRobustness), backward-compat alias (TestBackwardCompat), and BOM handling in load_instruction_files (TestLoadInstructionFilesBom).
- ruff check + ruff format clean.