### PR TITLE
fix(cli): suppress web-bg dashboard output in silent mode

### DIFF
--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -434,12 +434,13 @@ def run(
                 workspace_instructions=workspace_instructions,
                 cli_instructions=raw_instructions,
             )
-            console.print(f"[bold cyan]Dashboard:[/bold cyan] {launch.url}")
-            console.print(f"[dim]Child stderr log: {launch.stderr_log}[/dim]")
-            console.print(
-                "[dim]Workflow running in background. Dashboard auto-shuts down after "
-                "workflow completes and all clients disconnect.[/dim]"
-            )
+            if is_verbose():
+                console.print(f"[bold cyan]Dashboard:[/bold cyan] {launch.url}")
+                console.print(f"[dim]Child stderr log: {launch.stderr_log}[/dim]")
+                console.print(
+                    "[dim]Workflow running in background. Dashboard auto-shuts down after "
+                    "workflow completes and all clients disconnect.[/dim]"
+                )
         except Exception as e:
             print_error(e)
             raise typer.Exit(code=1) from None
@@ -844,12 +845,13 @@ def resume(
                 web_port=web_port,
                 metadata=cli_metadata,
             )
-            console.print(f"[bold cyan]Dashboard:[/bold cyan] {launch.url}")
-            console.print(f"[dim]Child stderr log: {launch.stderr_log}[/dim]")
-            console.print(
-                "[dim]Resumed workflow running in background. Dashboard auto-shuts down after "
-                "workflow completes and all clients disconnect.[/dim]"
-            )
+            if is_verbose():
+                console.print(f"[bold cyan]Dashboard:[/bold cyan] {launch.url}")
+                console.print(f"[dim]Child stderr log: {launch.stderr_log}[/dim]")
+                console.print(
+                    "[dim]Resumed workflow running in background. Dashboard auto-shuts down "
+                    "after workflow completes and all clients disconnect.[/dim]"
+                )
         except Exception as e:
             print_error(e)
             raise typer.Exit(code=1) from None

--- a/tests/test_cli/test_resume_command.py
+++ b/tests/test_cli/test_resume_command.py
@@ -334,6 +334,28 @@ class TestResumeCommand:
         assert kwargs["web_port"] == 9092
         assert kwargs["metadata"] == {"tracker": "ado"}
 
+    def test_silent_resume_web_bg_suppresses_dashboard_output(self, tmp_path: Path) -> None:
+        """Test --silent suppresses resume --web-bg parent-process dashboard output."""
+        from conductor.cli.bg_runner import BackgroundLaunch
+
+        wf_path = _write_workflow(tmp_path)
+
+        with patch("conductor.cli.bg_runner.launch_background_resume") as mock_launch:
+            mock_launch.return_value = BackgroundLaunch(
+                url="http://127.0.0.1:9092",
+                stderr_log=tmp_path / "stub-cafe1234.bg.stderr.log",
+                stdout_log=tmp_path / "stub-cafe1234.bg.stdout.log",
+                run_id="cafe1234",
+            )
+            result = runner.invoke(app, ["--silent", "resume", str(wf_path), "--web-bg"])
+
+        assert result.exit_code == 0
+        assert mock_launch.called
+        assert "http://127.0.0.1:9092" not in result.output
+        assert "Dashboard" not in result.output
+        assert "Resumed workflow running in background" not in result.output
+        assert "Child stderr log" not in result.output
+
     def test_resume_web_bg_with_from_checkpoint(self, tmp_path: Path) -> None:
         """Test --web-bg forwards --from checkpoint path."""
         from conductor.cli.bg_runner import BackgroundLaunch

--- a/tests/test_cli/test_web_flags.py
+++ b/tests/test_cli/test_web_flags.py
@@ -91,6 +91,30 @@ class TestWebFlagAcceptance:
             assert mock_launch.called
             _, kwargs = mock_launch.call_args
             assert kwargs["workflow_path"] == workflow_file
+            assert "http://127.0.0.1:9999" in result.output
+
+    def test_silent_web_bg_suppresses_dashboard_output(self, workflow_file: Path) -> None:
+        """Test --silent suppresses --web-bg parent-process dashboard output."""
+        from pathlib import Path as _Path
+
+        from conductor.cli.bg_runner import BackgroundLaunch
+
+        with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
+            mock_launch.return_value = BackgroundLaunch(
+                url="http://127.0.0.1:9999",
+                stderr_log=_Path("/tmp/conductor-test-deadbeef.bg.stderr.log"),
+                stdout_log=_Path("/tmp/conductor-test-deadbeef.bg.stdout.log"),
+                run_id="deadbeef",
+            )
+
+            result = runner.invoke(app, ["--silent", "run", str(workflow_file), "--web-bg"])
+
+            assert result.exit_code == 0
+            assert mock_launch.called
+            assert "http://127.0.0.1:9999" not in result.output
+            assert "Dashboard" not in result.output
+            assert "Workflow running in background" not in result.output
+            assert "Child stderr log" not in result.output
 
     def test_web_flags_default_values(self, workflow_file: Path) -> None:
         """Test that web flags default to False/0 when not specified."""


### PR DESCRIPTION
## Summary

Fixes `--silent --web-bg` still printing dashboard status lines.

## What changed

- Added regression coverage for silent `run --web-bg` and `resume --web-bg`.
- Suppressed dashboard URL/status output when silent mode is active.
- Preserved normal `--web-bg` output outside silent mode.

## Why

Issue #201 reports that `--silent` promises no progress output, but the background dashboard branch still prints to stderr.

## Testing

- `uv run pytest tests/test_cli/test_web_flags.py tests/test_cli/test_resume_command.py -k "web_bg"`
- `uv run pytest tests/test_cli/test_web_flags.py tests/test_cli/test_resume_command.py`
- `make lint`
- `make typecheck` (exit 0; reports an existing `possibly-missing-attribute` diagnostic in `src/conductor/engine/dialog_evaluator.py`)
- `uv run pytest -m "not install_scripts and not real_api"`

Note: `make test` currently fails locally on `tests/test_integration/test_copilot_large_write.py::test_large_create_tool_call_does_not_truncate` because the Copilot SDK reports model `claude-opus-4.7-1m-internal` is not available. The web-bg CLI regression tests above pass.

Fixes #201