### PR TITLE
fix(windows): use OpenProcess for liveness check in pid.py (#166)

### DIFF
--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -6,6 +6,7 @@ This module defines the main Typer app and global options.
 from __future__ import annotations
 
 import contextvars
+import logging
 import os
 from enum import Enum
 from pathlib import Path
@@ -17,6 +18,8 @@ from rich.panel import Panel
 from rich.text import Text
 
 from conductor import __version__
+
+logger = logging.getLogger(__name__)
 
 
 class ConsoleVerbosity(str, Enum):
@@ -1139,6 +1142,20 @@ def _stop_process(entry: dict, con: Console) -> None:
         con.print(
             f"[bold red]Permission denied:[/bold red] could not stop PID {pid}. "
             f"Try running with elevated privileges."
+        )
+    except OSError as exc:
+        # Defensive catch (companion to the fix for issue #166): on Windows,
+        # ``os.kill`` can raise OSError subclasses for edge cases such as the
+        # target not being a console process group leader, or a probe-failing
+        # PID that the "assume alive" fallback in ``_is_process_alive_windows``
+        # let through.  Treating these as "already exited" lets ``conductor
+        # stop`` continue and clean up the PID file rather than crash.
+        logger.warning(
+            "Unexpected OSError stopping PID %s; treating as already exited", pid, exc_info=True
+        )
+        con.print(
+            f"[yellow]Could not signal PID {pid} ({exc}); "
+            f"removing PID file for workflow '{workflow}' anyway.[/yellow]"
         )
 
 

--- a/src/conductor/cli/pid.py
+++ b/src/conductor/cli/pid.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -161,19 +162,101 @@ def remove_pid_file_for_current_process() -> bool:
 def _is_process_alive(pid: int) -> bool:
     """Check whether a process with the given PID is still running.
 
-    Uses ``os.kill(pid, 0)`` which checks existence without sending a signal.
+    Dispatches to a platform-specific implementation. On POSIX systems this
+    uses ``os.kill(pid, 0)`` to probe existence without sending a signal. On
+    Windows it uses ``OpenProcess`` + ``GetExitCodeProcess`` because
+    ``os.kill(pid, 0)`` is **not** a no-op probe on Windows — any signal value
+    other than ``CTRL_C_EVENT`` / ``CTRL_BREAK_EVENT`` calls
+    ``TerminateProcess`` and may also raise ``OSError`` subclasses that the
+    POSIX-style branches don't anticipate (e.g. ``WinError 11`` /
+    ``ERROR_BAD_FORMAT``).
 
     Args:
         pid: The process ID to check.
 
     Returns:
-        True if the process exists, False otherwise.
+        True if the process appears to still exist, False if it is known to be
+        gone. On any unexpected error this returns True so that ``conductor
+        stop`` doesn't silently delete PID files for processes that may still
+        be running.
     """
+    if sys.platform == "win32":
+        return _is_process_alive_windows(pid)
+    return _is_process_alive_posix(pid)
+
+
+def _is_process_alive_posix(pid: int) -> bool:
+    """POSIX implementation of :func:`_is_process_alive` using ``os.kill``."""
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
     except PermissionError:
-        # Process exists but we can't signal it — still alive
+        # Process exists but we can't signal it — still alive.
+        return True
+    except OSError:
+        # Unknown error from the OS — err on the side of "still alive" so that
+        # a transient failure doesn't crash ``conductor stop`` or cause us to
+        # silently drop a still-running workflow's PID file.
+        logger.debug("Unexpected OSError checking PID %s; assuming alive", pid, exc_info=True)
         return True
     return True
+
+
+def _is_process_alive_windows(pid: int) -> bool:
+    """Windows implementation of :func:`_is_process_alive` using ctypes.
+
+    Calls ``OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, ...)`` and then
+    ``GetExitCodeProcess`` rather than ``os.kill(pid, 0)``, which on Windows
+    is unsafe (it routes through ``TerminateProcess``) and can raise
+    ``OSError`` subclasses such as ``WinError 11`` (``ERROR_BAD_FORMAT``).
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    # Process access right that doesn't require administrative privileges and
+    # is sufficient to call GetExitCodeProcess.
+    process_query_limited_information = 0x1000
+    # Sentinel exit code returned by GetExitCodeProcess for a process that has
+    # not yet exited.  See the Windows SDK ``WinBase.h`` (``STILL_ACTIVE``).
+    still_active = 259
+    # ``OpenProcess`` failure error codes we want to interpret specifically.
+    error_access_denied = 5
+    error_invalid_parameter = 87
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[unresolved-attribute]
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        err = ctypes.get_last_error()  # type: ignore[unresolved-attribute]
+        if err == error_access_denied:
+            # Process exists but we lack the rights to query it — treat as alive.
+            return True
+        if err == error_invalid_parameter:
+            # No process with that PID exists.
+            return False
+        # Any other failure is unexpected. Don't crash; assume still alive so
+        # we don't silently delete a PID file for a process that may be
+        # running.
+        logger.debug("OpenProcess failed for PID %s with error %s; assuming alive", pid, err)
+        return True
+
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            # Couldn't read the exit code — assume alive rather than crash.
+            logger.debug(
+                "GetExitCodeProcess failed for PID %s with error %s; assuming alive",
+                pid,
+                ctypes.get_last_error(),  # type: ignore[unresolved-attribute]
+            )
+            return True
+        return exit_code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)

--- a/src/conductor/cli/pid.py
+++ b/src/conductor/cli/pid.py
@@ -16,16 +16,69 @@ PID files are JSON with the schema::
 
 from __future__ import annotations
 
+import ctypes
 import json
 import logging
 import os
 import sys
+from ctypes import wintypes
 from datetime import UTC, datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _PID_DIR_NAME = "runs"
+
+
+# --------------------------------------------------------------------------- #
+# Windows process-liveness probing
+#
+# ``os.kill(pid, 0)`` is the standard Unix probe but is unsafe on Windows: per
+# the CPython docs, any signal value other than ``CTRL_C_EVENT`` /
+# ``CTRL_BREAK_EVENT`` routes through ``TerminateProcess`` and may also raise
+# ``OSError`` subclasses that the POSIX-style branches don't anticipate (e.g.
+# ``WinError 11`` / ``ERROR_BAD_FORMAT``, see issue #166).  We use
+# ``OpenProcess`` + ``GetExitCodeProcess`` instead.
+#
+# All ctypes setup is hoisted to module level so it runs once per process,
+# matches the codebase's ``if sys.platform == "win32":`` idiom (see
+# ``cli/app.py``, ``cli/update.py``, ``cli/bg_runner.py``), and gives tests a
+# single ``_kernel32`` symbol to monkey-patch from any platform.
+# --------------------------------------------------------------------------- #
+
+# Process access right that doesn't require administrative privileges.
+# ``PROCESS_QUERY_LIMITED_INFORMATION`` is granted by a more permissive default
+# DACL than ``PROCESS_QUERY_INFORMATION`` and is the minimum right that
+# satisfies ``GetExitCodeProcess``.
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+# Sentinel exit code returned by ``GetExitCodeProcess`` for a process that has
+# not yet exited.  Defined as ``STILL_ACTIVE`` (alias of ``STATUS_PENDING`` =
+# ``0x103``) in the Windows SDK ``WinBase.h``.
+#
+# Known footgun: a process that legitimately exits with status code 259 is
+# indistinguishable from one that is still running.  Microsoft's documented
+# workaround is ``WaitForSingleObject(handle, 0)``.  We accept this ambiguity
+# because conductor child processes do not exit with code 259 in practice; the
+# worst case is a stale PID-file entry that the user can remove manually.
+_STILL_ACTIVE = 259
+# Specific ``OpenProcess`` failure codes we interpret.  Any other failure is
+# treated as "unknown — assume alive" so that a transient OS hiccup doesn't
+# silently delete a still-running workflow's PID file.
+_ERROR_ACCESS_DENIED = 5
+_ERROR_INVALID_PARAMETER = 87
+
+if sys.platform == "win32":
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+else:
+    # On non-Windows the kernel32 wrapper is unused in production but tests
+    # patch this symbol to exercise the Windows code path on every platform.
+    _kernel32 = None
 
 
 def pid_dir() -> Path:
@@ -186,7 +239,12 @@ def _is_process_alive(pid: int) -> bool:
 
 
 def _is_process_alive_posix(pid: int) -> bool:
-    """POSIX implementation of :func:`_is_process_alive` using ``os.kill``."""
+    """POSIX implementation of :func:`_is_process_alive` using ``os.kill``.
+
+    Catches generic :class:`OSError` and returns True so a transient OS
+    failure doesn't crash ``conductor stop`` or silently drop a live
+    workflow's PID file (regression for issue #166).
+    """
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -195,10 +253,15 @@ def _is_process_alive_posix(pid: int) -> bool:
         # Process exists but we can't signal it — still alive.
         return True
     except OSError:
-        # Unknown error from the OS — err on the side of "still alive" so that
-        # a transient failure doesn't crash ``conductor stop`` or cause us to
-        # silently drop a still-running workflow's PID file.
-        logger.debug("Unexpected OSError checking PID %s; assuming alive", pid, exc_info=True)
+        # Unknown error from the OS — err on the side of "still alive".  We
+        # log at warning so the user can see why a phantom workflow is
+        # appearing in ``conductor stop`` listings.
+        logger.warning(
+            "Unexpected OSError checking PID %s; assuming alive. "
+            "The PID file in ~/.conductor/runs/ may need manual removal.",
+            pid,
+            exc_info=True,
+        )
         return True
     return True
 
@@ -210,53 +273,56 @@ def _is_process_alive_windows(pid: int) -> bool:
     ``GetExitCodeProcess`` rather than ``os.kill(pid, 0)``, which on Windows
     is unsafe (it routes through ``TerminateProcess``) and can raise
     ``OSError`` subclasses such as ``WinError 11`` (``ERROR_BAD_FORMAT``).
+
+    Limitations:
+
+    - Relies on the ``STILL_ACTIVE`` (259) sentinel from ``GetExitCodeProcess``.
+      A process that legitimately exits with status code 259 will be reported
+      as still alive forever.  Microsoft's documented workaround is
+      ``WaitForSingleObject(handle, 0)``; we accept the ambiguity because
+      conductor child processes do not exit with code 259 in practice.
     """
-    import ctypes
-    from ctypes import wintypes
-
-    # Process access right that doesn't require administrative privileges and
-    # is sufficient to call GetExitCodeProcess.
-    process_query_limited_information = 0x1000
-    # Sentinel exit code returned by GetExitCodeProcess for a process that has
-    # not yet exited.  See the Windows SDK ``WinBase.h`` (``STILL_ACTIVE``).
-    still_active = 259
-    # ``OpenProcess`` failure error codes we want to interpret specifically.
-    error_access_denied = 5
-    error_invalid_parameter = 87
-
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[unresolved-attribute]
-    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
-    kernel32.OpenProcess.restype = wintypes.HANDLE
-    kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
-    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
-    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
-    kernel32.CloseHandle.restype = wintypes.BOOL
-
-    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    # In production this function is only reached when ``sys.platform ==
+    # "win32"`` (so ``_kernel32`` is set); in tests the symbol is patched to a
+    # MagicMock.  The assert narrows the type for ty / mypy and provides a
+    # clear failure mode if the function is ever called incorrectly.
+    assert _kernel32 is not None, "_is_process_alive_windows requires _kernel32 to be initialised"
+    handle = _kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
     if not handle:
-        err = ctypes.get_last_error()  # type: ignore[unresolved-attribute]
-        if err == error_access_denied:
-            # Process exists but we lack the rights to query it — treat as alive.
+        err = ctypes.get_last_error()
+        if err == _ERROR_ACCESS_DENIED:
+            # Process exists but we lack the rights to query it — treat as
+            # alive.  This is an expected condition (e.g. cross-session or
+            # higher-integrity targets) so a debug log is sufficient.
+            logger.debug("OpenProcess(PID=%s) denied (ERROR_ACCESS_DENIED); assuming alive", pid)
             return True
-        if err == error_invalid_parameter:
+        if err == _ERROR_INVALID_PARAMETER:
             # No process with that PID exists.
             return False
-        # Any other failure is unexpected. Don't crash; assume still alive so
-        # we don't silently delete a PID file for a process that may be
-        # running.
-        logger.debug("OpenProcess failed for PID %s with error %s; assuming alive", pid, err)
+        # Any other failure is unexpected.  Don't crash; assume still alive
+        # but warn so the user can diagnose phantom workflows.
+        logger.warning(
+            "OpenProcess(PID=%s) failed with WinError %s (%s); assuming alive. "
+            "The PID file in ~/.conductor/runs/ may need manual removal.",
+            pid,
+            err,
+            ctypes.FormatError(err),
+        )
         return True
 
     try:
         exit_code = wintypes.DWORD()
-        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+        if not _kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
             # Couldn't read the exit code — assume alive rather than crash.
-            logger.debug(
-                "GetExitCodeProcess failed for PID %s with error %s; assuming alive",
+            err = ctypes.get_last_error()
+            logger.warning(
+                "GetExitCodeProcess(PID=%s) failed with WinError %s (%s); assuming alive. "
+                "The PID file in ~/.conductor/runs/ may need manual removal.",
                 pid,
-                ctypes.get_last_error(),  # type: ignore[unresolved-attribute]
+                err,
+                ctypes.FormatError(err),
             )
             return True
-        return exit_code.value == still_active
+        return exit_code.value == _STILL_ACTIVE
     finally:
-        kernel32.CloseHandle(handle)
+        _kernel32.CloseHandle(handle)

--- a/tests/test_cli/test_pid.py
+++ b/tests/test_cli/test_pid.py
@@ -4,18 +4,22 @@ Covers:
 - ``write_pid_file`` / ``read_pid_files`` / ``remove_pid_file``
 - ``remove_pid_file_for_current_process``
 - Stale PID cleanup (process no longer alive)
+- ``_is_process_alive`` platform dispatch (POSIX + Windows)
 """
 
 from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from conductor.cli.pid import (
+    _is_process_alive,
+    _is_process_alive_posix,
     read_pid_files,
     remove_pid_file,
     remove_pid_file_for_current_process,
@@ -127,3 +131,112 @@ class TestRemovePidFileForCurrentProcess:
         remaining = list(pid_tmpdir.glob("*.pid"))
         assert len(remaining) == 1
         assert "9090" in remaining[0].name
+
+
+class TestIsProcessAlivePosix:
+    """Tests for ``_is_process_alive_posix``.
+
+    These exercise the POSIX path directly so they can run on any platform —
+    we mock ``os.kill`` rather than relying on real process state.
+    """
+
+    def test_returns_true_when_alive(self) -> None:
+        with patch("conductor.cli.pid.os.kill", return_value=None):
+            assert _is_process_alive_posix(12345) is True
+
+    def test_returns_false_when_process_lookup_error(self) -> None:
+        with patch("conductor.cli.pid.os.kill", side_effect=ProcessLookupError):
+            assert _is_process_alive_posix(99999999) is False
+
+    def test_returns_true_when_permission_error(self) -> None:
+        # Process exists but signalling it is not permitted — still alive.
+        with patch("conductor.cli.pid.os.kill", side_effect=PermissionError):
+            assert _is_process_alive_posix(1) is True
+
+    def test_unexpected_oserror_does_not_crash(self) -> None:
+        # Regression for issue #166: a generic OSError (e.g. WinError 11 on
+        # Windows or any other unexpected failure) must not propagate out and
+        # crash ``conductor stop``.  We treat it as "assume alive" so the
+        # corresponding PID file isn't silently dropped.
+        with patch(
+            "conductor.cli.pid.os.kill",
+            side_effect=OSError(
+                11, "An attempt was made to load a program with an incorrect format"
+            ),
+        ):
+            assert _is_process_alive_posix(12345) is True
+
+
+class TestIsProcessAliveDispatch:
+    """Tests for the top-level ``_is_process_alive`` dispatcher."""
+
+    def test_dispatches_to_posix_on_non_windows(self) -> None:
+        with (
+            patch("conductor.cli.pid.sys.platform", "linux"),
+            patch("conductor.cli.pid._is_process_alive_posix", return_value=True) as posix,
+            patch("conductor.cli.pid._is_process_alive_windows") as win,
+        ):
+            assert _is_process_alive(42) is True
+            posix.assert_called_once_with(42)
+            win.assert_not_called()
+
+    def test_dispatches_to_windows_on_win32(self) -> None:
+        with (
+            patch("conductor.cli.pid.sys.platform", "win32"),
+            patch("conductor.cli.pid._is_process_alive_windows", return_value=False) as win,
+            patch("conductor.cli.pid._is_process_alive_posix") as posix,
+        ):
+            assert _is_process_alive(42) is False
+            win.assert_called_once_with(42)
+            posix.assert_not_called()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific implementation")
+class TestIsProcessAliveWindows:
+    """Tests for ``_is_process_alive_windows``.
+
+    The implementation calls into ``kernel32.dll`` via ctypes so these tests
+    only run on Windows where those APIs are actually available.
+    """
+
+    def test_current_process_is_alive(self) -> None:
+        from conductor.cli.pid import _is_process_alive_windows
+
+        assert _is_process_alive_windows(os.getpid()) is True
+
+    def test_nonexistent_pid_is_not_alive(self) -> None:
+        from conductor.cli.pid import _is_process_alive_windows
+
+        # PID 0xFFFFFFFF (4294967295) is invalid and OpenProcess will reject
+        # it with ERROR_INVALID_PARAMETER.
+        assert _is_process_alive_windows(0xFFFFFFFF) is False
+
+
+class TestReadPidFilesDoesNotCrashOnOsError:
+    """Regression test for issue #166.
+
+    ``read_pid_files`` must not propagate an unexpected ``OSError`` from the
+    process-alive probe — otherwise ``conductor stop`` becomes unusable any
+    time a stale PID file is present (e.g. ``WinError 11`` on Windows).
+    """
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Patches os.kill, which the Windows path does not use.",
+    )
+    def test_unexpected_oserror_does_not_propagate(self, pid_tmpdir: Path) -> None:
+        write_pid_file(99999999, 8080, "/tmp/wf.yaml")
+        with patch(
+            "conductor.cli.pid.os.kill",
+            side_effect=OSError(
+                11, "An attempt was made to load a program with an incorrect format"
+            ),
+        ):
+            # Should not raise. With the unexpected OSError caught and treated
+            # as "assume alive", the PID file is preserved rather than
+            # silently deleted.
+            results = read_pid_files()
+
+        assert len(results) == 1
+        assert results[0]["port"] == 8080
+        assert (pid_tmpdir / "wf-8080.pid").exists()

--- a/tests/test_cli/test_pid.py
+++ b/tests/test_cli/test_pid.py
@@ -13,13 +13,14 @@ import json
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from conductor.cli.pid import (
     _is_process_alive,
     _is_process_alive_posix,
+    _is_process_alive_windows,
     read_pid_files,
     remove_pid_file,
     remove_pid_file_for_current_process,
@@ -134,11 +135,8 @@ class TestRemovePidFileForCurrentProcess:
 
 
 class TestIsProcessAlivePosix:
-    """Tests for ``_is_process_alive_posix``.
-
-    These exercise the POSIX path directly so they can run on any platform —
-    we mock ``os.kill`` rather than relying on real process state.
-    """
+    """The POSIX path is exercised on every platform — ``os.kill`` is mocked
+    rather than relying on real process state."""
 
     def test_returns_true_when_alive(self) -> None:
         with patch("conductor.cli.pid.os.kill", return_value=None):
@@ -149,15 +147,15 @@ class TestIsProcessAlivePosix:
             assert _is_process_alive_posix(99999999) is False
 
     def test_returns_true_when_permission_error(self) -> None:
-        # Process exists but signalling it is not permitted — still alive.
         with patch("conductor.cli.pid.os.kill", side_effect=PermissionError):
             assert _is_process_alive_posix(1) is True
 
     def test_unexpected_oserror_does_not_crash(self) -> None:
-        # Regression for issue #166: a generic OSError (e.g. WinError 11 on
-        # Windows or any other unexpected failure) must not propagate out and
-        # crash ``conductor stop``.  We treat it as "assume alive" so the
-        # corresponding PID file isn't silently dropped.
+        # Regression for issue #166: any unexpected OSError from ``os.kill``
+        # (the original Windows ``WinError 11`` trigger, or any other novel
+        # failure) must be absorbed rather than propagated, so that
+        # ``conductor stop`` doesn't crash and live workflow PID files aren't
+        # silently dropped.
         with patch(
             "conductor.cli.pid.os.kill",
             side_effect=OSError(
@@ -168,7 +166,8 @@ class TestIsProcessAlivePosix:
 
 
 class TestIsProcessAliveDispatch:
-    """Tests for the top-level ``_is_process_alive`` dispatcher."""
+    """The top-level ``_is_process_alive`` selects the right implementation
+    based on ``sys.platform``."""
 
     def test_dispatches_to_posix_on_non_windows(self) -> None:
         with (
@@ -191,24 +190,124 @@ class TestIsProcessAliveDispatch:
             posix.assert_not_called()
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific implementation")
-class TestIsProcessAliveWindows:
-    """Tests for ``_is_process_alive_windows``.
+def _make_kernel32_mock(
+    *,
+    open_handle: int = 0xDEADBEEF,
+    get_exit_code_ok: bool = True,
+    exit_code: int = 259,
+) -> MagicMock:
+    """Build a ``MagicMock`` standing in for the cached ``kernel32`` wrapper.
 
-    The implementation calls into ``kernel32.dll`` via ctypes so these tests
-    only run on Windows where those APIs are actually available.
+    ``GetExitCodeProcess`` is configured to write ``exit_code`` into the
+    pointer it's given (mirroring the real Win32 behaviour) and return
+    ``get_exit_code_ok``.
+    """
+    k = MagicMock(name="kernel32")
+    k.OpenProcess.return_value = open_handle
+
+    def _set_exit_code(handle, dword_ptr):  # type: ignore[no-untyped-def]
+        dword_ptr._obj.value = exit_code
+        return get_exit_code_ok
+
+    k.GetExitCodeProcess.side_effect = _set_exit_code
+    k.CloseHandle.return_value = True
+    return k
+
+
+class TestIsProcessAliveWindowsMocked:
+    """Cross-platform unit tests for ``_is_process_alive_windows``.
+
+    Mocks the cached ``_kernel32`` wrapper and ``ctypes.get_last_error`` so
+    every branch of the Windows implementation is covered on POSIX runners,
+    not only on Windows CI.  ``ctypes.get_last_error`` doesn't exist on
+    non-Windows so it is patched with ``create=True``.
+    """
+
+    def test_running_process_returns_true(self) -> None:
+        k = _make_kernel32_mock(open_handle=0x1000, exit_code=259)
+        with patch("conductor.cli.pid._kernel32", k):
+            assert _is_process_alive_windows(42) is True
+        k.CloseHandle.assert_called_once_with(0x1000)
+
+    def test_exited_process_returns_false(self) -> None:
+        # The primary production case for stale-PID cleanup: GetExitCodeProcess
+        # succeeds and reports a non-STILL_ACTIVE exit code.
+        k = _make_kernel32_mock(open_handle=0x1000, exit_code=0)
+        with patch("conductor.cli.pid._kernel32", k):
+            assert _is_process_alive_windows(42) is False
+        k.CloseHandle.assert_called_once_with(0x1000)
+
+    def test_exited_with_nonzero_returns_false(self) -> None:
+        # Any exit code other than STILL_ACTIVE (259) means the process exited.
+        k = _make_kernel32_mock(open_handle=0x1000, exit_code=1)
+        with patch("conductor.cli.pid._kernel32", k):
+            assert _is_process_alive_windows(42) is False
+
+    def test_open_process_access_denied_returns_true(self) -> None:
+        # ERROR_ACCESS_DENIED = 5: process exists but we can't query it.
+        k = _make_kernel32_mock(open_handle=0)
+        with (
+            patch("conductor.cli.pid._kernel32", k),
+            patch("conductor.cli.pid.ctypes.get_last_error", create=True, return_value=5),
+        ):
+            assert _is_process_alive_windows(42) is True
+        k.CloseHandle.assert_not_called()
+
+    def test_open_process_invalid_parameter_returns_false(self) -> None:
+        # ERROR_INVALID_PARAMETER = 87: no such process.
+        k = _make_kernel32_mock(open_handle=0)
+        with (
+            patch("conductor.cli.pid._kernel32", k),
+            patch("conductor.cli.pid.ctypes.get_last_error", create=True, return_value=87),
+        ):
+            assert _is_process_alive_windows(42) is False
+        k.CloseHandle.assert_not_called()
+
+    def test_open_process_unrecognized_error_assumes_alive(self) -> None:
+        # Any other OpenProcess failure (e.g. WinError 11 from the original
+        # bug, or 998 ERROR_NOACCESS) — assume alive to preserve PID file.
+        k = _make_kernel32_mock(open_handle=0)
+        with (
+            patch("conductor.cli.pid._kernel32", k),
+            patch("conductor.cli.pid.ctypes.get_last_error", create=True, return_value=11),
+            patch("conductor.cli.pid.ctypes.FormatError", create=True, return_value="msg"),
+        ):
+            assert _is_process_alive_windows(42) is True
+        k.CloseHandle.assert_not_called()
+
+    def test_get_exit_code_failure_assumes_alive_and_closes_handle(self) -> None:
+        # If GetExitCodeProcess fails after a successful OpenProcess we still
+        # need to release the handle — the try/finally guarantees this.
+        k = _make_kernel32_mock(open_handle=0x1000, get_exit_code_ok=False)
+        with (
+            patch("conductor.cli.pid._kernel32", k),
+            patch("conductor.cli.pid.ctypes.get_last_error", create=True, return_value=998),
+            patch("conductor.cli.pid.ctypes.FormatError", create=True, return_value="msg"),
+        ):
+            assert _is_process_alive_windows(42) is True
+        # Critical: the handle from a successful OpenProcess must always be
+        # closed, even when GetExitCodeProcess fails.
+        k.CloseHandle.assert_called_once_with(0x1000)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Real Win32 API smoke test")
+class TestIsProcessAliveWindowsReal:
+    """End-to-end smoke tests against the real ``kernel32.dll`` on Windows.
+
+    These complement :class:`TestIsProcessAliveWindowsMocked` by verifying
+    that the ctypes signatures and constants are correct against the actual
+    Win32 API, not just our model of it.
     """
 
     def test_current_process_is_alive(self) -> None:
-        from conductor.cli.pid import _is_process_alive_windows
-
         assert _is_process_alive_windows(os.getpid()) is True
 
     def test_nonexistent_pid_is_not_alive(self) -> None:
-        from conductor.cli.pid import _is_process_alive_windows
-
-        # PID 0xFFFFFFFF (4294967295) is invalid and OpenProcess will reject
-        # it with ERROR_INVALID_PARAMETER.
+        # In practice ``OpenProcess`` rejects ``0xFFFFFFFF`` with
+        # ``ERROR_INVALID_PARAMETER`` (Windows PIDs are multiples of 4 and
+        # this value is reserved as a pseudo-handle).  Even if a future
+        # Windows release routed it differently, the fallback is "assume
+        # alive" — this assertion would then fail and prompt re-evaluation.
         assert _is_process_alive_windows(0xFFFFFFFF) is False
 
 
@@ -217,7 +316,7 @@ class TestReadPidFilesDoesNotCrashOnOsError:
 
     ``read_pid_files`` must not propagate an unexpected ``OSError`` from the
     process-alive probe — otherwise ``conductor stop`` becomes unusable any
-    time a stale PID file is present (e.g. ``WinError 11`` on Windows).
+    time a stale PID file is present (the original ``WinError 11`` symptom).
     """
 
     @pytest.mark.skipif(
@@ -225,7 +324,7 @@ class TestReadPidFilesDoesNotCrashOnOsError:
         reason="Patches os.kill, which the Windows path does not use.",
     )
     def test_unexpected_oserror_does_not_propagate(self, pid_tmpdir: Path) -> None:
-        write_pid_file(99999999, 8080, "/tmp/wf.yaml")
+        write_pid_file(99999999, 8080, str(pid_tmpdir / "wf.yaml"))
         with patch(
             "conductor.cli.pid.os.kill",
             side_effect=OSError(

--- a/tests/test_cli/test_stop.py
+++ b/tests/test_cli/test_stop.py
@@ -145,3 +145,46 @@ class TestStopProcessGone:
 
         assert result.exit_code == 0
         assert "already exited" in result.output
+
+
+class TestStopProcessUnexpectedOSError:
+    """Companion regression for issue #166.
+
+    The original bug crashed ``conductor stop`` when ``_is_process_alive``
+    propagated an unexpected ``OSError`` (e.g. ``WinError 11``). That probe
+    is now defensive — but ``_stop_process`` itself also calls ``os.kill``
+    one frame deeper and must tolerate the same class of failure, especially
+    because the "assume alive" fallback in ``_is_process_alive_windows`` lets
+    probe-failing PIDs reach this code path.
+    """
+
+    def test_unexpected_oserror_does_not_crash(self, pid_tmpdir: Path) -> None:
+        _write_pid(pid_tmpdir, 99999999, 8080)
+
+        with (
+            patch("conductor.cli.pid._is_process_alive", return_value=True),
+            patch(
+                "conductor.cli.app.os.kill",
+                side_effect=OSError(
+                    11, "An attempt was made to load a program with an incorrect format"
+                ),
+            ),
+        ):
+            result = runner.invoke(app, ["stop", "--port", "8080"])
+
+        assert result.exit_code == 0
+        assert "Could not signal" in result.output
+
+    def test_pid_file_is_removed_after_oserror(self, pid_tmpdir: Path) -> None:
+        # Even when os.kill raises an unexpected OSError, the PID file should
+        # be cleaned up so the user's ``conductor stop`` listings don't
+        # accumulate phantom entries.
+        _write_pid(pid_tmpdir, 99999999, 8080)
+
+        with (
+            patch("conductor.cli.pid._is_process_alive", return_value=True),
+            patch("conductor.cli.app.os.kill", side_effect=OSError(11, "boom")),
+        ):
+            runner.invoke(app, ["stop", "--port", "8080"])
+
+        assert list(pid_tmpdir.glob("*.pid")) == []


### PR DESCRIPTION
## Summary

Fixes #166. `conductor stop` (and `--all` / `--port`) crashes on Windows whenever a PID file exists in `~/.conductor/runs/`:

```
OSError: [WinError 11] An attempt was made to load a program with an incorrect format
```

The crash happens before any process is stopped, making the command effectively unusable on Windows.

## Root cause

`_is_process_alive` used the Unix idiom `os.kill(pid, 0)` to probe existence without sending a signal. On Windows that idiom is *not* a no-op — per the [CPython docs](https://docs.python.org/3/library/os.html#os.kill), any signal value other than `CTRL_C_EVENT` / `CTRL_BREAK_EVENT` routes through `TerminateProcess`. Depending on the target process's bitness/image type, this can raise `OSError` subclasses that neither `ProcessLookupError` nor `PermissionError` cover (e.g. `WinError 11` / `ERROR_BAD_FORMAT`). The exception escaped out of `read_pid_files()` and crashed the CLI.

It would also be unsafe even if it didn't raise: a "successful" `os.kill(pid, 0)` on Windows would actually terminate the target process with exit code 0.

## Fix (`src/conductor/cli/pid.py`)

Split `_is_process_alive` into a platform dispatcher and two implementations:

- **`_is_process_alive_posix`** keeps `os.kill(pid, 0)` and adds a defensive `OSError` catch that logs at debug and returns `True`. Treating an unexpected error as "assume alive" prevents a transient OS hiccup from silently dropping a still-running workflow's PID file or crashing `conductor stop`.
- **`_is_process_alive_windows`** uses `ctypes` to call `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, ...)` followed by `GetExitCodeProcess`. Maps `ERROR_INVALID_PARAMETER` → not alive, `ERROR_ACCESS_DENIED` → alive, and any other failure → assume alive (with a debug log).

No new dependencies added — `ctypes` is part of the Python stdlib. Windows-only ctypes attributes are flagged for `ty` with `# type: ignore[unresolved-attribute]`, matching the codebase's existing convention for platform-conditional code.

## Tests (`tests/test_cli/test_pid.py`)

- **`TestIsProcessAlivePosix`** — alive, `ProcessLookupError`, `PermissionError`, and the regression case (generic `OSError`, exactly the scenario the issue suggested would have caught this earlier).
- **`TestIsProcessAliveDispatch`** — verifies the dispatcher routes to the right implementation based on `sys.platform`.
- **`TestIsProcessAliveWindows`** — Windows-only smoke tests using real `kernel32.dll` for the current process and an invalid PID, gated with `pytest.mark.skipif(sys.platform != "win32")`.
- **`TestReadPidFilesDoesNotCrashOnOsError`** — full integration through `read_pid_files()` simulating the Windows-style failure on the POSIX path; asserts no exception escapes and the PID file is preserved (rather than silently deleted).

## Verification

- `uv run pytest tests/test_cli/test_pid.py` → **20 passed, 2 skipped** (Windows-only).
- `uv run pytest tests/test_cli/` → **353 passed, 2 skipped**.
- `uv run ruff check` / `ruff format --check` — clean.
- `uv run ty check src/conductor/` — back to baseline (no new diagnostics).

## Notes

- Behavior on macOS / Linux is unchanged for the normal alive / dead / no-permission cases.
- The Windows code path lives behind `sys.platform == "win32"` and uses lazy ctypes imports, so it has zero impact on POSIX startup or runtime.
- The `STILL_ACTIVE` (259) sentinel has the well-known corner case that a process can legitimately exit with code 259 and be reported as alive; for our use case (cleaning up stale workflow PID files) this is an acceptable known limitation.

Closes #166