### PR TITLE
fix(ci): exclude performance tests from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,10 @@ jobs:
         run: uv sync --group dev
 
       - name: Run tests
-        run: uv run pytest -m "not real_api"
+        # Exclude performance tests: they assert wall-clock thresholds (e.g.
+        # config load <100ms) that flake on shared GitHub Actions runners.
+        # ci.yml uses the same filter — see its inline comment for rationale.
+        run: uv run pytest -m "not real_api and not performance"
         env:
           ANTHROPIC_API_KEY: "sk-ant-test-fake-key-for-mocking"
 


### PR DESCRIPTION
The release workflow ran `pytest -m "not real_api"`, which still picked up `tests/test_performance.py` (entire module is marked `pytestmark = pytest.mark.performance`). These tests assert wall-clock thresholds — most notably `test_config_load_time` at **<100ms** — that routinely flake on shared GitHub Actions runners. Observed on the v0.1.15 release run [25826854283](https://github.com/microsoft/conductor/actions/runs/25826854283):

| Attempt | Measured | Threshold |
|---|---|---|
| 1 | 0.127s | 0.100s |
| 2 (rerun) | 0.145s | 0.100s |

`ci.yml:115` already excludes them via `-m "not real_api and not performance"` with an inline comment spelling out exactly this concern. This PR brings `release.yml` into parity.

### Diff

```diff
- run: uv run pytest -m "not real_api"
+ run: uv run pytest -m "not real_api and not performance"
```

### Follow-up

After merge: delete the `v0.1.15` tag and re-tag the new main HEAD so the release workflow re-runs against the fixed config.