### PR TITLE
fix(copilot): tolerate SDK metadata parsing errors when listing models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.16...HEAD)
 
+### Fixed
+- Workflows that configure `reasoning.effort` (or workflow-wide
+  `runtime.default_reasoning_effort`) on the Copilot provider were broken
+  for **every named Copilot model** when running against
+  `github-copilot-sdk` 0.3.0. The SDK's `models.list` response includes a
+  `billing` object on every model, but none of them currently ship the
+  `multiplier` field that the SDK's `ModelBilling.from_dict` parser
+  treats as required — so every model in the response triggers
+  `ValueError("Missing required field 'multiplier' in ModelBilling")`,
+  which kills the entire `list_models()` call. The error then leaked
+  through the narrow `except` tuple in
+  `_validate_reasoning_effort_for_model` (and `get_max_prompt_tokens`),
+  poisoned the retry loop, and surfaced as `Dialog turn failed: …` after
+  three wasted attempts. (`get_max_prompt_tokens` was rescued by the
+  engine's outer `except Exception`, so context-window metadata was
+  silently unavailable rather than fatal.)
+  Both metadata methods now catch any `Exception` raised at the SDK
+  boundary and treat the failure as "metadata unavailable" — validation
+  is skipped permissively and the configured `reasoning_effort` is
+  forwarded to `create_session` as before.
+  `asyncio.CancelledError`/`KeyboardInterrupt`/`SystemExit` (all
+  `BaseException` subclasses) still propagate.
+
 ## [0.1.16](https://github.com/microsoft/conductor/compare/v0.1.15...v0.1.16) - 2026-05-14
 
 ### Added

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -1935,13 +1935,22 @@ class CopilotProvider(AgentProvider):
         Returns ``None`` in mock-handler mode, when the SDK is unavailable,
         when no match is found, or when the SDK call fails — context-window
         metadata must never block workflow execution.
+
+        Catches ``Exception`` (not ``BaseException``) at the SDK boundary so
+        ``asyncio.CancelledError``/``KeyboardInterrupt``/``SystemExit`` still
+        propagate. The broad catch is required because Copilot SDK >=0.3.0
+        eagerly parses every entry in the ``models.list`` response with
+        dataclass ``from_dict`` helpers that raise ``ValueError`` on any
+        missing required field — e.g. ``ModelBilling`` requires ``multiplier``,
+        and certain models (such as ``claude-opus-4.7-1m-internal``) ship a
+        ``billing`` object without one, which kills the entire listing.
         """
         if self._mock_handler is not None or not COPILOT_SDK_AVAILABLE:
             return None
         try:
             await self._ensure_client_started()
             models = await self._client.list_models()
-        except (TimeoutError, ProviderError, OSError, RuntimeError) as e:
+        except Exception as e:
             logger.debug("Failed to list Copilot models for %r: %s", model, e)
             return None
         by_id = {info.id: info for info in models}
@@ -1967,6 +1976,15 @@ class CopilotProvider(AgentProvider):
         — capability metadata must never block a workflow that the SDK might
         otherwise accept.
 
+        Catches ``Exception`` (not ``BaseException``) at the SDK boundary so
+        ``asyncio.CancelledError``/``KeyboardInterrupt``/``SystemExit`` still
+        propagate. The broad catch is required because Copilot SDK >=0.3.0
+        eagerly parses every entry in the ``models.list`` response with
+        dataclass ``from_dict`` helpers that raise ``ValueError`` on any
+        missing required field — e.g. ``ModelBilling`` requires ``multiplier``,
+        and certain models (such as ``claude-opus-4.7-1m-internal``) ship a
+        ``billing`` object without one, which kills the entire listing.
+
         Skipped entirely in mock-handler mode and when the SDK is not
         installed.
         """
@@ -1975,7 +1993,7 @@ class CopilotProvider(AgentProvider):
         try:
             await self._ensure_client_started()
             models = await self._client.list_models()
