### PR TITLE
fix(config): auto-fetch sibling sub-workflow from registry cache during validation

### DIFF
--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -905,16 +905,36 @@ def _resolve_subworkflow_ref_for_validation(
     Returns:
         Tuple of (resolved path or None on error, list of error strings).
     """
-    from conductor.registry.cache import resolve_and_fetch
+    from conductor.registry.cache import auto_fetch_relative_workflow, resolve_and_fetch
     from conductor.registry.errors import RegistryError
     from conductor.registry.resolver import resolve_ref
 
     errors: list[str] = []
 
-    # Check for an existing file beside the parent workflow first.
+    # Step 1: check for an existing file beside the parent workflow first.
     candidate = (base_dir / workflow_ref).resolve()
     if candidate.is_file():
         return candidate, errors
+
+    # Step 1b: when the parent workflow lives inside a registry SHA cache,
+    # try to auto-fetch a sibling workflow from the same registry. Mirrors
+    # the engine's ``_resolve_subworkflow_path`` step 1b so that
+    # ``conductor validate`` succeeds for the same cross-workflow refs
+    # (e.g. ``../document-review/workflow.yaml``) that succeed at runtime.
+    # Only attempts when the candidate looks like a file path (has
+    # separators or a YAML extension) AND is not a registry ref
+    # ('@' indicates named or ad-hoc registry syntax handled below).
+    looks_like_file = "@" not in workflow_ref and (
+        "/" in workflow_ref or "\\" in workflow_ref or candidate.suffix.lower() in {".yaml", ".yml"}
+    )
+    if looks_like_file:
+        try:
+            auto_fetched = auto_fetch_relative_workflow(candidate)
+        except RegistryError as exc:
+            errors.append(f"{label}: failed to auto-fetch sub-workflow '{workflow_ref}': {exc}")
+            return None, errors
+        if auto_fetched is not None and auto_fetched.is_file():
+            return auto_fetched, errors
 
     try:
         resolved = resolve_ref(workflow_ref)

--- a/tests/test_config/test_validator.py
+++ b/tests/test_config/test_validator.py
@@ -1772,3 +1772,134 @@ class TestSubWorkflowRefValidation:
             pytest.raises(ConfigurationError, match="failed to fetch sub-workflow"),
         ):
             validate_workflow_config(config, workflow_path=parent)
+
+    def test_relative_ref_to_sibling_workflow_in_registry_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cross-workflow relative refs between workflows in the same registry validate.
+
+        Reproduces the bug where ``conductor validate <registry-workflow>`` for
+        a workflow at ``sdd/plan.yaml`` that references
+        ``../document-review/workflow.yaml`` failed with "sub-workflow file
+        not found", even though ``conductor run`` for the same workflow
+        succeeds via the engine's auto-fetch hook. Validation must mirror
+        the engine and auto-fetch the sibling workflow from the same
+        registry+SHA cache.
+        """
+        import json
+        import textwrap
+        from unittest.mock import patch
+
+        from conductor.config.loader import load_config
+        from conductor.config.validator import validate_workflow_config
+        from conductor.registry.cache import CACHE_LAYOUT_VERSION
+        from conductor.registry.index import RegistryIndex, WorkflowInfo
+
+        # Point CONDUCTOR_HOME at a temp dir so the cache lives there.
+        home = tmp_path / "conductor_home"
+        home.mkdir()
+        monkeypatch.setenv("CONDUCTOR_HOME", str(home))
+
+        sha = "a" * 40
+        sha_dir = sha[:12]
+        cache_base = home / "cache" / "registries"
+        official_sha_root = cache_base / "official" / sha_dir
+
+        # Pre-cache the parent workflow (sdd/plan.yaml) only — the sibling
+        # ``document-review/workflow.yaml`` must be auto-fetched during
+        # validation.
+        parent_dir = official_sha_root / "sdd"
+        parent_dir.mkdir(parents=True)
+        parent_path = parent_dir / "plan.yaml"
+        parent_path.write_text(
+            textwrap.dedent("""\
+                workflow:
+                  name: sdd-plan
+                  entry_point: document_review
+                  runtime:
+                    provider: copilot
+                  limits:
+                    max_iterations: 10
+                agents:
+                  - name: document_review
+                    type: workflow
+                    workflow: ../document-review/workflow.yaml
+                    routes:
+                      - to: "$end"
+                output:
+                  result: "{{ document_review.output.verdict }}"
+            """),
+            encoding="utf-8",
+        )
+
+        # Pre-write source.json + cached index + sentinel for the parent.
+        meta_dir = cache_base / "official" / "_meta" / sha_dir
+        meta_dir.mkdir(parents=True)
+        (meta_dir / "source.json").write_text(
+            json.dumps(
+                {
+                    "cache_layout_version": CACHE_LAYOUT_VERSION,
+                    "registry_type": "github",
+                    "source": "myorg/workflows",
+                    "full_sha": sha,
+                },
+                sort_keys=True,
+                indent=2,
+            )
+        )
+        (meta_dir / "index.yaml").write_text(
+            "workflows:\n"
+            "  sdd-plan:\n    description: ''\n    path: sdd/plan.yaml\n"
+            "  document-review:\n    description: ''\n    path: document-review/workflow.yaml\n"
+        )
+        (meta_dir / "sdd-plan.complete").write_text("")
+
+        sub_yaml = textwrap.dedent(
+            """\
+            workflow:
+              name: document-review
+              entry_point: reviewer
+              runtime:
+                provider: copilot
+              limits:
+                max_iterations: 10
+            agents:
+              - name: reviewer
+                type: agent
+                prompt: review the doc
+                routes:
+                  - to: "$end"
+            output:
+              verdict: "{{ reviewer.output.verdict }}"
+            """
+        )
+
+        index_obj = RegistryIndex(
+            workflows={
+                "sdd-plan": WorkflowInfo(description="", path="sdd/plan.yaml"),
+                "document-review": WorkflowInfo(
+                    description="", path="document-review/workflow.yaml"
+                ),
+            }
+        )
+
+        def fake_fetch_github(entry, workflow_path, sha_arg, dest_dir):
+            target = dest_dir / workflow_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(sub_yaml)
+
+        config = load_config(parent_path)
+
+        with (
+            patch("conductor.registry.cache.materialize_to_sha", return_value=sha),
+            patch("conductor.registry.cache.resolve_ref", return_value=sha),
+            patch("conductor.registry.cache.load_index", return_value=index_obj),
+            patch("conductor.registry.cache._fetch_github", side_effect=fake_fetch_github),
+        ):
+            # Should succeed without raising — the sibling is auto-fetched.
+            warnings = validate_workflow_config(config, workflow_path=parent_path)
+
+        assert warnings == []
+        # Confirm the sibling was actually auto-fetched into the shared SHA root.
+        sibling = official_sha_root / "document-review" / "workflow.yaml"
+        assert sibling.exists()


### PR DESCRIPTION
## Problem

`conductor validate <registry-workflow>` failed with:

> sub-workflow file not found: '…/workflows/document-review/workflow.yaml'

…for workflows pulled from a registry that reference a sibling workflow via a relative path (e.g. `sdd/plan.yaml` referencing `../document-review/workflow.yaml`). The same workflow runs successfully with `conductor run`, because the engine auto-fetches the sibling on demand.

## Root cause

The engine's `_resolve_subworkflow_path` has a step 1b (`src/conductor/engine/workflow.py:774-800`) that calls `auto_fetch_relative_workflow(candidate)` when the parent workflow lives inside a registry SHA cache. The validator's `_resolve_subworkflow_ref_for_validation` was missing this step — it went straight from "file exists on disk?" to "file not found", so cross-workflow refs that the runtime resolves were rejected by validation.

## Fix

Mirror the engine's step 1b in the validator so validation and execution agree on which refs are resolvable. The validator now attempts `auto_fetch_relative_workflow` for file-like refs before reporting "file not found".

## Test

Added `test_relative_ref_to_sibling_workflow_in_registry_cache` in `tests/test_config/test_validator.py` that reproduces the user-reported scenario: a parent at `sdd/plan.yaml` references `../document-review/workflow.yaml` and the sibling is auto-fetched into the shared SHA root during validation.

## Verification

- New + existing `TestSubWorkflowRefValidation` tests pass (12/12)
- Full non-performance test suite passes (2617 tests)
- Lint, format, typecheck clean