### PR TITLE
fix(executor): render system_prompt and pass it to providers

### DIFF
--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -106,6 +106,27 @@ def validate_workflow_config(config: WorkflowConfig) -> list[str]:
             tool_errors = _validate_tool_references(agent.name, agent.tools, set(config.tools))
             errors.extend(tool_errors)
 
+        # Warn when an LLM agent has system_prompt but no (non-empty) prompt.
+        # The Copilot provider concatenates `agent.system_prompt` into the prompt,
+        # but providers that ignore system_prompt entirely (e.g., Claude) would
+        # leave such agents with an empty user message. Even with the executor
+        # rendering system_prompt, omitting `prompt:` is a portability hazard
+        # and almost always indicates the author meant to include a `prompt:`
+        # block alongside the persona/methodology in `system_prompt:`.
+        if (
+            agent.type in (None, "agent")
+            and agent.system_prompt
+            and not (agent.prompt and agent.prompt.strip())
+        ):
+            warnings.append(
+                f"Agent '{agent.name}' defines `system_prompt` but no `prompt` (or only whitespace). "
+                "Some providers (e.g., Claude) ignore `system_prompt` entirely, which would send an "
+                "empty user message to the model. Even with the Copilot provider, the model often "
+                "responds poorly to a missing user prompt. Move the dynamic, must-execute content "
+                "(input references, instructions) into a `prompt:` block; keep the persona and "
+                "static methodology in `system_prompt:`."
+            )
+
     # Validate parallel groups
     if config.parallel:
         parallel_errors = _validate_parallel_groups(config)

--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -119,12 +119,14 @@ def validate_workflow_config(config: WorkflowConfig) -> list[str]:
             and not (agent.prompt and agent.prompt.strip())
         ):
             warnings.append(
-                f"Agent '{agent.name}' defines `system_prompt` but no `prompt` (or only whitespace). "
-                "Some providers (e.g., Claude) ignore `system_prompt` entirely, which would send an "
-                "empty user message to the model. Even with the Copilot provider, the model often "
-                "responds poorly to a missing user prompt. Move the dynamic, must-execute content "
-                "(input references, instructions) into a `prompt:` block; keep the persona and "
-                "static methodology in `system_prompt:`."
+                f"Agent '{agent.name}' defines `system_prompt` but no `prompt` "
+                "(or only whitespace). "
+                "Some providers (e.g., Claude) ignore `system_prompt` entirely, "
+                "which would send an empty user message to the model. "
+                "Even with the Copilot provider, the model often responds poorly "
+                "to a missing user prompt. Move the dynamic, must-execute content "
+                "(input references, instructions) into a `prompt:` block; keep the "
+                "persona and static methodology in `system_prompt:`."
             )
 
     # Validate parallel groups

--- a/src/conductor/executor/agent.py
+++ b/src/conductor/executor/agent.py
@@ -174,10 +174,16 @@ class AgentExecutor:
             rendered_prompt,
         )
 
-        # Render system prompt if present (used by some providers)
-        # Note: System prompt support will be fully utilized in later EPICs
+        # Render system prompt if present and update the agent so that providers
+        # which forward `agent.system_prompt` (e.g., the Copilot provider) see
+        # the rendered text instead of the raw template with unfilled `{{ }}`
+        # placeholders. Without this, agents whose instructions live in
+        # `system_prompt` send unrendered Jinja to the model, which then
+        # correctly reports "the prompt template contains unfilled variables"
+        # and refuses to do useful work.
         if agent.system_prompt:
-            _ = self.renderer.render(agent.system_prompt, context)
+            rendered_system_prompt = self.renderer.render(agent.system_prompt, context)
+            agent = agent.model_copy(update={"system_prompt": rendered_system_prompt})
 
         # Resolve tools for this agent
         resolved_tools = resolve_agent_tools(agent.tools, self.workflow_tools)

--- a/tests/test_config/test_validator.py
+++ b/tests/test_config/test_validator.py
@@ -77,8 +77,7 @@ class TestValidateWorkflowConfig:
         )
         warnings = validate_workflow_config(config)
         assert any(
-            "lonely" in w and "system_prompt" in w and "no `prompt`" in w
-            for w in warnings
+            "lonely" in w and "system_prompt" in w and "no `prompt`" in w for w in warnings
         ), f"expected system_prompt-without-prompt warning; got: {warnings!r}"
 
     def test_no_warning_when_prompt_present_alongside_system_prompt(self) -> None:
@@ -96,9 +95,7 @@ class TestValidateWorkflowConfig:
             ],
         )
         warnings = validate_workflow_config(config)
-        assert not any(
-            "system_prompt" in w and "no `prompt`" in w for w in warnings
-        )
+        assert not any("system_prompt" in w and "no `prompt`" in w for w in warnings)
 
 
 class TestRouteValidation:

