### PR TITLE
fix(registry): mirror repo layout in cache so cross-workflow refs resolve

### DIFF
--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -719,6 +719,14 @@ class WorkflowEngine:
            ``base_dir``, return that path immediately. This preserves
            backward-compatibility for bare names like ``analysis`` that refer
            to a sibling file without a ``.yaml`` extension.
+        1b. If the candidate path looks like a file (has separators or a
+            YAML extension) and the parent workflow lives inside a registry
+            cache, attempt to auto-fetch a sibling workflow from the same
+            registry+SHA via
+            :func:`~conductor.registry.cache.auto_fetch_relative_workflow`.
+            This handles cross-workflow refs like
+            ``../document-review/workflow.yaml`` between workflows in the
+            same registry repo.
         2. Otherwise, parse as a registry reference via
            :func:`~conductor.registry.resolver.resolve_ref`.
         3. If the parsed ref is still a file kind (e.g. a path with a
@@ -749,7 +757,10 @@ class WorkflowEngine:
             ExecutionError: If the registry reference is malformed, names an
                 unknown registry, or the registry fetch fails.
         """
-        from conductor.registry.cache import resolve_and_fetch
+        from conductor.registry.cache import (
+            auto_fetch_relative_workflow,
+            resolve_and_fetch,
+        )
         from conductor.registry.errors import RegistryError
         from conductor.registry.resolver import resolve_ref
 
@@ -759,6 +770,34 @@ class WorkflowEngine:
         candidate = (base_dir / agent_workflow).resolve()
         if candidate.is_file():
             return candidate
+
+        # Step 1b: when the parent workflow lives inside a registry SHA cache,
+        # try to auto-fetch a sibling workflow from the same registry. This
+        # covers cross-workflow refs like ``../document-review/workflow.yaml``
+        # that were broken by the per-workflow cache layout. Only attempts
+        # when the candidate looks like a file path (has separators or a
+        # YAML extension) AND is not a registry ref ('@' present indicates
+        # named or ad-hoc registry syntax; step 2 handles those).
+        looks_like_file = "@" not in agent_workflow and (
+            "/" in agent_workflow
+            or "\\" in agent_workflow
+            or candidate.suffix.lower() in {".yaml", ".yml"}
+        )
+        if looks_like_file:
+            try:
+                auto_fetched = await asyncio.to_thread(auto_fetch_relative_workflow, candidate)
+            except RegistryError as exc:
+                raise ExecutionError(
+                    f"Failed to auto-fetch sub-workflow '{agent_workflow}' "
+                    f"(referenced by agent '{agent_name}'): {exc}",
+                    suggestion=(
+                        "The parent workflow lives in a registry cache, but "
+                        "the sibling workflow could not be fetched. Check "
+                        "that the path matches an entry in the registry index."
+                    ),
+                ) from exc
+            if auto_fetched is not None and auto_fetched.is_file():
+                return auto_fetched
 
         # Step 2: parse as file-path / named-registry / ad-hoc reference.
         try:

--- a/src/conductor/registry/cache.py
+++ b/src/conductor/registry/cache.py
@@ -8,40 +8,71 @@ requirement for ``!file`` tag resolution and checkpoint identity.
 Path registries are read directly from the source directory (no caching)
 so that local edits are reflected immediately.
 
-Cache layout::
+Cache layout
+============
 
-    <base>/cache/registries/<registry>/<workflow>/<sha[:12]>/
+Workflows from the same registry+SHA share a per-SHA root that mirrors
+the source repository's directory structure. This lets workflows reference
+sibling workflows via repo-relative paths (e.g. ``../other/workflow.yaml``)
+just as they do at the source.
+
+::
+
+    <base>/<registry>/<sha[:12]>/<repo_path>            # mirrored repo files
+    <base>/<registry>/_meta/<sha[:12]>/source.json      # cache metadata
+    <base>/<registry>/_meta/<sha[:12]>/index.yaml       # cached registry index
+    <base>/<registry>/_meta/<sha[:12]>/<workflow>.complete  # readiness sentinel
 
 For ad-hoc references (``workflow@owner/repo#ref``) the registry namespace
 is ``_adhoc/<owner>/<repo>`` so adhoc caches are isolated from named
 registry caches and cannot collide with any user-configured registry name
 (named registries reject names containing ``/``)::
 
-    <base>/cache/registries/_adhoc/<owner>/<repo>/<workflow>/<sha[:12]>/
+    <base>/_adhoc/<owner>/<repo>/<sha[:12]>/<repo_path>
+    <base>/_adhoc/<owner>/<repo>/_meta/<sha[:12]>/...
+
+The ``_meta`` directory lives **outside** the SHA-rooted mirror so it can
+never collide with a real ``.conductor/`` (or any other) directory in the
+source repo.
+
+A workflow is considered "fully cached" only when its readiness sentinel
+file exists (written **last** during a fetch). This prevents readers from
+observing a partially populated workflow during a concurrent fetch.
 """
 
 from __future__ import annotations
 
+import contextlib
+import json
 import os
+import re
 import shutil
 import tempfile
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from conductor.registry.config import RegistryEntry, RegistryType
 from conductor.registry.errors import RegistryError
 from conductor.registry.github import fetch_file, list_directory, parse_github_source
-from conductor.registry.index import load_index
+from conductor.registry.index import RegistryIndex, load_index, parse_index_text
 from conductor.registry.version_resolver import materialize_to_sha, resolve_ref
 
 if TYPE_CHECKING:
     from conductor.registry.resolver import ResolvedRef
 
-# fetch_file returns bytes; list_directory returns filenames (not full paths)
-
-# Reserved cache namespace for ad-hoc references. Cannot collide with a
-# named registry because configured registry names cannot contain '/'.
+# Reserved cache namespaces. Cannot collide with named registries because
+# configured registry names are not allowed to contain '/' and these names
+# start with '_'.
 _ADHOC_NAMESPACE = "_adhoc"
+_META_NAMESPACE = "_meta"
+
+# Current on-disk cache layout version. Bumping this invalidates all existing
+# caches (their source.json will fail validation and the entries are re-fetched).
+CACHE_LAYOUT_VERSION = 2
+
+_SHA_DIR_RE = re.compile(r"^[0-9a-f]{12}$")
+
 
 # ---------------------------------------------------------------------------
 # Path helpers
@@ -59,39 +90,283 @@ def get_cache_base() -> Path:
     return base / "cache" / "registries"
 
 
+def _registry_root(registry_name: str) -> Path:
+    """Return ``<base>/<registry_name>`` (joined per-segment for adhoc names)."""
+    base = get_cache_base()
+    # registry_name may contain '/' for adhoc (e.g. "_adhoc/owner/repo")
+    # which Path naturally splits into segments.
+    return base / registry_name
+
+
+def _sha_dir(registry_name: str, sha: str) -> Path:
+    """Return the per-SHA root for a registry."""
+    return _registry_root(registry_name) / sha[:12]
+
+
+def _meta_dir(registry_name: str, sha: str) -> Path:
+    """Return the per-SHA metadata directory."""
+    return _registry_root(registry_name) / _META_NAMESPACE / sha[:12]
+
+
+def _sentinel_path(registry_name: str, sha: str, workflow_name: str) -> Path:
+    """Return the readiness sentinel for a single workflow within a SHA dir."""
+    # workflow_name is a registry index key; sanitize for filesystem use.
+    safe = workflow_name.replace("/", "_").replace("\\", "_")
+    return _meta_dir(registry_name, sha) / f"{safe}.complete"
+
+
+def _safe_repo_path(repo_path: str) -> PurePosixPath:
+    """Validate a repo-relative path and return it as a normalized PurePosixPath.
+
+    Rejects:
+    - empty paths
+    - absolute paths (POSIX or Windows-style with drive)
+    - paths containing ``..`` segments
+    - paths containing NUL bytes
+
+    Returns a :class:`PurePosixPath` suitable for joining with a local cache
+    root via ``Path / posix_path``.
+
+    Raises:
+        RegistryError: If *repo_path* is unsafe.
+    """
+    if not repo_path or repo_path in (".", "./"):
+        raise RegistryError(
+            "Workflow path is empty",
+            suggestion="Set 'path' to a non-empty repo-relative file path in the index.",
+        )
+    if "\x00" in repo_path:
+        raise RegistryError(
+            f"Workflow path contains a NUL byte: {repo_path!r}",
+            suggestion="Remove invalid characters from the index path.",
+        )
+    # Reject Windows drive letters and UNC anchors, plus POSIX-absolute paths.
+    if repo_path.startswith(("/", "\\")) or (
+        len(repo_path) >= 2 and repo_path[1] == ":" and repo_path[0].isalpha()
+    ):
+        raise RegistryError(
+            f"Workflow path must be repo-relative, got absolute path: {repo_path!r}",
+            suggestion="Use a path like 'workflows/foo.yaml' relative to the registry root.",
+        )
+
+    # Normalize separators and split.
+    posix = PurePosixPath(repo_path.replace("\\", "/"))
+    parts = posix.parts
+    for part in parts:
+        if part in ("..", ""):
+            raise RegistryError(
+                f"Workflow path must not contain '..' segments: {repo_path!r}",
+                suggestion="Use a path that stays within the registry root.",
+            )
+    return posix
+
+
+def _resolve_within(root: Path, relative: PurePosixPath) -> Path:
+    """Join ``relative`` onto ``root`` and verify the result stays under ``root``.
+
+    Defense-in-depth on top of :func:`_safe_repo_path` — catches any escape via
+    symlinks or oddly-cased paths after disk resolution.
+    """
+    candidate = (root / relative).resolve()
+    root_resolved = root.resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as exc:
+        raise RegistryError(
+            f"Resolved cache path {candidate} escapes registry SHA root {root_resolved}",
+            suggestion="Check the workflow path in the registry index for unsafe components.",
+        ) from exc
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Source metadata + cached index
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SourceMetadata:
+    """Identity of a cache directory, persisted to source.json for validation."""
+
+    cache_layout_version: int
+    registry_type: str
+    source: str
+    full_sha: str
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "cache_layout_version": self.cache_layout_version,
+                "registry_type": self.registry_type,
+                "source": self.source,
+                "full_sha": self.full_sha,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+
+def _read_source_metadata(meta_dir: Path) -> _SourceMetadata | None:
+    """Read source.json from a meta dir, returning ``None`` if missing/invalid."""
+    path = meta_dir / "source.json"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    try:
+        return _SourceMetadata(
+            cache_layout_version=int(data["cache_layout_version"]),
+            registry_type=str(data["registry_type"]),
+            source=str(data["source"]),
+            full_sha=str(data["full_sha"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _write_source_metadata(meta_dir: Path, entry: RegistryEntry, full_sha: str) -> None:
+    """Atomically write source.json for the cache directory."""
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    metadata = _SourceMetadata(
+        cache_layout_version=CACHE_LAYOUT_VERSION,
+        registry_type=entry.type.value,
+        source=entry.source,
+        full_sha=full_sha,
+    )
+    target = meta_dir / "source.json"
+    _atomic_write_text(target, metadata.to_json())
+
+
+def _metadata_matches(meta: _SourceMetadata | None, entry: RegistryEntry, full_sha: str) -> bool:
+    """Return True if cached metadata matches the current registry+SHA."""
+    if meta is None:
+        return False
+    return (
+        meta.cache_layout_version == CACHE_LAYOUT_VERSION
+        and meta.registry_type == entry.type.value
+        and meta.source == entry.source
+        and meta.full_sha == full_sha
+    )
+
+
+def _load_cached_index(meta_dir: Path) -> RegistryIndex | None:
+    """Load the cached registry index from ``<meta_dir>/index.yaml``.
+
+    Returns ``None`` when the file is missing or unparseable. Callers fall
+    back to fetching the index from the upstream registry on ``None``.
+    """
+    path = meta_dir / "index.yaml"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    try:
+        return parse_index_text(text, "yaml", str(path))
+    except RegistryError:
+        return None
+
+
+def _save_cached_index(meta_dir: Path, raw_yaml_text: str) -> None:
+    """Atomically write the registry index to the meta dir."""
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(meta_dir / "index.yaml", raw_yaml_text)
+
+
+def _atomic_write_text(target: Path, text: str) -> None:
+    """Atomically write text to ``target`` via tempfile + ``os.replace``."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".tmp-{target.name}-",
+        dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp_name, target)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def _atomic_write_bytes(target: Path, data: bytes) -> None:
+    """Atomically write bytes to ``target`` via tempfile + ``os.replace``."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".tmp-{target.name}-",
+        dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp_name, target)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Cache hit detection
+# ---------------------------------------------------------------------------
+
+
 def get_cached_workflow_path(
     registry_name: str,
     workflow_name: str,
     sha: str,
+    *,
+    workflow_repo_path: str | None = None,
 ) -> Path | None:
-    """Return the cached workflow YAML path if it exists, else ``None``.
+    """Return the cached workflow YAML path if fully cached, else ``None``.
 
-    Looks for the workflow at::
+    A workflow is considered fully cached when:
 
-        <cache_base>/<registry_name>/<workflow_name>/<sha[:12]>/
+    1. The per-workflow readiness sentinel
+       (``_meta/<sha>/<workflow_name>.complete``) exists.
+    2. The workflow file itself exists at the expected mirrored path.
 
-    The filename is derived from a glob of ``*.yaml`` / ``*.yml`` files in the
-    SHA directory.  Returns the first YAML file found (there should be
-    exactly one workflow file per cached SHA directory).
+    When ``workflow_repo_path`` is omitted, this falls back to looking up the
+    path in the cached registry index (``_meta/<sha>/index.yaml``). If
+    neither is available, returns ``None``.
 
     Args:
         registry_name: Name of the registry.
-        workflow_name: Name of the workflow.
-        sha: Full immutable commit SHA. The first 12 chars are used as the
-            on-disk directory name.
+        workflow_name: Workflow key as listed in the registry index.
+        sha: Full immutable commit SHA. Only the first 12 chars are used as
+            the on-disk directory name.
+        workflow_repo_path: Optional repo-relative path of the workflow
+            (e.g. ``"sdd-plan/plan.yaml"``). When omitted, the cached index
+            is consulted.
 
     Returns:
         ``Path`` to the cached workflow YAML, or ``None`` when not cached.
     """
-    sha_dir = get_cache_base() / registry_name / workflow_name / sha[:12]
-    if not sha_dir.is_dir():
+    sentinel = _sentinel_path(registry_name, sha, workflow_name)
+    if not sentinel.is_file():
         return None
 
-    for ext in ("*.yaml", "*.yml"):
-        matches = list(sha_dir.glob(ext))
-        if matches:
-            return matches[0]
-    return None
+    repo_path = workflow_repo_path
+    if repo_path is None:
+        meta = _meta_dir(registry_name, sha)
+        index = _load_cached_index(meta)
+        if index is None or workflow_name not in index.workflows:
+            return None
+        repo_path = index.workflows[workflow_name].path
+
+    try:
+        safe = _safe_repo_path(repo_path)
+    except RegistryError:
+        return None
+
+    workflow_path = _sha_dir(registry_name, sha) / safe
+    if not workflow_path.is_file():
+        return None
+    return workflow_path
 
 
 # ---------------------------------------------------------------------------
@@ -113,20 +388,21 @@ def fetch_workflow(
 
     For **github** registries:
 
-    1. Resolve ``ref`` (or "latest") to a concrete git ref name.
-    2. Materialize that ref to an immutable commit SHA.
-    3. Return the cached workflow path if already present.
-    4. Otherwise, load the registry index **at that SHA** (so the index and
-       workflow file are guaranteed to come from the same commit), look up
-       the workflow path, fetch the workflow + sibling files into a temp
-       directory, and atomically rename it into the cache.
+    1. Resolve ``ref`` (or "latest") to a concrete git ref name and
+       materialize to an immutable commit SHA.
+    2. If the source metadata already matches and the per-workflow sentinel
+       is present, return the cached path.
+    3. Otherwise, load the index pinned to the SHA (preferring the cached
+       copy under ``_meta/<sha>/index.yaml``), fetch the workflow + sibling
+       files into a staging dir, atomically promote each file into the
+       shared SHA root, and finally write the readiness sentinel.
 
     Args:
         registry_name: Configured registry name.
         registry_entry: The registry definition (type + source).
         workflow_name: Workflow key as listed in the registry index.
         ref: Explicit git ref (tag, branch, or SHA), or ``None`` for the
-            registry's default (latest tag, falling back to default branch).
+            registry's default (default branch HEAD).
 
     Returns:
         Path to the cached workflow YAML file.
@@ -150,7 +426,10 @@ def fetch_workflow(
                 ),
             )
         workflow_info = index.workflows[workflow_name]
-        source_path = Path(registry_entry.source) / workflow_info.path
+        # Validate the path before joining, even for path registries — keeps
+        # the safety contract uniform regardless of backend.
+        safe = _safe_repo_path(workflow_info.path)
+        source_path = Path(registry_entry.source) / safe
         if not source_path.exists():
             raise RegistryError(
                 f"Workflow file not found at '{source_path}'",
@@ -159,16 +438,35 @@ def fetch_workflow(
             )
         return source_path
 
-    # GitHub registry: resolve ref → SHA, then check cache.
+    # GitHub registry: resolve ref → SHA, then attempt cache hit.
     resolved_ref = resolve_ref(registry_entry, ref)
     sha = materialize_to_sha(registry_entry, resolved_ref)
 
-    cached = get_cached_workflow_path(registry_name, workflow_name, sha)
-    if cached is not None:
-        return cached
+    meta = _meta_dir(registry_name, sha)
+    metadata = _read_source_metadata(meta)
+    matches = _metadata_matches(metadata, registry_entry, sha)
 
-    # Load the index pinned to the SHA so the workflow path comes from the
-    # exact commit we're about to fetch.
+    # Try the cache first: requires matching metadata, sentinel present, and
+    # the workflow file present at its mirrored path.
+    if matches:
+        index = _load_cached_index(meta)
+        if index is not None and workflow_name in index.workflows:
+            cached = get_cached_workflow_path(
+                registry_name,
+                workflow_name,
+                sha,
+                workflow_repo_path=index.workflows[workflow_name].path,
+            )
+            if cached is not None:
+                return cached
+    else:
+        # Stale or missing metadata — clear the meta dir to avoid serving an
+        # inconsistent index/source on a subsequent miss. Don't touch the SHA
+        # mirror itself; new fetches will overwrite content-addressed files.
+        if metadata is not None:
+            shutil.rmtree(meta, ignore_errors=True)
+
+    # Fetch the index from the upstream registry (pinned to SHA) and persist it.
     index = load_index(registry_entry, ref=sha)
     if workflow_name not in index.workflows:
         raise RegistryError(
@@ -176,38 +474,37 @@ def fetch_workflow(
             suggestion=f"Run 'conductor registry list {registry_name}' to see available workflows.",
         )
     workflow_info = index.workflows[workflow_name]
+    safe_path = _safe_repo_path(workflow_info.path)
 
-    # Atomically write to cache: fetch into a tmp dir under the workflow
-    # parent (so the rename is intra-filesystem), then os.replace().
-    parent = get_cache_base() / registry_name / workflow_name
-    parent.mkdir(parents=True, exist_ok=True)
-    final_dir = parent / sha[:12]
+    sha_root = _sha_dir(registry_name, sha)
+    sha_root.mkdir(parents=True, exist_ok=True)
 
-    tmp_dir = Path(tempfile.mkdtemp(prefix=".tmp-", dir=parent))
+    # Stage everything in a temp dir under the meta dir (intra-filesystem, so
+    # per-file os.replace into sha_root is atomic).
+    meta.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp(prefix=f".tmp-{workflow_name}-", dir=meta))
     try:
-        _fetch_github(registry_entry, workflow_info.path, sha, tmp_dir)
-        try:
-            os.replace(tmp_dir, final_dir)
-        except OSError:
-            # Likely a race: another process populated final_dir first. If it
-            # exists, drop our tmp work and use the cached entry. Otherwise
-            # re-raise.
-            if final_dir.exists():
-                shutil.rmtree(tmp_dir, ignore_errors=True)
-            else:
-                raise
-    except Exception:
+        _fetch_github(registry_entry, str(safe_path), sha, tmp_dir)
+        _promote_staged_files(tmp_dir, sha_root)
+    finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
-        raise
 
-    workflow_filename = Path(workflow_info.path).name
-    result = final_dir / workflow_filename
-    if not result.exists():
+    # Persist metadata + cached index, then write the readiness sentinel
+    # **last** so concurrent readers never observe a partial fetch.
+    _write_source_metadata(meta, registry_entry, sha)
+    _save_cached_index(meta, _index_to_yaml(index))
+
+    workflow_path = _resolve_within(sha_root, safe_path)
+    if not workflow_path.is_file():
         raise RegistryError(
-            f"Workflow file '{workflow_filename}' not found in cache after fetch",
+            f"Workflow file '{safe_path}' not found in cache after fetch",
             suggestion="The registry index may reference a file that does not exist.",
         )
-    return result
+
+    sentinel = _sentinel_path(registry_name, sha, workflow_name)
+    _atomic_write_text(sentinel, "")
+
+    return workflow_path
 
 
 def fetch_workflow_adhoc(
@@ -311,7 +608,146 @@ def resolve_and_fetch(resolved: ResolvedRef) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# GitHub fetch
+# Auto-fetch sub-workflows from the same registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CacheLocation:
+    """Identity of a path inside the registry cache."""
+
+    registry_name: str
+    sha: str
+    sha_root: Path
+
+
+def find_registry_cache_location(path: Path) -> _CacheLocation | None:
+    """Detect whether ``path`` lives inside a registry SHA-mirrored cache.
+
+    Recognizes both named-registry and ad-hoc layouts and returns the
+    parsed registry name, 12-char SHA prefix, and the SHA root. Returns
+    ``None`` when ``path`` does not match either layout (or when the SHA
+    segment is not a 12-char hex string).
+    """
+    base = get_cache_base()
+    try:
+        rel = path.resolve().relative_to(base.resolve())
+    except (FileNotFoundError, ValueError):
+        return None
+
+    parts = rel.parts
+    if not parts:
+        return None
+
+    # Adhoc: _adhoc/<owner>/<repo>/<sha>/...
+    if parts[0] == _ADHOC_NAMESPACE:
+        if len(parts) < 4:
+            return None
+        owner, repo, sha = parts[1], parts[2], parts[3]
+        if not _SHA_DIR_RE.match(sha):
+            return None
+        registry_name = f"{_ADHOC_NAMESPACE}/{owner}/{repo}"
+        sha_root = base / _ADHOC_NAMESPACE / owner / repo / sha
+        return _CacheLocation(registry_name=registry_name, sha=sha, sha_root=sha_root)
+
+    # Named: <registry>/<sha>/...
+    if len(parts) < 2:
+        return None
+    registry_name, sha = parts[0], parts[1]
+    # The reserved "_meta" subdirectory is not a SHA root — skip it.
+    if registry_name == _META_NAMESPACE or sha == _META_NAMESPACE:
+        return None
+    if not _SHA_DIR_RE.match(sha):
+        return None
+    sha_root = base / registry_name / sha
+    return _CacheLocation(registry_name=registry_name, sha=sha, sha_root=sha_root)
+
+
+def auto_fetch_relative_workflow(absolute_path: Path) -> Path | None:
+    """Try to populate the cache for a missing workflow file resolved by
+    relative path against another cached workflow.
+
+    Used by :class:`~conductor.engine.workflow.WorkflowEngine` when a
+    sub-workflow reference like ``../document-review/workflow.yaml``
+    resolves to a path that does not exist on disk. If the referenced file
+    sits inside the same registry+SHA cache as the parent workflow and is
+    listed in that registry's cached index, fetch it.
+
+    Returns ``absolute_path`` (now populated) on success, or ``None`` when
+    the path is outside any registry cache, the index has no workflow at
+    that repo-relative path, or the cached metadata is missing/stale.
+
+    Failures during fetch propagate as :class:`RegistryError` so callers
+    can produce a clear error message.
+    """
+    location = find_registry_cache_location(absolute_path)
+    if location is None:
+        return None
+
+    # Compute the repo-relative path of the requested workflow.
+    try:
+        rel_in_repo = PurePosixPath(
+            absolute_path.resolve().relative_to(location.sha_root.resolve()).as_posix()
+        )
+    except ValueError:
+        return None
+
+    meta = _meta_dir(location.registry_name, location.sha)
+    metadata = _read_source_metadata(meta)
+    if metadata is None:
+        return None
+
+    # Validate the cached metadata before trusting it for re-fetch:
+    # - layout version must match (avoids using older/newer cache shapes)
+    # - registry type must be github (path registries don't share this cache)
+    # - the SHA in metadata must agree with the on-disk SHA dir name
+    # - the source must look like a valid github source
+    if metadata.cache_layout_version != CACHE_LAYOUT_VERSION:
+        return None
+    if metadata.registry_type != RegistryType.github.value:
+        return None
+    if not metadata.full_sha.startswith(location.sha):
+        return None
+    try:
+        parse_github_source(metadata.source)
+    except RegistryError:
+        return None
+
+    index = _load_cached_index(meta)
+    if index is None:
+        return None
+
+    # Find a workflow whose path matches the requested repo-relative path.
+    matching_name: str | None = None
+    for name, info in index.workflows.items():
+        try:
+            info_rel = _safe_repo_path(info.path)
+        except RegistryError:
+            continue
+        if info_rel == rel_in_repo:
+            matching_name = name
+            break
+
+    if matching_name is None:
+        return None
+
+    # Reconstruct the registry entry from the cached metadata.
+    try:
+        entry = RegistryEntry(type=RegistryType(metadata.registry_type), source=metadata.source)
+    except (ValueError, RegistryError):
+        return None
+
+    fetched = fetch_workflow(
+        registry_name=location.registry_name,
+        registry_entry=entry,
+        workflow_name=matching_name,
+        ref=metadata.full_sha,
+    )
+    return fetched
+
+
+# ---------------------------------------------------------------------------
+# GitHub fetch + staging
 # ---------------------------------------------------------------------------
 
 
@@ -321,40 +757,97 @@ def _fetch_github(
     sha: str,
     dest_dir: Path,
 ) -> None:
-    """Fetch a workflow and its sibling files from a GitHub registry.
+    """Fetch a workflow and its sibling files from a GitHub registry into a staging dir.
+
+    Files are written into ``dest_dir`` preserving the workflow's repo
+    parent directory. For example, fetching ``sdd-plan/plan.yaml`` writes::
+
+        <dest_dir>/sdd-plan/plan.yaml
+        <dest_dir>/sdd-plan/<sibling files>
 
     Args:
         registry_entry: Registry entry with ``source`` as ``owner/repo``.
-        workflow_path: Relative path to the workflow YAML in the repo.
+        workflow_path: Validated repo-relative path to the workflow YAML.
         sha: Immutable commit SHA to fetch at.
-        dest_dir: Local directory to write files into.
+        dest_dir: Local staging directory to write files into.
     """
     owner, repo = parse_github_source(registry_entry.source)
-    workflow_p = Path(workflow_path)
-    parent_dir = str(workflow_p.parent)
+    workflow_p = PurePosixPath(workflow_path)
+    parent_dir = workflow_p.parent  # PurePosixPath('.') for repo-root workflows
     workflow_filename = workflow_p.name
 
     # Fetch the workflow file itself (returns bytes)
     content = fetch_file(owner, repo, workflow_path, ref=sha)
-    (dest_dir / workflow_filename).write_bytes(content)
+    target_dir = dest_dir if str(parent_dir) == "." else dest_dir / parent_dir
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / workflow_filename).write_bytes(content)
 
     # Fetch sibling files — list_directory returns filenames (not full paths)
+    parent_dir_str = str(parent_dir) if str(parent_dir) != "." else "."
     try:
-        sibling_names = list_directory(owner, repo, parent_dir, ref=sha)
+        sibling_names = list_directory(owner, repo, parent_dir_str, ref=sha)
     except Exception:
-        # If listing fails, we already have the workflow file
         return
 
     for name in sibling_names:
         if name == workflow_filename:
             continue  # already fetched
-        sibling_repo_path = f"{parent_dir}/{name}" if parent_dir != "." else name
+        sibling_repo_path = f"{parent_dir_str}/{name}" if parent_dir_str != "." else name
+        # Best-effort: skip names with unsafe characters rather than fail
+        # the whole fetch over a single malformed sibling entry.
+        try:
+            _safe_repo_path(sibling_repo_path)
+        except RegistryError:
+            continue
         try:
             sibling_content = fetch_file(owner, repo, sibling_repo_path, ref=sha)
-            (dest_dir / name).write_bytes(sibling_content)
+            (target_dir / name).write_bytes(sibling_content)
         except Exception:
             # Best-effort for siblings — don't fail the whole fetch
             pass
+
+
+def _promote_staged_files(tmp_dir: Path, sha_root: Path) -> None:
+    """Move every file from ``tmp_dir`` into ``sha_root`` atomically.
+
+    Preserves the relative directory layout of ``tmp_dir``. Each file is
+    moved with ``os.replace()`` so concurrent readers see either the old or
+    the new file, never a half-written one. Files in ``sha_root`` are
+    content-addressed by the immutable SHA so overwriting an existing entry
+    with the same content is safe and idempotent.
+    """
+    for src in sorted(tmp_dir.rglob("*")):
+        if src.is_dir():
+            continue
+        rel = src.relative_to(tmp_dir)
+        # Defense-in-depth: re-validate that the staged path stays inside
+        # sha_root (catches any unexpected absolute component).
+        try:
+            _safe_repo_path(str(rel))
+        except RegistryError:
+            continue
+        dest = _resolve_within(sha_root, PurePosixPath(rel.as_posix()))
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(src, dest)
+
+
+def _index_to_yaml(index: RegistryIndex) -> str:
+    """Render a RegistryIndex back to YAML for persistence in the meta dir."""
+    from io import StringIO
+
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+    data = {
+        "workflows": {
+            name: {"description": info.description, "path": info.path}
+            for name, info in index.workflows.items()
+        }
+    }
+    buf = StringIO()
+    yaml.dump(data, buf)
+    return buf.getvalue()
 
 
 # ---------------------------------------------------------------------------
@@ -386,9 +879,10 @@ def prune_temp_dirs(registry_name: str | None = None) -> int:
     """Remove orphaned ``.tmp-*`` directories under the cache.
 
     The atomic write pattern in :func:`fetch_workflow` creates ``.tmp-XXXX``
-    directories alongside each workflow's SHA directory. If a process is
-    killed mid-write, these orphans never get cleaned up. This helper walks
-    the cache and removes any directory whose name starts with ``.tmp-``.
+    directories under each registry's ``_meta/<sha>/`` directory. If a
+    process is killed mid-write, these orphans never get cleaned up. This
+    helper walks the cache and removes any directory whose name starts with
+    ``.tmp-``.
 
     Args:
         registry_name: If provided, only that registry's cache is scanned.
@@ -410,13 +904,9 @@ def prune_temp_dirs(registry_name: str | None = None) -> int:
     for reg_root in registry_roots:
         if not reg_root.is_dir():
             continue
-        # Layout: <reg>/<workflow>/<sha-or-.tmp-*>/
-        for workflow_dir in reg_root.iterdir():
-            if not workflow_dir.is_dir():
-                continue
-            for child in workflow_dir.iterdir():
-                if child.is_dir() and child.name.startswith(".tmp-"):
-                    shutil.rmtree(child, ignore_errors=True)
-                    if not child.exists():
-                        removed += 1
+        for tmp in reg_root.rglob(".tmp-*"):
+            if tmp.is_dir():
+                shutil.rmtree(tmp, ignore_errors=True)
+                if not tmp.exists():
+                    removed += 1
     return removed

--- a/src/conductor/registry/config.py
+++ b/src/conductor/registry/config.py
@@ -190,6 +190,8 @@ def add_registry(
     """
     config = load_config()
 
+    _validate_registry_name(name)
+
     if name in config.registries:
         raise RegistryError(
             f"Registry '{name}' already exists",
@@ -204,6 +206,46 @@ def add_registry(
 
     save_config(config)
     return config
+
+
+# Names reserved for cache namespaces — see ``registry/cache.py``. Using
+# these as named-registry names would collide with internal cache
+# directories and break adhoc/auto-fetch detection.
+_RESERVED_REGISTRY_NAMES = frozenset({"_adhoc", "_meta"})
+
+
+def _validate_registry_name(name: str) -> None:
+    """Reject registry names that would conflict with cache namespaces.
+
+    Disallows:
+
+    * Empty names.
+    * Names containing path separators (``/`` or ``\\``) — these segment
+      the on-disk cache directory and could be mistaken for ad-hoc refs.
+    * The reserved names ``_adhoc`` and ``_meta`` used by the cache layer.
+
+    Raises:
+        RegistryError: If *name* is invalid.
+    """
+    if not name:
+        raise RegistryError(
+            "Registry name cannot be empty",
+            suggestion="Provide a non-empty name (e.g. 'team-a').",
+        )
+    if "/" in name or "\\" in name:
+        raise RegistryError(
+            f"Registry name '{name}' must not contain '/' or '\\'",
+            suggestion=(
+                "Use a simple identifier without path separators. "
+                "For ad-hoc references to a GitHub repo, use the "
+                "'workflow@owner/repo[#ref]' syntax in the workflow ref instead."
+            ),
+        )
+    if name in _RESERVED_REGISTRY_NAMES:
+        raise RegistryError(
+            f"Registry name '{name}' is reserved for internal use",
+            suggestion="Choose a different name.",
+        )
 
 
 def remove_registry(name: str) -> RegistriesConfig:

--- a/src/conductor/registry/index.py
+++ b/src/conductor/registry/index.py
@@ -216,27 +216,55 @@ def _load_github_index(source: str, ref: str | None) -> RegistryIndex:
 
 def _parse_github_response(text: str, filename: str, url: str) -> RegistryIndex:
     """Parse the content fetched from GitHub."""
-    if filename.endswith(".yaml"):
+    fmt = "yaml" if filename.endswith(".yaml") else "json"
+    return parse_index_text(text, fmt, url)
+
+
+def parse_index_text(text: str, fmt: str, source_label: str) -> RegistryIndex:
+    """Parse a registry index from in-memory text.
+
+    Used by the cache layer to load a registry index that was previously
+    persisted to disk (``_meta/<sha>/index.yaml``) without re-fetching from
+    the upstream registry.
+
+    Args:
+        text: The full text of the index file.
+        fmt: Either ``"yaml"`` or ``"json"``.
+        source_label: Human-readable identifier of the source for use in
+            error messages (e.g. a file path or URL).
+
+    Returns:
+        The parsed :class:`RegistryIndex`.
+
+    Raises:
+        RegistryError: If parsing fails or the document is not a mapping.
+    """
+    if fmt == "yaml":
         try:
             yaml = YAML(typ="safe")
             data = yaml.load(text)
         except YAMLError as exc:
             raise RegistryError(
-                f"Failed to parse index from {url}: {exc}",
-                suggestion="Check the YAML syntax in the remote index file.",
+                f"Failed to parse index from {source_label}: {exc}",
+                suggestion="Check the YAML syntax in the index file.",
             ) from exc
-    else:
+    elif fmt == "json":
         try:
             data = json.loads(text)
         except json.JSONDecodeError as exc:
             raise RegistryError(
-                f"Failed to parse index from {url}: {exc}",
-                suggestion="Check the JSON syntax in the remote index file.",
+                f"Failed to parse index from {source_label}: {exc}",
+                suggestion="Check the JSON syntax in the index file.",
             ) from exc
+    else:
+        raise RegistryError(
+            f"Unknown index format {fmt!r}",
+            suggestion="Pass 'yaml' or 'json' as the format.",
+        )
 
     if not isinstance(data, dict):
         raise RegistryError(
-            f"Malformed registry index from {url}: expected a mapping at the top level",
+            f"Malformed registry index from {source_label}: expected a mapping at the top level",
             suggestion="Check that the index file matches the expected schema.",
         )
-    return _parse_index_data(data, url)
+    return _parse_index_data(data, source_label)

--- a/tests/test_engine/test_subworkflow.py
+++ b/tests/test_engine/test_subworkflow.py
@@ -1984,3 +1984,149 @@ class TestRegistrySubWorkflowResolution:
             pytest.raises(ExecutionError, match="Failed to fetch sub-workflow"),
         ):
             await engine.run({})
+
+
+class TestCrossWorkflowRegistryRef:
+    """Cross-workflow relative refs between workflows in the same registry.
+
+    These exercise the auto-fetch hook in ``_resolve_subworkflow_path`` that
+    handles refs like ``../document-review/workflow.yaml`` from a parent
+    workflow that lives inside a registry SHA cache directory.
+    """
+
+    @pytest.mark.asyncio
+    async def test_relative_ref_to_sibling_workflow_in_registry_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reproduces the bug: parent at sdd-plan/plan.yaml refs ../document-review/workflow.yaml.
+
+        With the fixed cache layout, both workflows share a per-SHA root and
+        the relative path resolves correctly. The sub-workflow file is
+        auto-fetched on demand by ``auto_fetch_relative_workflow`` because
+        only the parent was previously cached.
+        """
+        import json
+        from unittest.mock import patch
+
+        from conductor.registry.cache import CACHE_LAYOUT_VERSION
+
+        # Point CONDUCTOR_HOME at a temp dir so the cache lives there.
+        home = tmp_path / "conductor_home"
+        home.mkdir()
+        monkeypatch.setenv("CONDUCTOR_HOME", str(home))
+
+        sha = "a" * 40
+        sha_dir = sha[:12]
+        cache_base = home / "cache" / "registries"
+        official_sha_root = cache_base / "official" / sha_dir
+
+        # Pre-cache the parent workflow (sdd-plan/plan.yaml) only.
+        parent_dir = official_sha_root / "sdd-plan"
+        parent_dir.mkdir(parents=True)
+        parent_path = parent_dir / "plan.yaml"
+        _write_yaml(
+            parent_path,
+            """\
+            workflow:
+              name: sdd-plan
+              entry_point: sub
+              runtime:
+                provider: copilot
+              limits:
+                max_iterations: 10
+            agents:
+              - name: sub
+                type: workflow
+                workflow: ../document-review/workflow.yaml
+                routes:
+                  - to: "$end"
+            output:
+              result: "{{ sub.output.verdict }}"
+            """,
+        )
+
+        # Pre-write source.json + cached index + sentinel for sdd-plan.
+        meta_dir = cache_base / "official" / "_meta" / sha_dir
+        meta_dir.mkdir(parents=True)
+        (meta_dir / "source.json").write_text(
+            json.dumps(
+                {
+                    "cache_layout_version": CACHE_LAYOUT_VERSION,
+                    "registry_type": "github",
+                    "source": "myorg/workflows",
+                    "full_sha": sha,
+                },
+                sort_keys=True,
+                indent=2,
+            )
+        )
+        (meta_dir / "index.yaml").write_text(
+            "workflows:\n"
+            "  sdd-plan:\n    description: ''\n    path: sdd-plan/plan.yaml\n"
+            "  document-review:\n    description: ''\n    path: document-review/workflow.yaml\n"
+        )
+        (meta_dir / "sdd-plan.complete").write_text("")
+
+        # Document-review YAML that the engine will auto-fetch.
+        sub_yaml = textwrap.dedent(
+            """\
+            workflow:
+              name: document-review
+              entry_point: reviewer
+              runtime:
+                provider: copilot
+              limits:
+                max_iterations: 10
+            agents:
+              - name: reviewer
+                type: agent
+                prompt: review the doc
+                routes:
+                  - to: "$end"
+            output:
+              verdict: "{{ reviewer.output.verdict }}"
+            """
+        )
+
+        from conductor.registry.index import RegistryIndex, WorkflowInfo
+
+        index_obj = RegistryIndex(
+            workflows={
+                "sdd-plan": WorkflowInfo(description="", path="sdd-plan/plan.yaml"),
+                "document-review": WorkflowInfo(
+                    description="", path="document-review/workflow.yaml"
+                ),
+            }
+        )
+
+        def fake_fetch_github(entry, workflow_path, sha_arg, dest_dir):
+            target = dest_dir / workflow_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(sub_yaml)
+
+        def mock_handler(agent, prompt, context):
+            return {"verdict": "approved"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+
+        # Load the parent workflow from the cached path and run it.
+        from conductor.config.loader import load_config
+
+        config = load_config(parent_path)
+
+        with (
+            patch("conductor.registry.cache.materialize_to_sha", return_value=sha),
+            patch("conductor.registry.cache.resolve_ref", return_value=sha),
+            patch("conductor.registry.cache.load_index", return_value=index_obj),
+            patch("conductor.registry.cache._fetch_github", side_effect=fake_fetch_github),
+        ):
+            engine = WorkflowEngine(config, provider, workflow_path=parent_path)
+            result = await engine.run({})
+
+        assert result.get("result") == "approved"
+
+        # Verify the sibling was actually auto-fetched into the shared SHA root.
+        sibling = official_sha_root / "document-review" / "workflow.yaml"
+        assert sibling.exists()
+        # And its sentinel was written.
+        assert (meta_dir / "document-review.complete").exists()

--- a/tests/test_registry/test_cache.py
+++ b/tests/test_registry/test_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import textwrap
 from pathlib import Path
 from unittest.mock import patch
@@ -9,14 +10,19 @@ from unittest.mock import patch
 import pytest
 
 from conductor.registry.cache import (
+    CACHE_LAYOUT_VERSION,
+    _safe_repo_path,
+    auto_fetch_relative_workflow,
     clear_cache,
     fetch_workflow,
+    find_registry_cache_location,
     get_cache_base,
     get_cached_workflow_path,
     prune_temp_dirs,
 )
 from conductor.registry.config import RegistryEntry, RegistryType
 from conductor.registry.errors import RegistryError
+from conductor.registry.index import RegistryIndex, WorkflowInfo
 
 # A canned 40-char hex SHA used throughout these tests.
 _FAKE_SHA = "a" * 40
@@ -67,25 +73,11 @@ def _create_path_registry(tmp_path: Path) -> Path:
     return registry_dir
 
 
-class _FakeWorkflowInfo:
-    """Minimal stand-in for WorkflowInfo returned by the index module."""
-
-    def __init__(self, *, description: str, path: str) -> None:
-        self.description = description
-        self.path = path
-
-
-class _FakeIndex:
-    """Minimal stand-in for RegistryIndex returned by load_index."""
-
-    def __init__(self, workflows: dict[str, _FakeWorkflowInfo]) -> None:
-        self.workflows = workflows
-
-
-def _make_index() -> _FakeIndex:
-    return _FakeIndex(
+def _make_index() -> RegistryIndex:
+    """Default index used in most GitHub-fetch tests."""
+    return RegistryIndex(
         workflows={
-            "qa-bot": _FakeWorkflowInfo(
+            "qa-bot": WorkflowInfo(
                 description="Simple Q&A",
                 path="workflows/qa-bot.yaml",
             ),
@@ -93,9 +85,74 @@ def _make_index() -> _FakeIndex:
     )
 
 
-def _write_workflow_file(dest_dir: Path) -> None:
-    """Helper: simulate _fetch_github writing the workflow file."""
-    (dest_dir / "qa-bot.yaml").write_bytes(b"name: qa-bot\nagents: []\n")
+def _write_workflow_into_staging(dest_dir: Path, repo_path: str = "workflows/qa-bot.yaml") -> None:
+    """Mimic _fetch_github writing a workflow file into a staging dir.
+
+    Preserves the workflow's repo parent directory inside ``dest_dir``.
+    """
+    target = dest_dir / repo_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"name: qa-bot\nagents: []\n")
+
+
+def _pre_populate_cache(
+    home: Path,
+    *,
+    registry_name: str,
+    workflow_name: str,
+    sha: str,
+    workflow_repo_path: str,
+    registry_source: str,
+    registry_type: str = "github",
+    workflow_content: bytes = b"name: qa-bot\n",
+) -> Path:
+    """Populate the cache for a workflow as if it had been fully fetched.
+
+    Writes the workflow file at the mirrored repo path, the source.json
+    metadata, the cached index, and the per-workflow readiness sentinel.
+
+    Returns the absolute path to the cached workflow file.
+    """
+    base = home / "cache" / "registries"
+
+    # Mirrored workflow file
+    sha_root = base / registry_name / sha[:12]
+    workflow_path = sha_root / workflow_repo_path
+    workflow_path.parent.mkdir(parents=True, exist_ok=True)
+    workflow_path.write_bytes(workflow_content)
+
+    # Metadata directory
+    meta_dir = base / registry_name / "_meta" / sha[:12]
+    meta_dir.mkdir(parents=True, exist_ok=True)
+
+    (meta_dir / "source.json").write_text(
+        json.dumps(
+            {
+                "cache_layout_version": CACHE_LAYOUT_VERSION,
+                "registry_type": registry_type,
+                "source": registry_source,
+                "full_sha": sha,
+            },
+            sort_keys=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    (meta_dir / "index.yaml").write_text(
+        textwrap.dedent(f"""\
+            workflows:
+              {workflow_name}:
+                description: ""
+                path: {workflow_repo_path}
+            """),
+        encoding="utf-8",
+    )
+
+    safe_name = workflow_name.replace("/", "_")
+    (meta_dir / f"{safe_name}.complete").write_text("", encoding="utf-8")
+
+    return workflow_path
 
 
 # ---------------------------------------------------------------------------
@@ -117,6 +174,51 @@ class TestGetCacheBase:
 
 
 # ---------------------------------------------------------------------------
+# _safe_repo_path
+# ---------------------------------------------------------------------------
+
+
+class TestSafeRepoPath:
+    @pytest.mark.parametrize(
+        "path",
+        ["workflows/foo.yaml", "foo.yaml", "a/b/c/d.yaml", "deep/nested/file.yml"],
+    )
+    def test_accepts_safe_paths(self, path: str) -> None:
+        result = _safe_repo_path(path)
+        assert str(result) == path
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "../escape.yaml",
+            "../../etc/passwd",
+            "ok/../escape.yaml",
+            "ok/../../escape.yaml",
+        ],
+    )
+    def test_rejects_dotdot(self, path: str) -> None:
+        with pytest.raises(RegistryError, match="must not contain '..'"):
+            _safe_repo_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/abs/path.yaml", "\\abs\\path.yaml", "C:/Win/path.yaml", "Z:\\Win\\path.yaml"],
+    )
+    def test_rejects_absolute(self, path: str) -> None:
+        with pytest.raises(RegistryError, match="absolute"):
+            _safe_repo_path(path)
+
+    @pytest.mark.parametrize("path", ["", ".", "./"])
+    def test_rejects_empty(self, path: str) -> None:
+        with pytest.raises(RegistryError, match="empty"):
+            _safe_repo_path(path)
+
+    def test_rejects_nul_byte(self) -> None:
+        with pytest.raises(RegistryError, match="NUL byte"):
+            _safe_repo_path("ok\x00/file.yaml")
+
+
+# ---------------------------------------------------------------------------
 # get_cached_workflow_path
 # ---------------------------------------------------------------------------
 
@@ -129,18 +231,57 @@ class TestGetCachedWorkflowPath:
         result = get_cached_workflow_path("myregistry", "qa-bot", _FAKE_SHA)
         assert result is None
 
-    def test_returns_path_when_cached(
+    def test_returns_path_when_fully_cached(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         home = _setup_conductor_home(tmp_path, monkeypatch)
-        sha_dir = home / "cache" / "registries" / "myregistry" / "qa-bot" / _SHA_DIR
-        sha_dir.mkdir(parents=True)
-        wf_file = sha_dir / "qa-bot.yaml"
-        wf_file.write_text("name: qa-bot\n", encoding="utf-8")
+        wf_path = _pre_populate_cache(
+            home,
+            registry_name="myregistry",
+            workflow_name="qa-bot",
+            sha=_FAKE_SHA,
+            workflow_repo_path="workflows/qa-bot.yaml",
+            registry_source="myorg/workflows",
+        )
 
         result = get_cached_workflow_path("myregistry", "qa-bot", _FAKE_SHA)
-        assert result is not None
-        assert result == wf_file
+        assert result == wf_path
+
+    def test_returns_none_without_sentinel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even with the workflow file present, no sentinel == cache miss."""
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        # Write the workflow file but skip the sentinel.
+        sha_root = home / "cache" / "registries" / "myregistry" / _SHA_DIR
+        wf_dir = sha_root / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "qa-bot.yaml").write_bytes(b"name: qa-bot\n")
+        # Index is also present, but no sentinel.
+        meta_dir = home / "cache" / "registries" / "myregistry" / "_meta" / _SHA_DIR
+        meta_dir.mkdir(parents=True)
+        (meta_dir / "index.yaml").write_text(
+            "workflows:\n  qa-bot:\n    description: ''\n    path: workflows/qa-bot.yaml\n"
+        )
+
+        result = get_cached_workflow_path("myregistry", "qa-bot", _FAKE_SHA)
+        assert result is None
+
+    def test_returns_none_when_sentinel_present_but_file_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the sentinel exists but the workflow YAML doesn't, treat as miss."""
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        meta_dir = home / "cache" / "registries" / "myregistry" / "_meta" / _SHA_DIR
+        meta_dir.mkdir(parents=True)
+        (meta_dir / "qa-bot.complete").write_text("")
+        (meta_dir / "index.yaml").write_text(
+            "workflows:\n  qa-bot:\n    description: ''\n    path: workflows/qa-bot.yaml\n"
+        )
+        # No workflow file under sha_root.
+
+        result = get_cached_workflow_path("myregistry", "qa-bot", _FAKE_SHA)
+        assert result is None
 
     def test_uses_first_12_chars_of_sha(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -148,23 +289,38 @@ class TestGetCachedWorkflowPath:
         """Cache directory name is sha[:12]; full SHA is accepted for lookup."""
         home = _setup_conductor_home(tmp_path, monkeypatch)
         sha = "0123456789abcdef" * 2 + "01234567"  # 40 chars
-        sha_dir = home / "cache" / "registries" / "myregistry" / "qa-bot" / sha[:12]
-        sha_dir.mkdir(parents=True)
-        (sha_dir / "qa-bot.yaml").write_text("name: qa-bot\n", encoding="utf-8")
+        wf_path = _pre_populate_cache(
+            home,
+            registry_name="myregistry",
+            workflow_name="qa-bot",
+            sha=sha,
+            workflow_repo_path="qa-bot.yaml",
+            registry_source="myorg/workflows",
+        )
 
         result = get_cached_workflow_path("myregistry", "qa-bot", sha)
-        assert result is not None
+        assert result == wf_path
         assert sha[:12] in str(result)
 
-    def test_returns_none_for_empty_dir(
+    def test_explicit_repo_path_skips_index_lookup(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Passing workflow_repo_path explicitly avoids loading the cached index."""
         home = _setup_conductor_home(tmp_path, monkeypatch)
-        sha_dir = home / "cache" / "registries" / "myregistry" / "qa-bot" / _SHA_DIR
-        sha_dir.mkdir(parents=True)
-        # directory exists but has no YAML files
-        result = get_cached_workflow_path("myregistry", "qa-bot", _FAKE_SHA)
-        assert result is None
+        meta_dir = home / "cache" / "registries" / "myregistry" / "_meta" / _SHA_DIR
+        meta_dir.mkdir(parents=True)
+        (meta_dir / "qa-bot.complete").write_text("")
+        # No index.yaml on disk — should still work because we pass the path.
+
+        sha_root = home / "cache" / "registries" / "myregistry" / _SHA_DIR
+        wf = sha_root / "custom" / "qa-bot.yaml"
+        wf.parent.mkdir(parents=True)
+        wf.write_bytes(b"x")
+
+        result = get_cached_workflow_path(
+            "myregistry", "qa-bot", _FAKE_SHA, workflow_repo_path="custom/qa-bot.yaml"
+        )
+        assert result == wf
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +395,7 @@ class TestFetchWorkflowPath:
         self, mock_load_index: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _setup_conductor_home(tmp_path, monkeypatch)
-        mock_load_index.return_value = _FakeIndex(workflows={})  # type: ignore[union-attr]
+        mock_load_index.return_value = RegistryIndex(workflows={})  # type: ignore[union-attr]
 
         entry = RegistryEntry(type=RegistryType.path, source=str(tmp_path))
         with pytest.raises(RegistryError, match="not found"):
@@ -258,6 +414,23 @@ class TestFetchWorkflowPath:
 
         with pytest.raises(RegistryError, match="not found"):
             fetch_workflow("local", entry, "qa-bot")
+
+    @patch("conductor.registry.cache.load_index")
+    def test_path_registry_rejects_unsafe_workflow_path(
+        self, mock_load_index: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An index with an unsafe path (e.g. ../escape.yaml) is rejected."""
+        _setup_conductor_home(tmp_path, monkeypatch)
+        bad_index = RegistryIndex(
+            workflows={
+                "evil": WorkflowInfo(description="", path="../escape.yaml"),
+            }
+        )
+        mock_load_index.return_value = bad_index  # type: ignore[union-attr]
+
+        entry = RegistryEntry(type=RegistryType.path, source=str(tmp_path))
+        with pytest.raises(RegistryError, match=r"\.\.|absolute"):
+            fetch_workflow("local", entry, "evil")
 
 
 # ---------------------------------------------------------------------------
@@ -279,13 +452,13 @@ class TestFetchWorkflowGitHub:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Happy path: ref → SHA → cache miss → fetch → file present."""
+        """Happy path: ref → SHA → cache miss → fetch → file present at mirrored path."""
         home = _setup_conductor_home(tmp_path, monkeypatch)
         mock_resolve_ref.return_value = "v1.0.0"  # type: ignore[union-attr]
         mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
         mock_load_index.return_value = _make_index()  # type: ignore[union-attr]
         mock_fetch_github.side_effect = (  # type: ignore[union-attr]
-            lambda entry, path, sha, dest_dir: _write_workflow_file(dest_dir)
+            lambda entry, path, sha, dest_dir: _write_workflow_into_staging(dest_dir, path)
         )
 
         entry = RegistryEntry(type=RegistryType.github, source="myorg/workflows")
@@ -293,12 +466,34 @@ class TestFetchWorkflowGitHub:
 
         assert result.exists()
         assert result.name == "qa-bot.yaml"
-        # Cache directory uses sha[:12]
-        assert _SHA_DIR in str(result)
-        expected_dir = home / "cache" / "registries" / "official" / "qa-bot" / _SHA_DIR
-        assert result.parent == expected_dir
+        # Mirrored repo path inside per-SHA root
+        expected = (
+            home / "cache" / "registries" / "official" / _SHA_DIR / "workflows" / "qa-bot.yaml"
+        )
+        assert result == expected
 
-        # load_index should be pinned to the SHA
+        # Sentinel was written
+        sentinel = (
+            home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR / "qa-bot.complete"
+        )
+        assert sentinel.is_file()
+
+        # Source metadata was written and matches
+        meta_path = home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR / "source.json"
+        assert meta_path.is_file()
+        meta = json.loads(meta_path.read_text())
+        assert meta["full_sha"] == _FAKE_SHA
+        assert meta["source"] == "myorg/workflows"
+        assert meta["registry_type"] == "github"
+        assert meta["cache_layout_version"] == CACHE_LAYOUT_VERSION
+
+        # Cached index was persisted
+        cached_index = (
+            home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR / "index.yaml"
+        )
+        assert cached_index.is_file()
+
+        # load_index pinned to the SHA
         mock_load_index.assert_called_once()  # type: ignore[union-attr]
         call_kwargs = mock_load_index.call_args.kwargs  # type: ignore[union-attr]
         assert call_kwargs.get("ref") == _FAKE_SHA
@@ -321,24 +516,70 @@ class TestFetchWorkflowGitHub:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When cache directory already exists for the SHA, skip the fetch."""
+        """When sentinel + file are present, skip the fetch and the index load."""
         home = _setup_conductor_home(tmp_path, monkeypatch)
         mock_resolve_ref.return_value = "v1.0.0"  # type: ignore[union-attr]
         mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
 
-        # Pre-populate the cache at the resolved SHA dir.
-        sha_dir = home / "cache" / "registries" / "official" / "qa-bot" / _SHA_DIR
-        sha_dir.mkdir(parents=True)
-        (sha_dir / "qa-bot.yaml").write_text("name: qa-bot\n", encoding="utf-8")
+        wf_path = _pre_populate_cache(
+            home,
+            registry_name="official",
+            workflow_name="qa-bot",
+            sha=_FAKE_SHA,
+            workflow_repo_path="workflows/qa-bot.yaml",
+            registry_source="myorg/workflows",
+        )
+
+        entry = RegistryEntry(type=RegistryType.github, source="myorg/workflows")
+        result = fetch_workflow("official", entry, "qa-bot", ref="v1.0.0")
+
+        assert result == wf_path
+        mock_fetch_github.assert_not_called()  # type: ignore[union-attr]
+        mock_load_index.assert_not_called()  # type: ignore[union-attr]
+
+    @patch("conductor.registry.cache._fetch_github")
+    @patch("conductor.registry.cache.load_index")
+    @patch("conductor.registry.cache.materialize_to_sha")
+    @patch("conductor.registry.cache.resolve_ref")
+    def test_stale_metadata_triggers_refetch(
+        self,
+        mock_resolve_ref: object,
+        mock_materialize: object,
+        mock_load_index: object,
+        mock_fetch_github: object,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If source.json doesn't match (e.g. wrong source), re-fetch and rewrite."""
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        mock_resolve_ref.return_value = "v1.0.0"  # type: ignore[union-attr]
+        mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
+        mock_load_index.return_value = _make_index()  # type: ignore[union-attr]
+        mock_fetch_github.side_effect = (  # type: ignore[union-attr]
+            lambda entry, path, sha, dest_dir: _write_workflow_into_staging(dest_dir, path)
+        )
+
+        # Pre-populate with a DIFFERENT registry source so metadata mismatch triggers re-fetch.
+        _pre_populate_cache(
+            home,
+            registry_name="official",
+            workflow_name="qa-bot",
+            sha=_FAKE_SHA,
+            workflow_repo_path="workflows/qa-bot.yaml",
+            registry_source="someone-else/workflows",  # Different source
+        )
 
         entry = RegistryEntry(type=RegistryType.github, source="myorg/workflows")
         result = fetch_workflow("official", entry, "qa-bot", ref="v1.0.0")
 
         assert result.exists()
-        assert result.parent == sha_dir
-        # Fetch and index load were not invoked — pure cache hit.
-        mock_fetch_github.assert_not_called()  # type: ignore[union-attr]
-        mock_load_index.assert_not_called()  # type: ignore[union-attr]
+        # Metadata was rewritten with the new source
+        meta_path = home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR / "source.json"
+        meta = json.loads(meta_path.read_text())
+        assert meta["source"] == "myorg/workflows"
+        # Fetch and index load were both invoked
+        mock_fetch_github.assert_called_once()  # type: ignore[union-attr]
+        mock_load_index.assert_called_once()  # type: ignore[union-attr]
 
     @patch("conductor.registry.cache._fetch_github")
     @patch("conductor.registry.cache.load_index")
@@ -353,7 +594,7 @@ class TestFetchWorkflowGitHub:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """If fetch fails mid-write, final dir is not created and tmp dir is cleaned up."""
+        """If fetch fails mid-write, the sentinel is not written and tmp dir is cleaned up."""
         home = _setup_conductor_home(tmp_path, monkeypatch)
         mock_resolve_ref.return_value = "v1.0.0"  # type: ignore[union-attr]
         mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
@@ -370,16 +611,17 @@ class TestFetchWorkflowGitHub:
         with pytest.raises(RuntimeError, match="network blew up"):
             fetch_workflow("official", entry, "qa-bot", ref="v1.0.0")
 
-        # Final dir was never created.
-        final_dir = home / "cache" / "registries" / "official" / "qa-bot" / _SHA_DIR
-        assert not final_dir.exists()
+        # Sentinel was NEVER written — cache hit must fail on retry.
+        sentinel = (
+            home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR / "qa-bot.complete"
+        )
+        assert not sentinel.exists()
 
-        # Workflow parent exists (mkdir runs before fetch) but contains no
-        # leftover .tmp-* directories.
-        parent = home / "cache" / "registries" / "official" / "qa-bot"
-        assert parent.exists()
-        leftovers = [p for p in parent.iterdir() if p.name.startswith(".tmp-")]
-        assert leftovers == []
+        # No leftover .tmp-* directories under the meta dir.
+        meta_root = home / "cache" / "registries" / "official" / "_meta"
+        if meta_root.exists():
+            leftovers = [p for p in meta_root.rglob(".tmp-*") if p.is_dir()]
+            assert leftovers == []
 
     @patch("conductor.registry.cache._fetch_github")
     @patch("conductor.registry.cache.load_index")
@@ -394,17 +636,17 @@ class TestFetchWorkflowGitHub:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Calling fetch twice with the same branch ref re-resolves the SHA each time.
+        """Two fetches with the same branch ref re-resolve the SHA each time.
 
         When the underlying branch advances between calls (materialize_to_sha
-        returns different SHAs), the second fetch must populate a *new* cache
-        dir rather than reuse the old one.
+        returns different SHAs), the second fetch must populate a *new* SHA
+        directory rather than reuse the old one.
         """
         home = _setup_conductor_home(tmp_path, monkeypatch)
         mock_resolve_ref.return_value = "main"  # type: ignore[union-attr]
         mock_load_index.return_value = _make_index()  # type: ignore[union-attr]
         mock_fetch_github.side_effect = (  # type: ignore[union-attr]
-            lambda entry, path, sha, dest_dir: _write_workflow_file(dest_dir)
+            lambda entry, path, sha, dest_dir: _write_workflow_into_staging(dest_dir, path)
         )
 
         # Branch advances between calls.
@@ -415,63 +657,19 @@ class TestFetchWorkflowGitHub:
         first = fetch_workflow("official", entry, "qa-bot", ref="main")
         second = fetch_workflow("official", entry, "qa-bot", ref="main")
 
-        # Each call resolved to a different SHA → different cache dirs.
+        # Each call resolved to a different SHA → different SHA dirs.
         assert first != second
         assert _SHA_DIR in str(first)
         assert _SHA_DIR2 in str(second)
 
-        first_dir = home / "cache" / "registries" / "official" / "qa-bot" / _SHA_DIR
-        second_dir = home / "cache" / "registries" / "official" / "qa-bot" / _SHA_DIR2
+        first_dir = home / "cache" / "registries" / "official" / _SHA_DIR
+        second_dir = home / "cache" / "registries" / "official" / _SHA_DIR2
         assert first_dir.exists()
         assert second_dir.exists()
 
         # Both fetches actually executed (no spurious cache reuse).
         assert mock_fetch_github.call_count == 2  # type: ignore[union-attr]
         assert mock_materialize.call_count == 2  # type: ignore[union-attr]
-
-    @patch("conductor.registry.cache._fetch_github")
-    @patch("conductor.registry.cache.load_index")
-    @patch("conductor.registry.cache.materialize_to_sha")
-    @patch("conductor.registry.cache.resolve_ref")
-    def test_race_on_rename_uses_existing_cache(
-        self,
-        mock_resolve_ref: object,
-        mock_materialize: object,
-        mock_load_index: object,
-        mock_fetch_github: object,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """If another process wins the race, our tmp dir is cleaned up and the
-        cached path is returned successfully."""
-        home = _setup_conductor_home(tmp_path, monkeypatch)
-        mock_resolve_ref.return_value = "v1.0.0"  # type: ignore[union-attr]
-        mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
-        mock_load_index.return_value = _make_index()  # type: ignore[union-attr]
-
-        parent = home / "cache" / "registries" / "official" / "qa-bot"
-        final_dir = parent / _SHA_DIR
-
-        def racing_fetch(entry: object, path: str, sha: str, dest_dir: Path) -> None:
-            # Write our own workflow file into the temp dir.
-            _write_workflow_file(dest_dir)
-            # Simulate another process creating the final dir before we rename.
-            final_dir.mkdir(parents=True, exist_ok=True)
-            (final_dir / "qa-bot.yaml").write_bytes(b"name: qa-bot\n# from racer\n")
-
-        mock_fetch_github.side_effect = racing_fetch  # type: ignore[union-attr]
-
-        entry = RegistryEntry(type=RegistryType.github, source="myorg/workflows")
-        result = fetch_workflow("official", entry, "qa-bot", ref="v1.0.0")
-
-        # The cached path (populated by the racer) is returned.
-        assert result.exists()
-        assert result.parent == final_dir
-        assert b"from racer" in result.read_bytes()
-
-        # Our temp dir was cleaned up — no .tmp-* residue.
-        leftovers = [p for p in parent.iterdir() if p.name.startswith(".tmp-")]
-        assert leftovers == []
 
     @patch("conductor.registry.cache._fetch_github")
     @patch("conductor.registry.cache.load_index")
@@ -514,7 +712,7 @@ class TestFetchWorkflowGitHub:
         _setup_conductor_home(tmp_path, monkeypatch)
         mock_resolve_ref.return_value = "v1.0.0"  # type: ignore[union-attr]
         mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
-        mock_load_index.return_value = _FakeIndex(workflows={})  # type: ignore[union-attr]
+        mock_load_index.return_value = RegistryIndex(workflows={})  # type: ignore[union-attr]
 
         entry = RegistryEntry(type=RegistryType.github, source="myorg/workflows")
         with pytest.raises(RegistryError, match="not found"):
@@ -531,8 +729,8 @@ class TestClearCache:
         home = _setup_conductor_home(tmp_path, monkeypatch)
         cache_base = home / "cache" / "registries"
 
-        (cache_base / "reg-a" / "wf" / _SHA_DIR).mkdir(parents=True)
-        (cache_base / "reg-b" / "wf" / _SHA_DIR2).mkdir(parents=True)
+        (cache_base / "reg-a" / _SHA_DIR / "wf").mkdir(parents=True)
+        (cache_base / "reg-b" / _SHA_DIR2 / "wf").mkdir(parents=True)
 
         clear_cache()
 
@@ -542,8 +740,8 @@ class TestClearCache:
         home = _setup_conductor_home(tmp_path, monkeypatch)
         cache_base = home / "cache" / "registries"
 
-        (cache_base / "reg-a" / "wf" / _SHA_DIR).mkdir(parents=True)
-        (cache_base / "reg-b" / "wf" / _SHA_DIR2).mkdir(parents=True)
+        (cache_base / "reg-a" / _SHA_DIR / "wf").mkdir(parents=True)
+        (cache_base / "reg-b" / _SHA_DIR2 / "wf").mkdir(parents=True)
 
         clear_cache(registry_name="reg-a")
 
@@ -571,9 +769,9 @@ class TestPruneTempDirs:
         home = _setup_conductor_home(tmp_path, monkeypatch)
         cache_base = home / "cache" / "registries"
 
-        # Real SHA dir alongside an orphan .tmp-* dir.
-        real = cache_base / "reg-a" / "wf" / _SHA_DIR
-        orphan = cache_base / "reg-a" / "wf" / ".tmp-abc"
+        # Real SHA dir alongside an orphan .tmp-* dir under _meta/<sha>/.
+        real = cache_base / "reg-a" / _SHA_DIR
+        orphan = cache_base / "reg-a" / "_meta" / _SHA_DIR / ".tmp-abc"
         real.mkdir(parents=True)
         orphan.mkdir(parents=True)
         (orphan / "junk.yaml").write_text("x", encoding="utf-8")
@@ -590,8 +788,8 @@ class TestPruneTempDirs:
         home = _setup_conductor_home(tmp_path, monkeypatch)
         cache_base = home / "cache" / "registries"
 
-        orphan_a = cache_base / "reg-a" / "wf" / ".tmp-aaa"
-        orphan_b = cache_base / "reg-b" / "wf" / ".tmp-bbb"
+        orphan_a = cache_base / "reg-a" / "_meta" / _SHA_DIR / ".tmp-aaa"
+        orphan_b = cache_base / "reg-b" / "_meta" / _SHA_DIR2 / ".tmp-bbb"
         orphan_a.mkdir(parents=True)
         orphan_b.mkdir(parents=True)
 
@@ -608,10 +806,10 @@ class TestPruneTempDirs:
         cache_base = home / "cache" / "registries"
 
         for n in range(3):
-            (cache_base / "reg-a" / "wf" / f".tmp-{n}").mkdir(parents=True)
-        (cache_base / "reg-b" / "other-wf" / ".tmp-xyz").mkdir(parents=True)
+            (cache_base / "reg-a" / "_meta" / _SHA_DIR / f".tmp-{n}").mkdir(parents=True)
+        (cache_base / "reg-b" / "_meta" / _SHA_DIR2 / ".tmp-xyz").mkdir(parents=True)
         # Real dirs - should not be counted.
-        (cache_base / "reg-a" / "wf" / _SHA_DIR).mkdir(parents=True)
+        (cache_base / "reg-a" / _SHA_DIR / "wf").mkdir(parents=True)
 
         removed = prune_temp_dirs()
 
@@ -647,7 +845,7 @@ class TestFetchWorkflowAdhoc:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Ad-hoc fetch caches under <base>/_adhoc/<owner>/<repo>/<wf>/<sha>/."""
+        """Ad-hoc fetch caches under <base>/_adhoc/<owner>/<repo>/<sha>/<repo_path>."""
         from conductor.registry.cache import fetch_workflow_adhoc
 
         home = _setup_conductor_home(tmp_path, monkeypatch)
@@ -655,7 +853,7 @@ class TestFetchWorkflowAdhoc:
         mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
         mock_load_index.return_value = _make_index()  # type: ignore[union-attr]
         mock_fetch_github.side_effect = (  # type: ignore[union-attr]
-            lambda entry, path, sha, dest_dir: _write_workflow_file(dest_dir)
+            lambda entry, path, sha, dest_dir: _write_workflow_into_staging(dest_dir, path)
         )
 
         result = fetch_workflow_adhoc(
@@ -667,11 +865,19 @@ class TestFetchWorkflowAdhoc:
 
         assert result.exists()
         assert result.name == "qa-bot.yaml"
-        # Cache directory is namespaced under _adhoc/<owner>/<repo>/
-        expected_dir = (
-            home / "cache" / "registries" / "_adhoc" / "myorg" / "workflows" / "qa-bot" / _SHA_DIR
+        # Cache directory is namespaced under _adhoc/<owner>/<repo>/<sha>/<repo_path>
+        expected = (
+            home
+            / "cache"
+            / "registries"
+            / "_adhoc"
+            / "myorg"
+            / "workflows"
+            / _SHA_DIR
+            / "workflows"
+            / "qa-bot.yaml"
         )
-        assert result.parent == expected_dir
+        assert result == expected
 
     @patch("conductor.registry.cache._fetch_github")
     @patch("conductor.registry.cache.load_index")
@@ -694,7 +900,7 @@ class TestFetchWorkflowAdhoc:
         mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
         mock_load_index.return_value = _make_index()  # type: ignore[union-attr]
         mock_fetch_github.side_effect = (  # type: ignore[union-attr]
-            lambda entry, path, sha, dest_dir: _write_workflow_file(dest_dir)
+            lambda entry, path, sha, dest_dir: _write_workflow_into_staging(dest_dir, path)
         )
 
         # Fetch via named registry first
@@ -709,7 +915,7 @@ class TestFetchWorkflowAdhoc:
             ref="v1.0.0",
         )
 
-        # Both succeed but live in different cache directories
+        # Both succeed but live in different cache trees
         assert named_result.parent != adhoc_result.parent
         # Sanity: named_result lives under official/, adhoc under _adhoc/myorg/workflows/
         assert (home / "cache" / "registries" / "official").exists()
@@ -738,12 +944,14 @@ class TestFetchWorkflowAdhoc:
         mock_resolve_ref.return_value = "v1.0.0"  # type: ignore[union-attr]
         mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
 
-        # Pre-populate the ad-hoc cache
-        sha_dir = (
-            home / "cache" / "registries" / "_adhoc" / "myorg" / "workflows" / "qa-bot" / _SHA_DIR
+        wf_path = _pre_populate_cache(
+            home,
+            registry_name="_adhoc/myorg/workflows",
+            workflow_name="qa-bot",
+            sha=_FAKE_SHA,
+            workflow_repo_path="workflows/qa-bot.yaml",
+            registry_source="myorg/workflows",
         )
-        sha_dir.mkdir(parents=True)
-        (sha_dir / "qa-bot.yaml").write_text("name: qa-bot\n", encoding="utf-8")
 
         result = fetch_workflow_adhoc(
             owner="myorg",
@@ -752,7 +960,7 @@ class TestFetchWorkflowAdhoc:
             ref="v1.0.0",
         )
 
-        assert result.parent == sha_dir
+        assert result == wf_path
         mock_fetch_github.assert_not_called()  # type: ignore[union-attr]
         mock_load_index.assert_not_called()  # type: ignore[union-attr]
 
@@ -845,3 +1053,241 @@ class TestResolveAndFetch:
         )
         with pytest.raises(ValueError, match="adhoc_owner"):
             resolve_and_fetch(ref)
+
+
+# ---------------------------------------------------------------------------
+# find_registry_cache_location
+# ---------------------------------------------------------------------------
+
+
+class TestFindRegistryCacheLocation:
+    def test_named_registry(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        sha_root = home / "cache" / "registries" / "official" / _SHA_DIR
+        wf = sha_root / "sdd-plan" / "plan.yaml"
+        wf.parent.mkdir(parents=True)
+        wf.write_text("x")
+
+        location = find_registry_cache_location(wf)
+        assert location is not None
+        assert location.registry_name == "official"
+        assert location.sha == _SHA_DIR
+        assert location.sha_root == sha_root.resolve()
+
+    def test_adhoc_registry(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        sha_root = home / "cache" / "registries" / "_adhoc" / "myorg" / "workflows" / _SHA_DIR
+        wf = sha_root / "deep" / "nested" / "workflow.yaml"
+        wf.parent.mkdir(parents=True)
+        wf.write_text("x")
+
+        location = find_registry_cache_location(wf)
+        assert location is not None
+        assert location.registry_name == "_adhoc/myorg/workflows"
+        assert location.sha == _SHA_DIR
+        assert location.sha_root == sha_root.resolve()
+
+    def test_meta_dir_returns_none(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        # Files inside _meta/<sha>/ are NOT a SHA-rooted mirror.
+        meta_path = home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR / "source.json"
+        meta_path.parent.mkdir(parents=True)
+        meta_path.write_text("{}")
+
+        assert find_registry_cache_location(meta_path) is None
+
+    def test_outside_cache_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_conductor_home(tmp_path, monkeypatch)
+        outside = tmp_path / "elsewhere" / "workflow.yaml"
+        outside.parent.mkdir(parents=True)
+        outside.write_text("x")
+        assert find_registry_cache_location(outside) is None
+
+    def test_non_hex_sha_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        # 12 chars but not hex
+        path = home / "cache" / "registries" / "official" / "ZZZZZZZZZZZZ" / "wf.yaml"
+        path.parent.mkdir(parents=True)
+        path.write_text("x")
+        assert find_registry_cache_location(path) is None
+
+
+# ---------------------------------------------------------------------------
+# auto_fetch_relative_workflow (Part 2)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFetchRelativeWorkflow:
+    """Cross-workflow relative refs like ../other/workflow.yaml."""
+
+    @patch("conductor.registry.cache._fetch_github")
+    @patch("conductor.registry.cache.load_index")
+    @patch("conductor.registry.cache.materialize_to_sha")
+    @patch("conductor.registry.cache.resolve_ref")
+    def test_auto_fetches_sibling_workflow_in_same_registry(
+        self,
+        mock_resolve_ref: object,
+        mock_materialize: object,
+        mock_load_index: object,
+        mock_fetch_github: object,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The classic bug: parent workflow refs ../sibling/workflow.yaml."""
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        mock_resolve_ref.return_value = "v1.0.0"  # type: ignore[union-attr]
+        mock_materialize.return_value = _FAKE_SHA  # type: ignore[union-attr]
+
+        # Pre-populate the parent workflow (sdd-plan/plan.yaml) only.
+        index = RegistryIndex(
+            workflows={
+                "sdd-plan": WorkflowInfo(description="", path="sdd-plan/plan.yaml"),
+                "document-review": WorkflowInfo(
+                    description="", path="document-review/workflow.yaml"
+                ),
+            }
+        )
+        # Pre-write the cache as if sdd-plan were already fetched.
+        sha_root = home / "cache" / "registries" / "official" / _SHA_DIR
+        (sha_root / "sdd-plan").mkdir(parents=True)
+        (sha_root / "sdd-plan" / "plan.yaml").write_bytes(b"name: sdd-plan\n")
+        meta_dir = home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR
+        meta_dir.mkdir(parents=True)
+        (meta_dir / "source.json").write_text(
+            json.dumps(
+                {
+                    "cache_layout_version": CACHE_LAYOUT_VERSION,
+                    "registry_type": "github",
+                    "source": "myorg/workflows",
+                    "full_sha": _FAKE_SHA,
+                },
+                sort_keys=True,
+                indent=2,
+            )
+        )
+        (meta_dir / "index.yaml").write_text(
+            "workflows:\n"
+            "  sdd-plan:\n    description: ''\n    path: sdd-plan/plan.yaml\n"
+            "  document-review:\n    description: ''\n    path: document-review/workflow.yaml\n"
+        )
+        (meta_dir / "sdd-plan.complete").write_text("")
+
+        # Mock fetch — should be invoked for the auto-fetch of document-review.
+        mock_load_index.return_value = index  # type: ignore[union-attr]
+        mock_fetch_github.side_effect = (  # type: ignore[union-attr]
+            lambda entry, path, sha, dest_dir: _write_workflow_into_staging(dest_dir, path)
+        )
+
+        # Simulate the engine's relative-path resolution from sdd-plan/plan.yaml.
+        candidate = (sha_root / "sdd-plan" / "../document-review/workflow.yaml").resolve()
+        assert not candidate.exists()  # confirms the bug pre-conditions
+
+        fetched = auto_fetch_relative_workflow(candidate)
+        assert fetched is not None
+        assert fetched.exists()
+        assert fetched == sha_root / "document-review" / "workflow.yaml"
+        mock_fetch_github.assert_called_once()  # type: ignore[union-attr]
+
+    def test_returns_none_when_not_in_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_conductor_home(tmp_path, monkeypatch)
+        outside = tmp_path / "anywhere" / "wf.yaml"
+        outside.parent.mkdir(parents=True)
+        # Don't even create the file
+        assert auto_fetch_relative_workflow(outside) is None
+
+    def test_returns_none_when_no_metadata(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cache root exists but no metadata → can't auto-fetch."""
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        sha_root = home / "cache" / "registries" / "official" / _SHA_DIR
+        sha_root.mkdir(parents=True)
+        candidate = sha_root / "missing" / "wf.yaml"
+        assert auto_fetch_relative_workflow(candidate) is None
+
+    def test_returns_none_when_path_not_in_index(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cache + metadata + index exist but path doesn't match any workflow."""
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        _pre_populate_cache(
+            home,
+            registry_name="official",
+            workflow_name="parent",
+            sha=_FAKE_SHA,
+            workflow_repo_path="parent/wf.yaml",
+            registry_source="myorg/workflows",
+        )
+        sha_root = home / "cache" / "registries" / "official" / _SHA_DIR
+        candidate = sha_root / "not-in-index" / "wf.yaml"
+        assert auto_fetch_relative_workflow(candidate) is None
+
+    def test_returns_none_when_cache_layout_version_stale(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stale cache_layout_version in source.json should not be used."""
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        _pre_populate_cache(
+            home,
+            registry_name="official",
+            workflow_name="parent",
+            sha=_FAKE_SHA,
+            workflow_repo_path="parent/wf.yaml",
+            registry_source="myorg/workflows",
+        )
+        # Overwrite source.json with an older layout version.
+        meta = home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR
+        (meta / "source.json").write_text(
+            json.dumps(
+                {
+                    "cache_layout_version": CACHE_LAYOUT_VERSION - 1,
+                    "registry_type": "github",
+                    "source": "myorg/workflows",
+                    "full_sha": _FAKE_SHA,
+                },
+                sort_keys=True,
+                indent=2,
+            )
+        )
+
+        sha_root = home / "cache" / "registries" / "official" / _SHA_DIR
+        candidate = sha_root / "parent" / "wf.yaml"  # exists but stale meta
+        # Even valid candidate path returns None — metadata is rejected.
+        assert auto_fetch_relative_workflow(candidate) is None
+
+    def test_returns_none_when_metadata_sha_does_not_match(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """source.json full_sha must agree with the on-disk SHA dir prefix."""
+        home = _setup_conductor_home(tmp_path, monkeypatch)
+        _pre_populate_cache(
+            home,
+            registry_name="official",
+            workflow_name="parent",
+            sha=_FAKE_SHA,
+            workflow_repo_path="parent/wf.yaml",
+            registry_source="myorg/workflows",
+        )
+        # Tamper with source.json to claim a different SHA.
+        meta = home / "cache" / "registries" / "official" / "_meta" / _SHA_DIR
+        (meta / "source.json").write_text(
+            json.dumps(
+                {
+                    "cache_layout_version": CACHE_LAYOUT_VERSION,
+                    "registry_type": "github",
+                    "source": "myorg/workflows",
+                    "full_sha": _FAKE_SHA2,  # mismatched!
+                },
+                sort_keys=True,
+                indent=2,
+            )
+        )
+        sha_root = home / "cache" / "registries" / "official" / _SHA_DIR
+        candidate = sha_root / "parent" / "wf.yaml"
+        assert auto_fetch_relative_workflow(candidate) is None

--- a/tests/test_registry/test_config.py
+++ b/tests/test_registry/test_config.py
@@ -202,6 +202,29 @@ class TestAddRegistry:
         loaded = load_config()
         assert "persisted" in loaded.registries
 
+    @pytest.mark.parametrize("name", ["_adhoc", "_meta"])
+    def test_reserved_name_rejected(
+        self, name: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reserved cache namespaces cannot be used as registry names."""
+        _setup_config_home(tmp_path, monkeypatch)
+        with pytest.raises(RegistryError, match="reserved"):
+            add_registry(name, "org/repo")
+
+    @pytest.mark.parametrize("name", ["with/slash", "with\\backslash", "a/b/c"])
+    def test_name_with_separator_rejected(
+        self, name: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Path separators in registry names would break cache layout."""
+        _setup_config_home(tmp_path, monkeypatch)
+        with pytest.raises(RegistryError, match=r"must not contain '/'"):
+            add_registry(name, "org/repo")
+
+    def test_empty_name_rejected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_config_home(tmp_path, monkeypatch)
+        with pytest.raises(RegistryError, match="cannot be empty"):
+            add_registry("", "org/repo")
+
 
 # ---------------------------------------------------------------------------
 # remove_registry

--- a/tests/test_registry/test_integration.py
+++ b/tests/test_registry/test_integration.py
@@ -454,20 +454,14 @@ class TestAdhocRefIntegration:
         # Pre-populate a "fetched" workflow in the expected adhoc cache dir.
         # In the real flow, _fetch_github would write here; we short-circuit
         # by mocking materialize_to_sha + load_index + _fetch_github.
+        # Adhoc cache layout: <base>/_adhoc/<owner>/<repo>/<sha[:12]>/<repo_path>
         fake_sha = "c" * 40
-        sha_dir = (
-            home
-            / "cache"
-            / "registries"
-            / "_adhoc"
-            / "myorg"
-            / "team-a"
-            / "analysis"
-            / fake_sha[:12]
-        )
+        sha_dir = home / "cache" / "registries" / "_adhoc" / "myorg" / "team-a" / fake_sha[:12]
 
         def fake_fetch_github(entry, workflow_path, sha, dest_dir):
-            (dest_dir / "analysis.yaml").write_text(_SIMPLE_WORKFLOW)
+            target = dest_dir / workflow_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(_SIMPLE_WORKFLOW)
 
         from conductor.registry.index import RegistryIndex, WorkflowInfo
 


### PR DESCRIPTION
## Bug

The registry cache stored each workflow under
`<base>/<registry>/<workflow_name>/<sha[:12]>/<filename>`, isolating each
workflow in its own subtree. Repo-relative references between workflows in the
same registry repo broke at resolve time:

```
sdd-plan/plan.yaml          # references ../document-review/workflow.yaml
document-review/workflow.yaml
```

The `..` from `<cache>/<registry>/sdd-plan/<sha>/plan.yaml` resolved to
`<cache>/<registry>/sdd-plan/document-review/workflow.yaml` — a path that never
existed. Users had to manually copy files into the expected slots as a
workaround.

## Fix

### Cache layout

Workflows from the same registry+SHA now share a per-SHA root that mirrors the
source repository:

```
<base>/<registry>/<sha[:12]>/<repo_path>                      # mirrored repo files
<base>/<registry>/_meta/<sha[:12]>/source.json                # cache metadata
<base>/<registry>/_meta/<sha[:12]>/index.yaml                 # cached registry index
<base>/<registry>/_meta/<sha[:12]>/<workflow>.complete        # readiness sentinel
```

Adhoc:

```
<base>/_adhoc/<owner>/<repo>/<sha[:12]>/<repo_path>
<base>/_adhoc/<owner>/<repo>/_meta/<sha[:12]>/...
```

Metadata lives outside the SHA tree so it can never collide with real repo
paths (e.g. a repo's own `.conductor/` directory).

### Safety + correctness

- **Per-workflow readiness sentinel** written *last* so concurrent or
  interrupted fetches never expose a partially populated workflow.
- **Atomic per-file `os.replace()`** from a staging dir under `_meta/<sha>/`,
  intra-filesystem so renames are atomic. Files in the SHA mirror are
  content-addressed by the immutable SHA; concurrent promotions of identical
  content are idempotent.
- **`_safe_repo_path()`** rejects `..` segments, absolute paths (POSIX +
  Windows), NUL bytes, and empty paths from any index/sibling entry.
- **`_resolve_within()`** defense-in-depth ensures resolved targets stay under
  the SHA root after disk resolution.
- **`source.json`** carries `cache_layout_version`, `registry_type`, `source`,
  and `full_sha`; cache hits require all four to match the current registry
  entry. Stale metadata triggers a re-fetch.
- The registry index is **cached on disk** (`_meta/<sha>/index.yaml`) so cache
  hits avoid a network round-trip.

### Auto-fetch sub-workflows from same registry

When a sub-workflow ref like `../document-review/workflow.yaml` resolves to a
path inside a registry SHA cache but the file isn't yet present,
`_resolve_subworkflow_path` calls a new `auto_fetch_relative_workflow()` which:

1. Detects the `(registry, sha)` from the candidate path.
2. Validates the cached metadata (layout version, registry type, SHA prefix
   match, valid GitHub source).
3. Looks up a workflow in the cached index by repo-relative path.
4. Fetches it, populating the shared SHA mirror.

The hook is gated to candidates that look like a file path (separators or
`.yaml`/`.yml` extension) and not a registry ref (no `@`), so registry-style
refs continue through the existing resolver path.

### Reserved registry names

`add_registry()` now rejects names containing `/`, `\`, the empty string, or
the reserved `_adhoc` / `_meta` namespaces, preventing configurations that
would silently corrupt cache-layout detection.

## Backward compatibility

Old per-workflow caches are simply ignored — never read by the new code. They
become wasted disk that `conductor registry clear` removes. No automatic
migration; users re-fetch on next use.

## Out of scope

Cross-directory `!file` tag references (e.g.
`instructions: !file ../other-workflow/prompt.txt`) are unchanged. The loader
resolves `!file` during YAML load before `_resolve_subworkflow_path` runs;
supporting that case requires hooking the loader and tracking registry context
there. Same-directory `!file` refs continue to work because siblings are still
fetched alongside the workflow.

## Testing

- Full suite: **2633 passed, 11 skipped**.
- New cache tests: layout, sentinel-based hit detection, cached-index reuse,
  stale-metadata re-fetch, path-traversal rejection, cross-workflow
  auto-fetch, `find_registry_cache_location`, metadata-mismatch rejection.
- New end-to-end test (`TestCrossWorkflowRegistryRef`) reproduces the original
  bug with a parent workflow that references a sibling via
  `../other/workflow.yaml` and verifies the auto-fetch hook populates the
  cache and runs the sub-workflow.
- `make lint` ✅ — `make typecheck` ✅ (one pre-existing unrelated warning)