### PR TITLE
fix(bg): stop passing redundant --silent to bg child (#196)

### DIFF
--- a/src/conductor/cli/bg_runner.py
+++ b/src/conductor/cli/bg_runner.py
@@ -9,6 +9,13 @@ The child process is fully detached (new session on Unix, new process group on
 Windows) so it outlives the parent. It auto-shuts down after the workflow
 completes and all WebSocket clients disconnect (the existing ``--web`` +
 ``bg=True`` behavior in ``WebDashboard``).
+
+The child's stdout/stderr/stdin are redirected to ``DEVNULL`` in the Popen
+call, not suppressed via ``--silent``. This is a deliberate design choice:
+``--silent`` would also set ``verbose_mode=False``, which gates provider-side
+SDK event logging that ``--log-file`` writes to disk. Relying on DEVNULL
+keeps the file log populated for detached children where the user has no
+other way to observe runtime behavior (see issue #196).
 """
 
 from __future__ import annotations
@@ -164,12 +171,15 @@ def launch_background(
     if web_port == 0:
         web_port = _find_free_port()
 
-    # Build the subprocess command
+    # Build the subprocess command. Console output is already redirected to
+    # DEVNULL via the Popen ``stdout``/``stderr`` kwargs below, so the child
+    # runs at default verbosity. This keeps ``verbose_log()`` and provider
+    # SDK event logging active so ``--log-file`` captures a real trace when
+    # enabled (see issue #196).
     cmd: list[str] = [
         sys.executable,
         "-m",
         "conductor",
-        "--silent",  # suppress CLI output in the background process
         "run",
         str(workflow_path),
         "--web",
@@ -280,12 +290,15 @@ def launch_background_resume(
     if web_port == 0:
         web_port = _find_free_port()
 
-    # Build the subprocess command
+    # Build the subprocess command. Console output is already redirected to
+    # DEVNULL via the Popen ``stdout``/``stderr`` kwargs below, so the child
+    # runs at default verbosity. This keeps ``verbose_log()`` and provider
+    # SDK event logging active so ``--log-file`` captures a real trace when
+    # enabled (see issue #196).
     cmd: list[str] = [
         sys.executable,
         "-m",
         "conductor",
-        "--silent",  # suppress CLI output in the background process
         "resume",
     ]
 

--- a/tests/test_cli/test_resume_command.py
+++ b/tests/test_cli/test_resume_command.py
@@ -380,9 +380,11 @@ class TestLaunchBackgroundResume:
 
         assert url == "http://127.0.0.1:9099"
         cmd = captured["cmd"]
-        # `--silent` is global and must precede the subcommand
-        assert "--silent" in cmd
-        assert cmd.index("resume") > cmd.index("--silent")
+        # ``--silent`` must NOT be injected: console output is already
+        # suppressed by Popen ``stdout``/``stderr=DEVNULL``, and ``--silent``
+        # would also gate provider-side verbose logging that ``--log-file``
+        # relies on. See issue #196.
+        assert "--silent" not in cmd
         assert str(wf_path) in cmd
         assert "--web" in cmd
         assert "--web-port" in cmd

--- a/tests/test_cli/test_web_flags.py
+++ b/tests/test_cli/test_web_flags.py
@@ -123,6 +123,71 @@ class TestWebBgMutualExclusion:
         assert result.exit_code != 0
 
 
+class TestLaunchBackgroundSilentFlag:
+    """Regression tests for issue #196 — bg_runner must not pass --silent.
+
+    The child's ``stdout``/``stderr`` are already redirected to ``DEVNULL``, so
+    ``--silent`` adds nothing for the user. Worse, it sets
+    ``verbose_mode=False`` in the child, which gates provider-side SDK event
+    logging that ``--log-file`` would otherwise capture.
+    """
+
+    def test_launch_background_does_not_pass_silent(self, tmp_path: Path) -> None:
+        """``launch_background`` must not inject ``--silent`` into the cmd.
+
+        Asserts both the negative contract (no ``--silent``) and the positive
+        contract (expected flags still present) so that an accidental
+        regression that drops both ``--silent`` *and* another flag would
+        still be caught. Mirrors ``test_builds_resume_subcommand_with_workflow``
+        on the resume side.
+        """
+        from conductor.cli import bg_runner
+
+        wf_path = tmp_path / "wf.yaml"
+        wf_path.write_text("workflow: {name: x, entry_point: a}\nagents: []\n")
+
+        captured: dict[str, list[str]] = {}
+
+        def _fake_popen(cmd: list[str], **_kwargs: object) -> MagicMock:
+            captured["cmd"] = cmd
+            proc = MagicMock()
+            proc.pid = 12345
+            proc.poll.return_value = None
+            return proc
+
+        with (
+            patch("conductor.cli.bg_runner.subprocess.Popen", side_effect=_fake_popen),
+            patch("conductor.cli.bg_runner._wait_for_server", return_value=True),
+            patch("conductor.cli.pid.write_pid_file"),
+        ):
+            url = bg_runner.launch_background(
+                workflow_path=wf_path,
+                inputs={"question": "hello"},
+                provider_override="copilot",
+                skip_gates=True,
+                metadata={"tracker": "ado"},
+                web_port=9099,
+            )
+
+        assert url == "http://127.0.0.1:9099"
+        cmd = captured["cmd"]
+        # Issue #196: ``--silent`` must NOT be injected — see class docstring.
+        assert "--silent" not in cmd
+        # Positive contract: expected flags must still be present.
+        assert "run" in cmd
+        assert str(wf_path) in cmd
+        assert "--web" in cmd
+        assert "--web-port" in cmd
+        assert "9099" in cmd
+        assert "--no-interactive" in cmd
+        assert "--input" in cmd
+        assert "question=hello" in cmd
+        assert "--provider" in cmd and "copilot" in cmd
+        assert "--skip-gates" in cmd
+        assert "--metadata" in cmd
+        assert "tracker=ado" in cmd
+
+
 class TestDashboardStartupFailure:
     """Test that dashboard startup failure is non-fatal."""
 


### PR DESCRIPTION
Fixes #196.

## Problem

`bg_runner.launch_background()` and `launch_background_resume()` already redirect the child's `stdout`/`stderr`/`stdin` to `subprocess.DEVNULL`, so silence is enforced at the OS level. Passing `--silent` in addition to that adds nothing visible to the user — but it does flip `verbose_mode=False` in the child, and that gates real behavior, not just console prints:

- `copilot.py:867-868` — `_log_event_verbose()` is skipped for SDK events
- `copilot.py:701-706` — `_log_parse_recovery()` is skipped
- `copilot.py:1619-1620` — `_log_recovery_attempt()` is skipped

Critically, `_log_event_verbose()` writes to **both** a stderr Console and `_file_console`. So when `--silent` is set, those events are dropped from the log file too. That means `conductor run --web-bg --log-file auto` today produces a log file with no provider-side trace — exactly when you most want one for debugging a detached process.

By contrast, the `verbose_log_*` helpers in `cli/run.py` write to the file unconditionally, so the engine-level trace already survives `--silent`. Only the provider-side SDK events are the casualty, which makes the impact specifically about debugging stuck/looping agent sessions in bg mode.

## Fix

Drop `--silent` from both synthesized commands. Console output still goes to DEVNULL via the Popen kwargs (no visible change for users). The startup update hint is also gated on `console.is_terminal`, which is False when stderr=DEVNULL, so that doesn't reappear either.

Side benefit: the synthesized command is now reproducible by hand — useful when diagnosing related issues like #195.

## Changes

- `src/conductor/cli/bg_runner.py`: remove `--silent` from both \`cmd\` lists; replace the inline comment with a longer block explaining *why* it's absent and pointing at this issue.
- `tests/test_cli/test_resume_command.py`: flip the existing \`--silent\` assertion in \`test_builds_resume_subcommand_with_workflow\` from \"in cmd\" to \"not in cmd\" so the contract is locked in.
- `tests/test_cli/test_web_flags.py`: add \`TestLaunchBackgroundSilentFlag::test_launch_background_does_not_pass_silent\` — the run-side parity test that didn't exist before.

## Validation

- \`uv run pytest tests/test_cli tests/test_config\` → **832 passed, 2 skipped**
- \`make lint\` → clean
- \`make typecheck\` → clean (one pre-existing unrelated warning in \`dialog_evaluator.py\`)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>