--- a/tests/test_config/test_validator.py
+++ b/tests/test_config/test_validator.py
@@ -55,6 +55,51 @@ class TestValidateWorkflowConfig:
         warnings = validate_workflow_config(config)
         assert isinstance(warnings, list)
 
+    def test_warns_on_system_prompt_without_prompt(self) -> None:
+        """Agent with system_prompt but no prompt: should produce a warning.
+
+        The Copilot provider concatenates system_prompt with the user prompt,
+        so a missing prompt means an empty user message — almost always a
+        latent author mistake. Other providers (Claude) ignore system_prompt
+        entirely, so the agent would have no instructions at all.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="test", entry_point="lonely"),
+            agents=[
+                AgentDef(
+                    name="lonely",
+                    model="gpt-4",
+                    system_prompt="You are a helpful assistant.",
+                    # no prompt:
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any(
+            "lonely" in w and "system_prompt" in w and "no `prompt`" in w
+            for w in warnings
+        ), f"expected system_prompt-without-prompt warning; got: {warnings!r}"
+
+    def test_no_warning_when_prompt_present_alongside_system_prompt(self) -> None:
+        """Having both system_prompt and prompt is the expected pattern — no warning."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="test", entry_point="ok"),
+            agents=[
+                AgentDef(
+                    name="ok",
+                    model="gpt-4",
+                    system_prompt="You are a helpful assistant.",
+                    prompt="Answer: 42",
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any(
+            "system_prompt" in w and "no `prompt`" in w for w in warnings
+        )
+
 
 class TestRouteValidation:
     """Tests for route target validation."""

--- a/tests/test_executor/test_agent.py
+++ b/tests/test_executor/test_agent.py
@@ -144,9 +144,7 @@ class TestAgentExecutorBasic:
         provider = CopilotProvider(mock_handler=mock_handler)
         executor = AgentExecutor(provider)
 
-        context = {
-            "workflow": {"input": {"topic": "Python", "question": "What is it?"}}
-        }
+        context = {"workflow": {"input": {"topic": "Python", "question": "What is it?"}}}
         await executor.execute(agent_with_system_prompt, context)
 
         assert len(captured_agents) == 1

--- a/tests/test_executor/test_agent.py
+++ b/tests/test_executor/test_agent.py
@@ -121,6 +121,44 @@ class TestAgentExecutorBasic:
         assert output.content["anything"] == "goes"
         assert output.content["here"] == 123
 
+    @pytest.mark.asyncio
+    async def test_execute_renders_system_prompt_passed_to_provider(
+        self, agent_with_system_prompt: AgentDef
+    ) -> None:
+        """Regression test: the executor must render `system_prompt` and update
+        the agent before passing it to the provider.
+
+        The Copilot provider concatenates `agent.system_prompt` into the prompt
+        sent to the model. If the executor leaves it as the raw template (with
+        unrendered `{{ }}` placeholders), the model sees literal Jinja syntax
+        and typically refuses with a "prompt template contains unfilled
+        variables" message. This test asserts the agent the provider receives
+        has its `system_prompt` fully rendered.
+        """
+        captured_agents: list[AgentDef] = []
+
+        def mock_handler(agent: AgentDef, prompt: str, context: dict) -> dict:
+            captured_agents.append(agent)
+            return {"answer": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        executor = AgentExecutor(provider)
+
+        context = {
+            "workflow": {"input": {"topic": "Python", "question": "What is it?"}}
+        }
+        await executor.execute(agent_with_system_prompt, context)
+
+        assert len(captured_agents) == 1
+        seen_system_prompt = captured_agents[0].system_prompt
+        assert seen_system_prompt is not None
+        assert "{{" not in seen_system_prompt, (
+            f"system_prompt was not rendered before being passed to provider. "
+            f"Got: {seen_system_prompt!r}"
+        )
+        assert "{%" not in seen_system_prompt
+        assert "Python" in seen_system_prompt
+
 
 class TestAgentExecutorPromptRendering:
     """Tests for prompt rendering."""


### PR DESCRIPTION
Previously the executor rendered `agent.system_prompt` only to discard the result (`_ = self.renderer.render(...)`), and providers that forward `agent.system_prompt` (notably the Copilot provider, which concatenates it into the prompt) received the un-rendered Jinja template. Agents whose instructions lived in `system_prompt` therefore sent literal `{{ ... }}` placeholders to the model, which would correctly respond with "the prompt template contains unfilled variables" and refuse the task.

Fix by writing the rendered system_prompt back onto the agent via `model_copy` (mirroring how `model` is already rendered just above).

Also add a validator warning for agents that define `system_prompt` but no `prompt` -- this is a portability hazard (the Claude provider drops `system_prompt` entirely) and almost always indicates a missing `prompt:` block.

Tests:
* test_execute_renders_system_prompt_passed_to_provider asserts the agent the provider receives has no remaining `{{` / `{%` in system_prompt.
* test_warns_on_system_prompt_without_prompt asserts the new validator warning fires on the anti-pattern, and not when both fields are present.