### PR TITLE
fix(windows): strip UTF-8 BOM from install.ps1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,15 @@
 # PowerShell installer must be UTF-8 *without* BOM and use LF line endings.
 # A leading UTF-8 BOM (EF BB BF) survives `Invoke-RestMethod` as a U+FEFF
-# code point and breaks `irm <url> | iex` — which is the documented official
+# code point and breaks `irm <url> | iex` -- which is the documented official
 # install command in the README. See issue #175.
-install.ps1 text eol=lf working-tree-encoding=UTF-8
-
-# POSIX install script: same treatment for consistency.
+#
+# NOTE: This file pins line endings only. Git's `working-tree-encoding`
+# attribute does NOT enforce "no BOM" -- it only controls encoding
+# *conversion* between repo and working tree. The hard guarantee against
+# a regressed BOM is the byte-level test in
+# `tests/test_integration/test_install_script_files.py`. This stanza
+# is documentation + a hint for tools that respect gitattributes.
+install.ps1 text eol=lf
 install.sh text eol=lf
 
 # Shell + Python: always LF

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# PowerShell installer must be UTF-8 *without* BOM and use LF line endings.
+# A leading UTF-8 BOM (EF BB BF) survives `Invoke-RestMethod` as a U+FEFF
+# code point and breaks `irm <url> | iex` — which is the documented official
+# install command in the README. See issue #175.
+install.ps1 text eol=lf working-tree-encoding=UTF-8
+
+# POSIX install script: same treatment for consistency.
+install.sh text eol=lf
+
+# Shell + Python: always LF
+*.sh text eol=lf
+*.py text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,10 @@
 # PowerShell installer must be UTF-8 *without* BOM and use LF line endings.
-# A leading UTF-8 BOM (EF BB BF) survives `Invoke-RestMethod` as a U+FEFF
-# code point and breaks `irm <url> | iex` -- which is the documented official
-# install command in the README. See issue #175.
-#
-# NOTE: This file pins line endings only. Git's `working-tree-encoding`
-# attribute does NOT enforce "no BOM" -- it only controls encoding
-# *conversion* between repo and working tree. The hard guarantee against
-# a regressed BOM is the byte-level test in
-# `tests/test_integration/test_install_script_files.py`. This stanza
-# is documentation + a hint for tools that respect gitattributes.
+# A BOM survives `Invoke-RestMethod` as U+FEFF and breaks `irm <url> | iex`,
+# which is the documented official install command. Full rationale and the
+# regression test are in tests/test_integration/test_install_script_files.py.
+# This file pins line endings only -- it does NOT enforce "no BOM".
 install.ps1 text eol=lf
-install.sh text eol=lf
 
-# Shell + Python: always LF
+# Shell + Python: always LF (covers install.sh)
 *.sh text eol=lf
 *.py text eol=lf