-        except (TimeoutError, ProviderError, OSError, RuntimeError) as e:
+        except Exception as e:
             logger.debug(
                 "Failed to list Copilot models for reasoning_effort validation of %r: %s",
                 model,

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -916,16 +916,23 @@ class TestGetMaxPromptTokens:
         assert await provider.get_max_prompt_tokens("gpt-4o") == 128000
 
     @pytest.mark.asyncio
-    async def test_unexpected_exception_propagates(self) -> None:
-        """Non-SDK exceptions (programming errors) are not swallowed by the
-        provider — they bubble up so the engine's outer safety net handles them."""
+    async def test_value_error_from_sdk_parser_returns_none(self) -> None:
+        """SDK schema-parsing failures (e.g. ``ValueError`` from
+        ``ModelBilling.from_dict`` when the API omits the ``multiplier``
+        field) must be soft-swallowed — context-window metadata must
+        never block workflow execution.
+
+        Regression for github-copilot-sdk 0.3.0, where ``list_models()``
+        eagerly parses every model and a single malformed entry (observed
+        for ``claude-opus-4.7-1m-internal``) raises ``ValueError`` and
+        kills the whole call.
+        """
 
         async def list_models() -> list[Any]:
-            raise ValueError("bug")
+            raise ValueError("Missing required field 'multiplier' in ModelBilling")
 
         provider = self._provider_with_list_models(list_models)
-        with pytest.raises(ValueError):
-            await provider.get_max_prompt_tokens("gpt-4o")
+        assert await provider.get_max_prompt_tokens("gpt-4o") is None
 
     @pytest.mark.asyncio
     async def test_alias_resolves_via_match_model_id(self) -> None:
@@ -1100,6 +1107,37 @@ class TestReasoningEffort:
         agent = AgentDef(
             name="planner",
             model="gpt-4o",
+            prompt="Plan",
+            reasoning=ReasoningConfig(effort="xhigh"),
+        )
+        await provider.execute(agent=agent, context={}, rendered_prompt="Plan")
+        assert captured["create_session_kwargs"]["reasoning_effort"] == "xhigh"
+
+    @pytest.mark.asyncio
+    async def test_value_error_from_sdk_parser_skips_validation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SDK schema-parsing failures during ``list_models()`` must not block
+        execution — validation is skipped permissively and the configured
+        ``reasoning_effort`` is still forwarded to ``create_session``.
+
+        Regression for github-copilot-sdk 0.3.0: ``ModelBilling.from_dict``
+        raises ``ValueError("Missing required field 'multiplier' in
+        ModelBilling")`` for models like ``claude-opus-4.7-1m-internal``,
+        which previously leaked through the narrow except tuple in
+        ``_validate_reasoning_effort_for_model`` and surfaced as a
+        ``Dialog turn failed: …`` error after exhausting the retry loop.
+        """
+        from conductor.config.schema import ReasoningConfig
+
+        async def list_models() -> list[Any]:
+            raise ValueError("Missing required field 'multiplier' in ModelBilling")
+
+        captured: dict[str, Any] = {}
+        provider = await self._build_provider(captured, monkeypatch, list_models_impl=list_models)
+        agent = AgentDef(
+            name="planner",
+            model="claude-opus-4.7-1m-internal",
             prompt="Plan",
             reasoning=ReasoningConfig(effort="xhigh"),
         )


### PR DESCRIPTION
## Summary

Workflows that configure `reasoning.effort` (or workflow-wide
`runtime.default_reasoning_effort`) on the Copilot provider were failing with:

```
Dialog turn failed: Missing required field 'multiplier' in ModelBilling
```

after exhausting the retry loop. **The bug affects every named Copilot model**
(see "Blast radius" below) — it just wasn't caught earlier because few
workflows exercise the reasoning-effort path on Copilot.

## Root cause

`github-copilot-sdk` 0.3.0 eagerly parses every entry in its
`models.list` response with dataclass `from_dict` helpers. The
`ModelBilling.from_dict` parser
([client.py:496-507](https://github.com/github/copilot-sdk/blob/main/copilot/client.py))
treats `multiplier` as required and raises
`ValueError("Missing required field 'multiplier' in ModelBilling")` if it's
absent — and **none of the currently-served models include it**. Because the
parsing is done in a list-comprehension, a single malformed entry kills the
whole `list_models()` call, and the SDK's response cache is only populated
after a successful parse, so every call from a fresh session fails the same way.

Both `_validate_reasoning_effort_for_model` (called before every
`create_session` when `reasoning.effort` is set) and `get_max_prompt_tokens`
caught only `(TimeoutError, ProviderError, OSError, RuntimeError)` at the
SDK boundary, so the `ValueError` leaked through. In the reasoning-effort
path it then poisoned the retry loop and surfaced as the user-visible
`Dialog turn failed: ...` error. (`get_max_prompt_tokens` was rescued by
the engine's outer `except Exception` at
[engine/workflow.py:1071](../tree/main/src/conductor/engine/workflow.py#L1071),
so context-window metadata was silently unavailable rather than fatal.)

## Blast radius

Inspected the live response on this machine — 18 of 19 returned models ship
a `billing` object without `multiplier`:

```
claude-sonnet-4.6, claude-sonnet-4.5, claude-haiku-4.5,
claude-opus-4.7, claude-opus-4.7-1m-internal, claude-opus-4.7-high,
claude-opus-4.7-xhigh, claude-opus-4.6, claude-opus-4.6-1m,
claude-opus-4.5, gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex,
gpt-5.2-codex, gpt-5.2, gpt-5-mini, gpt-4.1
```

The only "clean" entry is `auto`, which has `billing: None` so the parser
short-circuits.

## Fix

Broaden both catches to `Exception` (still excludes
`asyncio.CancelledError` / `KeyboardInterrupt` / `SystemExit`, all of
which are `BaseException` subclasses) and document the SDK schema-failure
case at both call sites. This matches the existing docstring contract:
*"capability metadata must never block a workflow that the SDK might
otherwise accept."*

The narrow tuple was written before anyone realized the SDK would raise
non-OSError exceptions in normal operation.

## Tests

- Replaced `test_unexpected_exception_propagates` (which asserted the
  *opposite* of the docstring contract) with
  `test_value_error_from_sdk_parser_returns_none`, using the exact
  upstream error message for clarity.
- Added `test_value_error_from_sdk_parser_skips_validation` covering the
  reasoning-effort path: confirms the workflow proceeds normally and
  that `reasoning_effort` is still forwarded to `create_session`.
- Full suite green: `2579 passed, 15 skipped, 29 deselected` in 7m36s.

## Note

This is an internal-model regression on the Copilot SDK side, not worth
filing upstream — the missing field is a temporary backend quirk and the
SDK will likely make `multiplier` optional in a future release. Our fix
hardens the code path regardless.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>