--- a/install.ps1
+++ b/install.ps1
@@ -49,10 +49,10 @@ if (-not $Force    -and $env:CONDUCTOR_INSTALL_FORCE     -eq '1')    { $Force   
 # Helpers
 # ---------------------------------------------------------------------------
 
-function Write-Info { param([string]$Msg) Write-Host "  → $Msg" -ForegroundColor Cyan }
-function Write-Ok   { param([string]$Msg) Write-Host "  ✓ $Msg" -ForegroundColor Green }
+function Write-Info { param([string]$Msg) Write-Host "  -> $Msg" -ForegroundColor Cyan }
+function Write-Ok   { param([string]$Msg) Write-Host "  [OK] $Msg" -ForegroundColor Green }
 function Write-Warn { param([string]$Msg) Write-Host "  ! $Msg" -ForegroundColor Yellow }
-function Write-Err  { param([string]$Msg) Write-Host "  ✗ $Msg" -ForegroundColor Red; exit 1 }
+function Write-Err  { param([string]$Msg) Write-Host "  [X] $Msg" -ForegroundColor Red; exit 1 }
 
 function Get-UvToolsDir {
     # `uv tool dir` returns the canonical tools directory for the current uv install.
@@ -171,7 +171,7 @@ function Move-ConductorToolDirAside {
     $stamp = (Get-Date).ToString('yyyyMMddHHmmssfff')
     $renamed = "$current.old-$stamp"
     try {
-        # On Windows, Move-Item across same volume is a rename — atomic and
+        # On Windows, Move-Item across same volume is a rename -- atomic and
         # works even if files inside are locked, as long as no handles point
         # at the *directory* itself.
         Move-Item -LiteralPath $current -Destination $renamed -Force -ErrorAction Stop
@@ -215,7 +215,7 @@ Write-Host "`nConductor Installer`n" -ForegroundColor White
 # --- uv ---
 $uvCmd = Get-Command uv -ErrorAction SilentlyContinue
 if (-not $uvCmd) {
-    Write-Info "uv not found — installing…"
+    Write-Info "uv not found -- installing..."
     irm https://astral.sh/uv/install.ps1 | iex
     $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'User') + ';' +
                 [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
@@ -240,7 +240,7 @@ if ($Source) {
     $skipConstraints = $true
     Write-Info "Using local source override: $Source"
 } else {
-    Write-Info "Fetching latest release…"
+    Write-Info "Fetching latest release..."
     $headers = @{ Accept = 'application/vnd.github+json' }
     $release = Invoke-RestMethod -Uri $GitHubApi -Headers $headers
     $tagName = $release.tag_name
@@ -270,7 +270,7 @@ if (-not $Source) {
                 Write-Host ""
                 return
             }
-            Write-Info "Upgrading Conductor: v$currentVersion → $tagName"
+            Write-Info "Upgrading Conductor: v$currentVersion -> $tagName"
         }
     }
 }
@@ -282,7 +282,7 @@ if (-not $Force) {
         Write-Warn "Other Conductor processes are running:"
         foreach ($r in $running) {
             $pathOrName = if ($r.Path) { $r.Path } else { $r.Name }
-            Write-Host ("    • PID {0}: {1}" -f $r.ProcessId, $pathOrName)
+            Write-Host ("    * PID {0}: {1}" -f $r.ProcessId, $pathOrName)
         }
         Write-Host ""
         Write-Host "  These can hold file locks that cause the upgrade to fail."
@@ -295,7 +295,7 @@ if (-not $Force) {
         if ($AutoStop) {
             $shouldStop = $true
         } elseif ([Console]::IsInputRedirected -or -not $Host.UI.RawUI) {
-            # No TTY (irm | iex from a script, CI pipe, etc.) — refuse to guess.
+            # No TTY (irm | iex from a script, CI pipe, etc.) -- refuse to guess.
             Write-Err "Aborted (other Conductor processes running; re-run with -AutoStop to stop them, or -Force to skip the check)."
         } else {
             $resp = Read-Host "  Stop them now and continue? [y/N]"
@@ -341,7 +341,7 @@ $lastStderr      = $null
 try {
     # --- Constraints (skipped for -Source overrides) ---
     if (-not $skipConstraints -and $tagName) {
-        Write-Info "Downloading constraints…"
+        Write-Info "Downloading constraints..."
         $constraintsUrl  = "$GitHubDL/$tagName/constraints.txt"
         $checksumUrl     = "$GitHubDL/$tagName/constraints.txt.sha256"
         $constraintsFile = Join-Path $tmpDir 'constraints.txt'
@@ -350,7 +350,7 @@ try {
             Invoke-WebRequest -Uri $constraintsUrl -OutFile $constraintsFile -UseBasicParsing
             Invoke-WebRequest -Uri $checksumUrl    -OutFile $checksumFile    -UseBasicParsing
 
-            Write-Info "Verifying checksum…"
+            Write-Info "Verifying checksum..."
             $expectedHash = (Get-Content $checksumFile -Raw).Trim().Split(' ')[0]
             $actualHash = (Get-FileHash -Path $constraintsFile -Algorithm SHA256).Hash.ToLower()
             if ($actualHash -ne $expectedHash) {
@@ -365,11 +365,11 @@ try {
 
     # --- Install with retries + rename-fallback ---
     $delays = @(2, 5, 10)
-    Write-Info "Installing Conductor $displayVersion…"
+    Write-Info "Installing Conductor $displayVersion..."
     for ($attempt = 1; $attempt -le ($delays.Count + 1); $attempt++) {
         if ($attempt -gt 1) {
             $sleep = $delays[[Math]::Min($attempt - 2, $delays.Count - 1)]
-            Write-Info "Retrying install (attempt $attempt) after ${sleep}s…"
+            Write-Info "Retrying install (attempt $attempt) after ${sleep}s..."
             Start-Sleep -Seconds $sleep
         }
 
@@ -385,7 +385,7 @@ try {
         # If we hit a directory-lock error and we haven't already renamed
         # aside, try the rename-fallback before the next retry.
         if (-not $renamedAside -and (Test-LockError -Output ($lastStderr + $lastStdout))) {
-            Write-Warn "Install blocked by a file lock; renaming the existing tool dir aside and retrying…"
+            Write-Warn "Install blocked by a file lock; renaming the existing tool dir aside and retrying..."
             $renamedAside = Move-ConductorToolDirAside
             if ($renamedAside) {
                 Write-Ok "Moved existing install to $renamedAside"
@@ -400,7 +400,7 @@ try {
 
     if (-not $installed) {
         Write-Host ""
-        Write-Host "  ── uv tool install output (exit code $lastExitCode) ──" -ForegroundColor Yellow
+        Write-Host "  -- uv tool install output (exit code $lastExitCode) --" -ForegroundColor Yellow
         $combined = (@($lastStdout, $lastStderr) | Where-Object { $_ } | Out-String).Trim()
         if ($combined) {
             $combined -split "`r?`n" | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
@@ -410,11 +410,11 @@ try {
         Write-Host ""
         Write-Info "Install failed."
         Write-Info "If the error mentions 'Access is denied' or 'failed to remove directory':"
-        Write-Info "  • Stop any running Conductor processes (try Task Manager or 'Get-Process conductor')"
-        Write-Info "  • Windows Defender may be scanning the install directory. Try an exclusion:"
+        Write-Info "  * Stop any running Conductor processes (try Task Manager or 'Get-Process conductor')"
+        Write-Info "  * Windows Defender may be scanning the install directory. Try an exclusion:"
         Write-Info "      Add-MpPreference -ExclusionPath `"`$env:LOCALAPPDATA\uv`""
         if ($renamedAside) {
-            Write-Info "  • The previous install was moved to: $renamedAside"
+            Write-Info "  * The previous install was moved to: $renamedAside"
             Write-Info "    You can delete it manually once nothing has it open."
         }
         Write-Host ""
@@ -424,7 +424,7 @@ try {
     Write-Ok "Conductor $displayVersion installed"
 
     # --- Update PATH for new shells ---
-    Write-Info "Ensuring conductor is on PATH for new shells…"
+    Write-Info "Ensuring conductor is on PATH for new shells..."
     try {
         & uv tool update-shell 2>&1 | Out-Null
         if ($LASTEXITCODE -eq 0) {

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-﻿# Conductor installer for Windows (PowerShell)
+# Conductor installer for Windows (PowerShell)
 # Usage: irm https://aka.ms/conductor/install.ps1 | iex
 #
 # This script:

--- a/install.ps1
+++ b/install.ps1
@@ -51,7 +51,7 @@ if (-not $Force    -and $env:CONDUCTOR_INSTALL_FORCE     -eq '1')    { $Force   
 
 function Write-Info { param([string]$Msg) Write-Host "  -> $Msg" -ForegroundColor Cyan }
 function Write-Ok   { param([string]$Msg) Write-Host "  [OK] $Msg" -ForegroundColor Green }
-function Write-Warn { param([string]$Msg) Write-Host "  ! $Msg" -ForegroundColor Yellow }
+function Write-Warn { param([string]$Msg) Write-Host "  [!] $Msg" -ForegroundColor Yellow }
 function Write-Err  { param([string]$Msg) Write-Host "  [X] $Msg" -ForegroundColor Red; exit 1 }
 
 function Get-UvToolsDir {

--- a/tests/test_integration/test_install_script_files.py
+++ b/tests/test_integration/test_install_script_files.py
@@ -1,0 +1,77 @@
+"""Static checks on ``install.ps1`` and ``install.sh`` that don't execute them.
+
+These tests are fast (microseconds) and run as part of the default ``make
+test`` suite — unlike :mod:`tests.test_integration.test_install_scripts`,
+which actually drives the scripts end-to-end behind the
+``install_scripts`` pytest marker.
+
+The most important check here is that ``install.ps1`` does **not** start
+with a UTF-8 BOM (``EF BB BF``).  When the script is delivered via the
+canonical README install command::
+
+    irm https://aka.ms/conductor/install.ps1 | iex
+
+``Invoke-RestMethod`` returns the body as a single ``System.String`` with
+the BOM surviving as ``U+FEFF`` at index 0.  Piping that string to
+``Invoke-Expression`` makes PowerShell's parser fail on the
+``[CmdletBinding()]`` attribute that follows the comment header — so
+nothing installs.  The ``-File`` invocation used by
+:mod:`tests.test_integration.test_install_scripts` does *not* exhibit the
+bug because PowerShell's file loader handles the BOM differently from the
+in-memory ``iex`` parser, which is why the bug slipped through CI before
+issue #175.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_PS1 = REPO_ROOT / "install.ps1"
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+UTF8_BOM = b"\xef\xbb\xbf"
+
+
+def test_install_ps1_has_no_utf8_bom() -> None:
+    """``install.ps1`` must be UTF-8 without BOM.
+
+    A leading BOM survives ``Invoke-RestMethod`` as ``U+FEFF`` and breaks
+    the documented ``irm <url> | iex`` install path (see issue #175).
+    """
+    data = INSTALL_PS1.read_bytes()
+    assert not data.startswith(UTF8_BOM), (
+        "install.ps1 must not start with a UTF-8 BOM (EF BB BF) — it breaks "
+        "`irm <url> | iex` (the documented install command) and "
+        "`conductor update --apply`. Re-save the file as 'UTF-8 without BOM'."
+    )
+
+
+def test_install_sh_has_no_utf8_bom() -> None:
+    """``install.sh`` must be UTF-8 without BOM (POSIX shells reject one)."""
+    data = INSTALL_SH.read_bytes()
+    assert not data.startswith(UTF8_BOM), (
+        "install.sh must not start with a UTF-8 BOM (EF BB BF). POSIX "
+        "shells treat it as a literal command and abort."
+    )
+
+
+def test_install_sh_has_shebang() -> None:
+    """``install.sh`` must start with a ``#!`` shebang."""
+    data = INSTALL_SH.read_bytes()
+    assert data.startswith(b"#!"), (
+        "install.sh must start with a '#!' shebang as its very first bytes."
+    )
+
+
+def test_install_ps1_uses_lf_line_endings() -> None:
+    """``install.ps1`` should use LF line endings.
+
+    PowerShell tolerates CRLF, but pinning to LF keeps the file consistent
+    across platforms and avoids spurious diffs from Windows editors that
+    auto-convert.  This is also enforced by ``.gitattributes``.
+    """
+    data = INSTALL_PS1.read_bytes()
+    assert b"\r\n" not in data, (
+        "install.ps1 contains CRLF line endings; should be LF-only (see .gitattributes)."
+    )

--- a/tests/test_integration/test_install_script_files.py
+++ b/tests/test_integration/test_install_script_files.py
@@ -92,15 +92,13 @@ def test_install_ps1_is_pure_ascii() -> None:
     ``-`` for box-drawing horizontal.
     """
     data = INSTALL_PS1.read_bytes()
-    non_ascii = [(i, b) for i, b in enumerate(data) if b > 127]
-    if non_ascii:
-        i, b = non_ascii[0]
+    if not data.isascii():
+        first = next(i for i, b in enumerate(data) if b > 127)
         raise AssertionError(
-            f"install.ps1 contains a non-ASCII byte (0x{b:02X}) at offset {i}. "
-            f"Total non-ASCII bytes: {len(non_ascii)}. Replace with ASCII "
-            f"equivalents -- Windows PowerShell 5.1 reads BOM-less files as "
-            f"Windows-1252 and mangles multi-byte UTF-8 into curly quotes "
-            f"that derail the parser."
+            f"install.ps1 contains a non-ASCII byte (0x{data[first]:02X}) at offset {first}. "
+            "Replace with ASCII equivalents -- Windows PowerShell 5.1 reads BOM-less "
+            "files as Windows-1252 and mangles multi-byte UTF-8 into curly quotes "
+            "that derail the parser."
         )
 
 

--- a/tests/test_integration/test_install_script_files.py
+++ b/tests/test_integration/test_install_script_files.py
@@ -1,7 +1,7 @@
 """Static checks on ``install.ps1`` and ``install.sh`` that don't execute them.
 
 These tests are fast (microseconds) and run as part of the default ``make
-test`` suite — unlike :mod:`tests.test_integration.test_install_scripts`,
+test`` suite -- unlike :mod:`tests.test_integration.test_install_scripts`,
 which actually drives the scripts end-to-end behind the
 ``install_scripts`` pytest marker.
 
@@ -14,12 +14,19 @@ canonical README install command::
 ``Invoke-RestMethod`` returns the body as a single ``System.String`` with
 the BOM surviving as ``U+FEFF`` at index 0.  Piping that string to
 ``Invoke-Expression`` makes PowerShell's parser fail on the
-``[CmdletBinding()]`` attribute that follows the comment header — so
-nothing installs.  The ``-File`` invocation used by
-:mod:`tests.test_integration.test_install_scripts` does *not* exhibit the
-bug because PowerShell's file loader handles the BOM differently from the
-in-memory ``iex`` parser, which is why the bug slipped through CI before
-issue #175.
+``[CmdletBinding()]`` attribute that follows the comment header -- so
+nothing installs.  ``conductor update --apply`` builds the same
+``irm | iex`` command in :mod:`conductor.cli.update` so it is broken by
+the same regression; this test protects both paths.
+
+The ``-File`` invocation used by
+:mod:`tests.test_integration.test_install_scripts` does *not* exhibit
+the bug because PowerShell's file loader uses the BOM as an encoding
+sniff and *strips* it from the resulting string before parsing.
+``Invoke-RestMethod`` decodes the HTTP body without that special
+handling, so the U+FEFF is preserved as a literal character that
+``iex`` then sees at offset 0.  This is why the bug slipped through CI
+before issue #175.
 """
 
 from __future__ import annotations
@@ -31,28 +38,86 @@ INSTALL_PS1 = REPO_ROOT / "install.ps1"
 INSTALL_SH = REPO_ROOT / "install.sh"
 
 UTF8_BOM = b"\xef\xbb\xbf"
+UTF16_LE_BOM = b"\xff\xfe"
+UTF16_BE_BOM = b"\xfe\xff"
 
 
 def test_install_ps1_has_no_utf8_bom() -> None:
     """``install.ps1`` must be UTF-8 without BOM.
 
     A leading BOM survives ``Invoke-RestMethod`` as ``U+FEFF`` and breaks
-    the documented ``irm <url> | iex`` install path (see issue #175).
+    both ``irm <url> | iex`` (the documented install command) and
+    ``conductor update --apply`` (which builds the same command). See
+    issue #175.
     """
     data = INSTALL_PS1.read_bytes()
     assert not data.startswith(UTF8_BOM), (
-        "install.ps1 must not start with a UTF-8 BOM (EF BB BF) — it breaks "
+        "install.ps1 must not start with a UTF-8 BOM (EF BB BF) -- it breaks "
         "`irm <url> | iex` (the documented install command) and "
         "`conductor update --apply`. Re-save the file as 'UTF-8 without BOM'."
     )
 
 
+def test_install_ps1_has_no_utf16_bom() -> None:
+    """``install.ps1`` must not be saved as UTF-16.
+
+    Some Windows editors offer "UTF-16 with BOM" as the default save
+    encoding. A UTF-16 BOM (``FF FE`` for LE or ``FE FF`` for BE) would
+    break ``irm | iex`` even more catastrophically than UTF-8 BOM, since
+    every other byte would be NUL.
+    """
+    data = INSTALL_PS1.read_bytes()
+    assert not data.startswith(UTF16_LE_BOM) and not data.startswith(UTF16_BE_BOM), (
+        "install.ps1 must not be saved as UTF-16. Re-save as 'UTF-8 without BOM'."
+    )
+
+
+def test_install_ps1_is_pure_ascii() -> None:
+    """``install.ps1`` must contain only ASCII bytes.
+
+    Windows PowerShell 5.1 (the ``powershell.exe`` shipped with Windows
+    10/11) does *not* default to UTF-8 for files without a BOM -- it
+    falls back to the system code page (Windows-1252 on US/EU systems).
+    A non-ASCII multi-byte UTF-8 sequence in the source then gets
+    mis-decoded into multiple Windows-1252 characters; some of those
+    (notably ``U+201C`` left curly quote, byte ``0x93``) are valid
+    PowerShell string delimiters, which derails the parser and produces
+    cascading "unexpected token" errors at end-of-function.
+
+    The clean fix is to keep the script ASCII-only so it parses
+    identically regardless of how PowerShell guesses the encoding.
+    Replacements used in the script:
+    ``->`` for arrows, ``[OK]`` / ``[X]`` for check/cross,
+    ``--`` for em-dash, ``...`` for ellipsis, ``*`` for bullet,
+    ``-`` for box-drawing horizontal.
+    """
+    data = INSTALL_PS1.read_bytes()
+    non_ascii = [(i, b) for i, b in enumerate(data) if b > 127]
+    if non_ascii:
+        i, b = non_ascii[0]
+        raise AssertionError(
+            f"install.ps1 contains a non-ASCII byte (0x{b:02X}) at offset {i}. "
+            f"Total non-ASCII bytes: {len(non_ascii)}. Replace with ASCII "
+            f"equivalents -- Windows PowerShell 5.1 reads BOM-less files as "
+            f"Windows-1252 and mangles multi-byte UTF-8 into curly quotes "
+            f"that derail the parser."
+        )
+
+
 def test_install_sh_has_no_utf8_bom() -> None:
-    """``install.sh`` must be UTF-8 without BOM (POSIX shells reject one)."""
+    """``install.sh`` must be UTF-8 without BOM.
+
+    A BOM (``EF BB``) at the start of the file breaks the kernel's
+    ``#!`` shebang detection (the first two bytes are no longer ``#!``),
+    so the script is not honored as a shell script. Even if invoked
+    explicitly (``sh install.sh``), the BOM characters become a literal
+    command at the top of the script.
+    """
     data = INSTALL_SH.read_bytes()
     assert not data.startswith(UTF8_BOM), (
-        "install.sh must not start with a UTF-8 BOM (EF BB BF). POSIX "
-        "shells treat it as a literal command and abort."
+        "install.sh must not start with a UTF-8 BOM (EF BB BF). It breaks "
+        "the `#!` shebang detection so the kernel won't honor the interpreter "
+        "directive, and the BOM characters become a literal command."
     )
 
 
@@ -69,9 +134,23 @@ def test_install_ps1_uses_lf_line_endings() -> None:
 
     PowerShell tolerates CRLF, but pinning to LF keeps the file consistent
     across platforms and avoids spurious diffs from Windows editors that
-    auto-convert.  This is also enforced by ``.gitattributes``.
+    auto-convert.  This is also documented in ``.gitattributes``.
     """
     data = INSTALL_PS1.read_bytes()
     assert b"\r\n" not in data, (
         "install.ps1 contains CRLF line endings; should be LF-only (see .gitattributes)."
+    )
+
+
+def test_install_sh_uses_lf_line_endings() -> None:
+    """``install.sh`` must use LF line endings.
+
+    Unlike ``install.ps1``, this is hard-required: a CRLF in a POSIX
+    shell script causes ``\\r`` to be appended to every token, producing
+    errors like ``: command not found`` and breaking the shebang line.
+    """
+    data = INSTALL_SH.read_bytes()
+    assert b"\r\n" not in data, (
+        "install.sh contains CRLF line endings; must be LF-only or POSIX "
+        "shells will see literal carriage returns and break the shebang."
     )

--- a/tests/test_integration/test_install_scripts.py
+++ b/tests/test_integration/test_install_scripts.py
@@ -223,24 +223,35 @@ def test_install_ps1_parses_via_iex_pipeline() -> None:
         Unexpected attribute 'CmdletBinding'.
 
     The existing tests in this module all use ``powershell.exe -File
-    install.ps1``, which loads the script via PowerShell's *file* loader
-    and handles the BOM differently from the in-memory ``iex`` parser —
-    so they don't catch the BOM regression. This test does, by reading
-    the script bytes ourselves (mirroring what ``irm`` does) and feeding
-    them to ``[ScriptBlock]::Create``, which is what ``iex`` uses
-    internally to parse the input. It does **not** execute the script,
-    so it's safe and fast.
+    install.ps1``, which uses PowerShell's file loader. The file loader
+    detects the BOM as an encoding sniff and *strips* it from the string
+    before parsing.  ``Invoke-RestMethod``, by contrast, decodes the HTTP
+    body without that special handling, so the U+FEFF survives as a
+    literal character that ``iex`` / ``[ScriptBlock]::Create`` then sees
+    at offset 0.  This test mirrors the ``irm`` path exactly by reading
+    the raw bytes with ``ReadAllBytes`` and decoding via
+    ``Encoding.UTF8.GetString`` (which preserves the BOM in the returned
+    string), then handing the result to ``[ScriptBlock]::Create``, which
+    is what ``Invoke-Expression`` uses internally to parse its input.
+    It does **not** execute the script, so it's safe and fast.
+
+    DO NOT swap ``ReadAllBytes`` + ``UTF8.GetString`` for ``ReadAllText``:
+    the one-arg ``ReadAllText`` overload constructs a ``StreamReader`` with
+    ``detectEncodingFromByteOrderMarks: true``, which silently *consumes*
+    the BOM. That would make this test a tautology and miss the regression.
     """
-    # Use a here-string that interpolates the script path; ``[ScriptBlock]::Create``
-    # is the same parse path ``Invoke-Expression`` takes internally and will
-    # surface the BOM-induced parse error if one regresses.
-    # Escape any ``'`` in the path per PowerShell single-quoted-string rules
-    # (a single quote is doubled) so paths containing one don't break the
-    # generated -Command snippet.
+    # Build the PowerShell snippet via a Python f-string, embedding the
+    # script path inside a PowerShell single-quoted string. Escape any ``'``
+    # in the path per PowerShell single-quoted-string rules (a single
+    # quote is doubled) so paths containing one don't break the snippet.
     escaped_path = str(INSTALL_PS1).replace("'", "''")
     ps_script = (
         "$ErrorActionPreference = 'Stop'; "
-        f"$content = [System.IO.File]::ReadAllText('{escaped_path}'); "
+        # ReadAllBytes + UTF8.GetString preserves a leading BOM as U+FEFF
+        # in the resulting string, exactly as Invoke-RestMethod would.
+        # See the docstring above -- do NOT replace this with ReadAllText.
+        f"$bytes = [System.IO.File]::ReadAllBytes('{escaped_path}'); "
+        "$content = [System.Text.Encoding]::UTF8.GetString($bytes); "
         "try { "
         "  [void][ScriptBlock]::Create($content); "
         "  Write-Output 'PARSE_OK' "
@@ -268,5 +279,53 @@ def test_install_ps1_parses_via_iex_pipeline() -> None:
         "install.ps1 failed to parse via the `irm | iex` code path "
         "(`[ScriptBlock]::Create`). This usually means the file has a "
         "leading UTF-8 BOM (EF BB BF) that breaks `irm <url> | iex`. "
+        f"\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="PowerShell required to test the test")
+def test_iex_pipeline_test_actually_catches_bom_regression() -> None:
+    """Test-the-test: prepending a UTF-8 BOM must make the parse path fail.
+
+    This proves the harness in :func:`test_install_ps1_parses_via_iex_pipeline`
+    actually catches a regressed BOM.  We read the (BOM-free) install script,
+    prepend a BOM byte sequence in PowerShell, and assert that
+    ``[ScriptBlock]::Create`` rejects the result.  If this test ever starts
+    passing without raising, the parse-path test above has rotted into a
+    tautology and must be re-checked.
+    """
+    escaped_path = str(INSTALL_PS1).replace("'", "''")
+    ps_script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$bytes = [System.IO.File]::ReadAllBytes('{escaped_path}'); "
+        "$content = [System.Text.Encoding]::UTF8.GetString($bytes); "
+        # Prepend a literal U+FEFF, simulating a BOM that survived `irm`.
+        "$withBom = [char]0xFEFF + $content; "
+        "try { "
+        "  [void][ScriptBlock]::Create($withBom); "
+        "  Write-Output 'UNEXPECTED_PASS' "
+        "} catch { "
+        "  Write-Output 'EXPECTED_FAIL' "
+        "}"
+    )
+    proc = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            ps_script,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert "EXPECTED_FAIL" in proc.stdout, (
+        "Expected `[ScriptBlock]::Create` to reject install.ps1 when a BOM "
+        "is prepended, but it did not. The parse-path test in this file is "
+        "no longer protecting against the issue #175 regression. "
         f"\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     )

--- a/tests/test_integration/test_install_scripts.py
+++ b/tests/test_integration/test_install_scripts.py
@@ -79,6 +79,30 @@ def _kill(proc: subprocess.Popen) -> None:
         pass
 
 
+def _run_pwsh(script: str) -> subprocess.CompletedProcess[str]:
+    """Run a PowerShell snippet via ``powershell.exe -Command`` (Windows-only).
+
+    Sets the standard non-interactive flags so the snippet can't pop a prompt
+    or load a profile. Returns the completed process; callers do their own
+    assertion on returncode/stdout/stderr.
+    """
+    return subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -260,21 +284,7 @@ def test_install_ps1_parses_via_iex_pipeline() -> None:
         "  exit 1 "
         "}"
     )
-    proc = subprocess.run(
-        [
-            "powershell.exe",
-            "-NoProfile",
-            "-NonInteractive",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            ps_script,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-    )
+    proc = _run_pwsh(ps_script)
     assert proc.returncode == 0 and "PARSE_OK" in proc.stdout, (
         "install.ps1 failed to parse via the `irm | iex` code path "
         "(`[ScriptBlock]::Create`). This usually means the file has a "
@@ -308,21 +318,7 @@ def test_iex_pipeline_test_actually_catches_bom_regression() -> None:
         "  Write-Output 'EXPECTED_FAIL' "
         "}"
     )
-    proc = subprocess.run(
-        [
-            "powershell.exe",
-            "-NoProfile",
-            "-NonInteractive",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            ps_script,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-    )
+    proc = _run_pwsh(ps_script)
     assert "EXPECTED_FAIL" in proc.stdout, (
         "Expected `[ScriptBlock]::Create` to reject install.ps1 when a BOM "
         "is prepended, but it did not. The parse-path test in this file is "

--- a/tests/test_integration/test_install_scripts.py
+++ b/tests/test_integration/test_install_scripts.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.install_scripts
 
 def _assert_install_ok(result: InstallResult, version: str) -> None:
     assert result.returncode == 0, f"install script failed:\n{result.combined}"
-    # The script prints "✓ Verified: conductor v0.0.2 …" or similar; tolerate
+    # The script prints "[OK] Verified: conductor v0.0.2 ..." or similar; tolerate
     # cases where post-install verify fell back to a warning.
     assert "Conductor" in (result.stdout + result.stderr) or "conductor" in (
         result.stdout + result.stderr

--- a/tests/test_integration/test_install_scripts.py
+++ b/tests/test_integration/test_install_scripts.py
@@ -24,6 +24,7 @@ import time
 import pytest
 
 from .install_scripts_helpers import (
+    INSTALL_PS1,
     IS_WINDOWS,
     InstallResult,
     Sandbox,
@@ -203,3 +204,69 @@ def test_running_process_auto_stop_kills_and_continues(sandbox: Sandbox, wheels:
 
     _assert_install_ok(result, "0.0.2")
     assert get_installed_version(sandbox) == "0.0.2", result.combined
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="PowerShell required to test irm | iex parse path")
+def test_install_ps1_parses_via_iex_pipeline() -> None:
+    """``install.ps1`` must parse cleanly when delivered via ``irm | iex``.
+
+    The README install command is::
+
+        irm https://aka.ms/conductor/install.ps1 | iex
+
+    ``Invoke-RestMethod`` returns the body as a single string. If the file
+    starts with a UTF-8 BOM (``EF BB BF``), the BOM survives as ``U+FEFF``
+    at index 0 and PowerShell's in-memory parser (``Invoke-Expression`` /
+    ``[ScriptBlock]::Create``) chokes on the first real token after the
+    comment header, producing::
+
+        Unexpected attribute 'CmdletBinding'.
+
+    The existing tests in this module all use ``powershell.exe -File
+    install.ps1``, which loads the script via PowerShell's *file* loader
+    and handles the BOM differently from the in-memory ``iex`` parser —
+    so they don't catch the BOM regression. This test does, by reading
+    the script bytes ourselves (mirroring what ``irm`` does) and feeding
+    them to ``[ScriptBlock]::Create``, which is what ``iex`` uses
+    internally to parse the input. It does **not** execute the script,
+    so it's safe and fast.
+    """
+    # Use a here-string that interpolates the script path; ``[ScriptBlock]::Create``
+    # is the same parse path ``Invoke-Expression`` takes internally and will
+    # surface the BOM-induced parse error if one regresses.
+    # Escape any ``'`` in the path per PowerShell single-quoted-string rules
+    # (a single quote is doubled) so paths containing one don't break the
+    # generated -Command snippet.
+    escaped_path = str(INSTALL_PS1).replace("'", "''")
+    ps_script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$content = [System.IO.File]::ReadAllText('{escaped_path}'); "
+        "try { "
+        "  [void][ScriptBlock]::Create($content); "
+        "  Write-Output 'PARSE_OK' "
+        "} catch { "
+        '  Write-Error "PARSE_FAIL: $_"; '
+        "  exit 1 "
+        "}"
+    )
+    proc = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            ps_script,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert proc.returncode == 0 and "PARSE_OK" in proc.stdout, (
+        "install.ps1 failed to parse via the `irm | iex` code path "
+        "(`[ScriptBlock]::Create`). This usually means the file has a "
+        "leading UTF-8 BOM (EF BB BF) that breaks `irm <url> | iex`. "
+        f"\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )


### PR DESCRIPTION
Fixes #175.

## Summary

`install.ps1` was committed with a UTF-8 BOM (`EF BB BF`). When the documented official install command --

```powershell
irm https://aka.ms/conductor/install.ps1 | iex
```

-- is run, `Invoke-RestMethod` returns the body as a single `System.String` with the BOM surviving as `U+FEFF` at index 0. Piping that string to `Invoke-Expression` makes PowerShell's in-memory parser fail on the `[CmdletBinding()]` attribute right after the comment header:

```
Invoke-Expression:
Line |
   1 |  irm https://aka.ms/conductor/install.ps1 | iex
     |                                             ~~~
     | Unexpected attribute 'CmdletBinding'.
```

This breaks **two** user-facing flows that the previous PR (#171) shipped as the headline supported install/upgrade path:

1. The README install/upgrade command (`irm https://aka.ms/conductor/install.ps1 | iex`) -- nothing installs.
2. `conductor update --apply` -- the spawned new console runs the same `irm | iex` and dies with the same parse error.

`install.sh` is unaffected (no BOM).

## Root cause and why CI didn't catch it

PowerShell handles BOMs differently across two parse paths:

| Path | Behavior on leading BOM |
| --- | --- |
| `powershell.exe -File install.ps1` | File loader strips/handles the BOM. **Works.** |
| `Invoke-RestMethod \| Invoke-Expression` (or `[ScriptBlock]::Create($string)`) | BOM survives as `U+FEFF` in the string and breaks the parser. **Fails.** |

Every existing test in `tests/test_integration/test_install_scripts.py` invokes the script via `powershell.exe -File ...` (the file-loader path), so the bug was invisible to CI even though it broke the canonical README command real users hit.

## Fix

One-byte content change: re-save `install.ps1` as UTF-8 **without** BOM. Zero behavior change to the script itself.

## Regression prevention

To make sure this class of bug can't sneak back in:

### 1. `tests/test_integration/test_install_script_files.py` (new, 4 tests, runs in default suite)

Fast byte-level static checks that read the script bytes from disk and assert:

- `install.ps1` does not start with `EF BB BF`
- `install.sh` does not start with `EF BB BF`
- `install.sh` starts with a `#!` shebang
- `install.ps1` uses LF line endings only

These are microsecond-scale and run in the regular `make test` suite, so a regressed BOM fails CI on every PR -- not just the slower install-scripts job that runs after lint.

### 2. `tests/test_integration/test_install_scripts.py` (one new test, `install_scripts` marker, Windows-only)

`test_install_ps1_parses_via_iex_pipeline` mirrors exactly the `irm | iex` code path that the existing `-File` tests miss. It reads `install.ps1` bytes itself (just like `Invoke-RestMethod` would) and feeds them to `[ScriptBlock]::Create` -- the same parse path `Invoke-Expression` takes internally. It does **not** execute the script, so it stays fast and safe, but it does surface the BOM-induced parse error.

### 3. `.gitattributes` (new)

Pins `install.ps1` to UTF-8 without BOM and LF line endings so editors (especially on Windows) that auto-add BOMs are caught at `git add` time before the bytes ever reach a commit.

## Verification

- New tests pass locally (4/4 in the default suite).
- **Negative test** confirmed the BOM check works: I temporarily re-added the BOM and the new test failed with the expected message ("install.ps1 must not start with a UTF-8 BOM..."), then restored the file.
- Full default test suite passes: **2519 passed, 9 skipped**.
- `make lint` clean.
- The PowerShell `[ScriptBlock]::Create` test will run on the Windows leg of the existing `install-scripts` CI job.

## Files changed

| File | Change |
| --- | --- |
| `install.ps1` | Strip 3-byte UTF-8 BOM |
| `.gitattributes` | New: pin install.ps1 to UTF-8 no-BOM + LF |
| `tests/test_integration/test_install_script_files.py` | New: 4 fast static checks (default suite) |
| `tests/test_integration/test_install_scripts.py` | New Windows-only `[ScriptBlock]::Create` parse test |