### PR TITLE
fix(windows): make --web-bg startup crashes diagnosable (#116)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ make validate-examples    # validate all examples
 - **cli/**: Typer-based CLI with commands `run`, `validate`, `init`, `templates`, `stop`, `update`, `resume`, `checkpoints`
   - `app.py` - Main entry point, defines the Typer application
   - `run.py` - Workflow execution command with verbose logging helpers
-  - `bg_runner.py` - Background process forking for `--web-bg` mode
+  - `bg_runner.py` - Background process forking for `--web-bg` mode. Captures the detached child's stdout/stderr to `$TMPDIR/conductor/conductor-<name>-<ts>-<runid>.bg.{stderr,stdout}.log` so silent crashes (uncaught Python exceptions, `faulthandler` dumps) leave a forensic trail — DEVNULL is **not** used for stdout/stderr. Passes `CONDUCTOR_RUN_ID`, `CONDUCTOR_BG_STDERR_LOG`, and `CONDUCTOR_BG_STDOUT_LOG` to the child via env so the child's `EventLogSubscriber` shares a run id with the bg log files and surfaces both paths in `workflow_started` system metadata. Returns a `BackgroundLaunch` dataclass (`url`, `stderr_log`, `stdout_log`, `run_id`).
   - `pid.py` - PID file utilities for tracking/stopping background processes
   - `update.py` - Update check and version comparison. Upgrades are delegated to the install script (`install.ps1`/`install.sh`); in-process self-upgrade was removed because on Windows the running Python interpreter sits inside the venv `uv tool install --force` is trying to recreate, which fails with "Access is denied". `conductor update` prints the OS-appropriate install-script one-liner; `conductor update --apply` spawns the installer detached (Windows: new console window; POSIX: `os.execvpe` replace) and exits the current process so file locks release. The startup hint is suppressed by `CONDUCTOR_NO_UPDATE_CHECK=1`, `--silent`, `--help`/`--version`, and the `update` subcommand itself.
 
@@ -127,6 +127,28 @@ make validate-examples    # validate all examples
 - **Route evaluation**: First matching `when` condition wins; no `when` = always matches
 - **Tool resolution**: `null` = all workflow tools, `[]` = none, `[list]` = subset
 - **Reasoning effort**: `runtime.default_reasoning_effort` sets a workflow-wide default; per-agent `reasoning.effort` overrides it. Allowed values: `low`, `medium`, `high`, `xhigh`. Each provider translates the unified value to its native API (Copilot: `reasoning_effort` on the session, validated against the model's `supported_reasoning_efforts`; Claude: extended thinking with budget mapping low=2048, medium=8192, high=16384, xhigh=32768 tokens, with `temperature` coerced to 1.0 and `max_tokens` bumped to fit the budget). See `examples/reasoning-effort.yaml`.
+
+### Debugging `--web-bg` failures
+
+When a `conductor run --web-bg` (or `resume --web-bg`) child dies before
+the dashboard becomes reachable, or crashes mid-run, look at:
+
+1. The child's captured stderr log, printed alongside the dashboard URL
+   on a successful launch and included in every `RuntimeError` message
+   on a failed launch. The path is also stamped into the child's
+   `workflow_started` event under `system.bg_stderr_log` and surfaced
+   in the web dashboard.
+2. The matching `.events.jsonl` file in the same directory — same
+   timestamp and 8-hex run id in the filename, so the three artefacts
+   (`.events.jsonl`, `.bg.stderr.log`, `.bg.stdout.log`) sort together.
+3. For an apparent silent crash, search the events JSONL for a
+   `workflow_failed` event; the `is_base_exception` flag tells you
+   whether the failure escaped the engine's normal `Exception` handling
+   (e.g. a `SystemExit` from a misbehaving library).
+
+`faulthandler` is enabled at import time in `conductor/__init__.py`, so
+a native crash also dumps a Python stack trace to the captured stderr
+log. See issue #116.
 
 ## Tests Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appends to the original log, preserving `run_id` across resume
   generations so log/timeline correlation tools see one continuous run
   (#167).
+- `--web-bg` startup crashes on Windows are no longer silent
+  ([#116](https://github.com/microsoft/conductor/issues/116)). Three
+  changes work together to make any crash forensically traceable:
+  - `conductor.cli.bg_runner` now captures the detached child's stdout
+    and stderr to log files in `$TMPDIR/conductor/` (named to match the
+    existing `.events.jsonl` filename) instead of discarding them with
+    `subprocess.DEVNULL`. A Python traceback or `faulthandler` dump from
+    the child now survives the parent's exit. The captured stderr path
+    is printed alongside the dashboard URL and is included in every
+    background-launch failure message so users always know where to
+    look.
+  - `conductor/__init__.py` enables `faulthandler` at import time
+    (writing to `sys.__stderr__`), so a native crash — segfault, abort,
+    fatal Python error — dumps a Python-level stack trace into the
+    captured stderr log.
+  - `WorkflowEngine._execute_loop` now catches `BaseException` (in
+    addition to the existing `KeyboardInterrupt` / `ConductorError` /
+    `Exception` arms) and emits a `workflow_failed` event with
+    `is_base_exception: true` before re-raising. A bare `SystemExit` or
+    other non-`Exception` failure between `agent_started` and
+    `agent_prompt_rendered` now leaves a structured failure event in the
+    JSONL log instead of an unexplained two-event truncation. An
+    explicit `except asyncio.CancelledError: raise` arm sits in front of
+    it so a normal dashboard-stop or parent cancellation is not
+    mis-reported as an unexpected failure.
+  Two new env vars (`CONDUCTOR_RUN_ID`, `CONDUCTOR_BG_STDERR_LOG`,
+  `CONDUCTOR_BG_STDOUT_LOG`) propagate the parent-chosen run id and log
+  paths to the child so the bg log files and the child's events JSONL
+  share an 8-hex run id in their filenames, and `workflow_started`
+  system metadata surfaces both bg log paths to the dashboard. The root
+  cause of the underlying intermittent Windows crash is still pending —
+  this change makes it diagnosable rather than invisible.
+
 - Workflows that configure `reasoning.effort` (or workflow-wide
   `runtime.default_reasoning_effort`) on the Copilot provider were broken
   for **every named Copilot model** when running against

--- a/src/conductor/__init__.py
+++ b/src/conductor/__init__.py
@@ -30,6 +30,39 @@ Modules:
     exceptions: Custom exception hierarchy.
 """
 
+# Enable Python's ``faulthandler`` as early as possible — before any other
+# conductor import — so a native crash (segfault, abort, fatal Python error)
+# anywhere in the process dumps a traceback to the original stderr stream.
+# This is the earliest module imported by both ``python -m conductor`` (via
+# ``conductor.__main__``) and the installed ``conductor`` console script
+# (``conductor.cli.app:app`` in ``pyproject.toml``), so this single hook
+# covers every launch path.
+#
+# In ``--web-bg`` mode the parent passes a redirected stderr file handle to
+# ``subprocess.Popen`` (see ``conductor.cli.bg_runner``); when Python
+# initialises in the child process, ``sys.__stderr__`` already points at
+# that captured log file, so the crash trace survives the parent's exit.
+# See issue #116 for context.
+import sys as _sys
+
+try:
+    import faulthandler as _faulthandler
+
+    if _sys.__stderr__ is not None:
+        _faulthandler.enable(file=_sys.__stderr__, all_threads=True)
+except Exception as _faulthandler_exc:  # noqa: BLE001 - diagnostics must never break startup
+    # The very diagnostic this PR adds is dead if this silently fails;
+    # print a warning so the user knows the crash trace will not survive
+    # a native abort. Use ``sys.stderr`` (not ``sys.__stderr__``) because
+    # the original stderr may itself be the source of the failure.
+    try:  # noqa: SIM105 - cannot use contextlib.suppress here without an import
+        print(
+            f"conductor: WARNING: faulthandler failed to initialize: {_faulthandler_exc}",
+            file=_sys.stderr,
+        )
+    except Exception:  # noqa: BLE001 - really, truly must not break startup
+        pass
+
 from importlib.metadata import version as _pkg_version
 
 __version__ = _pkg_version("conductor-cli")

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -422,7 +422,7 @@ def run(
         from conductor.cli.bg_runner import launch_background
 
         try:
-            url = launch_background(
+            launch = launch_background(
                 workflow_path=workflow_path,
                 inputs=inputs,
                 provider_override=provider,
@@ -434,7 +434,8 @@ def run(
                 workspace_instructions=workspace_instructions,
                 cli_instructions=raw_instructions,
             )
-            console.print(f"[bold cyan]Dashboard:[/bold cyan] {url}")
+            console.print(f"[bold cyan]Dashboard:[/bold cyan] {launch.url}")
+            console.print(f"[dim]Child stderr log: {launch.stderr_log}[/dim]")
             console.print(
                 "[dim]Workflow running in background. Dashboard auto-shuts down after "
                 "workflow completes and all clients disconnect.[/dim]"
@@ -834,7 +835,7 @@ def resume(
         from conductor.cli.bg_runner import launch_background_resume
 
         try:
-            url = launch_background_resume(
+            launch = launch_background_resume(
                 workflow_path=resolved_workflow,
                 checkpoint_path=resolved_checkpoint,
                 provider_override=provider,
@@ -843,7 +844,8 @@ def resume(
                 web_port=web_port,
                 metadata=cli_metadata,
             )
-            console.print(f"[bold cyan]Dashboard:[/bold cyan] {url}")
+            console.print(f"[bold cyan]Dashboard:[/bold cyan] {launch.url}")
+            console.print(f"[dim]Child stderr log: {launch.stderr_log}[/dim]")
             console.print(
                 "[dim]Resumed workflow running in background. Dashboard auto-shuts down after "
                 "workflow completes and all clients disconnect.[/dim]"

--- a/src/conductor/cli/bg_runner.py
+++ b/src/conductor/cli/bg_runner.py
@@ -10,12 +10,18 @@ Windows) so it outlives the parent. It auto-shuts down after the workflow
 completes and all WebSocket clients disconnect (the existing ``--web`` +
 ``bg=True`` behavior in ``WebDashboard``).
 
-The child's stdout/stderr/stdin are redirected to ``DEVNULL`` in the Popen
-call, not suppressed via ``--silent``. This is a deliberate design choice:
-``--silent`` would also set ``verbose_mode=False``, which gates provider-side
-SDK event logging that ``--log-file`` writes to disk. Relying on DEVNULL
-keeps the file log populated for detached children where the user has no
-other way to observe runtime behavior (see issue #196).
+The child's stdout and stderr are redirected into log files under
+``$TMPDIR/conductor/`` (not ``DEVNULL``) so a silent crash — an uncaught
+Python exception, a ``faulthandler`` dump, or anything else the child
+would normally write to ``sys.stderr`` — leaves a forensic trail. See
+issue #116 for context.
+
+This is also why we deliberately do NOT pass ``--silent`` to the child
+even though no human is watching its console: ``--silent`` would also
+set ``verbose_mode=False``, which gates provider-side SDK event logging
+that ``--log-file`` writes to disk. Leaving verbosity at the default and
+capturing the stream to a file keeps both the log files and any
+``--log-file`` trace populated for detached children (see issue #196).
 """
 
 from __future__ import annotations
@@ -23,10 +29,15 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import re
+import secrets
 import socket
 import subprocess
 import sys
+import tempfile
 import time
+from dataclasses import dataclass
+from io import IOBase
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +52,8 @@ _CREATE_BREAKAWAY_FROM_JOB: int = getattr(subprocess, "CREATE_BREAKAWAY_FROM_JOB
 # called with ``CREATE_BREAKAWAY_FROM_JOB`` and the parent's job object has
 # ``JOB_OBJECT_LIMIT_BREAKAWAY_OK`` cleared (some hardened CI environments).
 _ERROR_ACCESS_DENIED = 5
+
+_RUN_ID_PATTERN_LOCAL = re.compile(r"[0-9a-f]{8}")
 
 
 def _detachment_kwargs() -> dict[str, Any]:
@@ -85,12 +98,22 @@ def _is_breakaway_denied(exc: OSError) -> bool:
     return getattr(exc, "winerror", None) == _ERROR_ACCESS_DENIED
 
 
-def _spawn_detached(cmd: list[str], env: dict[str, str]) -> subprocess.Popen[Any]:
+def _spawn_detached(
+    cmd: list[str],
+    env: dict[str, str],
+    *,
+    stdout: Any = subprocess.DEVNULL,
+    stderr: Any = subprocess.DEVNULL,
+    stdin: Any = subprocess.DEVNULL,
+) -> subprocess.Popen[Any]:
     """Launch a fully-detached child process for ``--web-bg`` mode.
 
-    Composes DEVNULL stdio + the supplied environment + the platform-specific
+    Composes the supplied stdio + environment + the platform-specific
     detachment kwargs from :func:`_detachment_kwargs`, then calls
-    ``subprocess.Popen``.
+    ``subprocess.Popen``. The default stdio is ``DEVNULL`` for all three
+    streams; callers that need to capture the child's stderr/stdout
+    (for diagnostics — see issue #116) can pass open file handles via
+    the ``stdout`` / ``stderr`` kwargs.
 
     On Windows, if the Popen call fails with ``ERROR_ACCESS_DENIED`` because
     the parent's job object forbids breakaway, prints a visible warning to
@@ -102,7 +125,13 @@ def _spawn_detached(cmd: list[str], env: dict[str, str]) -> subprocess.Popen[Any
     Args:
         cmd: The fully-resolved command-line argv to execute.
         env: The environment dict to pass to the child (callers prepare this
-            with ``CONDUCTOR_WEB_BG`` / ``CONDUCTOR_WEB_PORT`` set).
+            via :func:`_build_bg_env` with ``CONDUCTOR_WEB_BG`` /
+            ``CONDUCTOR_WEB_PORT`` and the bg-diagnostics vars set).
+        stdout: Popen ``stdout`` argument; defaults to ``DEVNULL``. Pass
+            an open file handle to capture the child's stdout.
+        stderr: Popen ``stderr`` argument; defaults to ``DEVNULL``. Pass
+            an open file handle to capture the child's stderr.
+        stdin: Popen ``stdin`` argument; defaults to ``DEVNULL``.
 
     Returns:
         The running :class:`subprocess.Popen` handle for the detached child.
@@ -113,9 +142,9 @@ def _spawn_detached(cmd: list[str], env: dict[str, str]) -> subprocess.Popen[Any
             missing executable). Callers wrap this in a ``RuntimeError``.
     """
     base: dict[str, Any] = {
-        "stdout": subprocess.DEVNULL,
-        "stderr": subprocess.DEVNULL,
-        "stdin": subprocess.DEVNULL,
+        "stdout": stdout,
+        "stderr": stderr,
+        "stdin": stdin,
         "env": env,
     }
     try:
@@ -136,23 +165,49 @@ def _spawn_detached(cmd: list[str], env: dict[str, str]) -> subprocess.Popen[Any
         )
 
 
-def _bg_child_env(web_port: int) -> dict[str, str]:
-    """Build the child-process environment for ``--web-bg`` mode.
+@dataclass(frozen=True, slots=True)
+class BackgroundLaunch:
+    """Result of launching a ``--web-bg`` child process.
 
-    Copies the current environment and sets the two signals the detached
-    child reads to enable bg-specific behavior in the web dashboard.
+    Attributes:
+        url: The dashboard URL (e.g. ``http://127.0.0.1:8080``).
+        stderr_log: Path to the file capturing the child's stderr — the
+            first place to look when a bg run misbehaves silently.
+        stdout_log: Path to the file capturing the child's stdout.
+        run_id: 8-hex-character run id that ties this bg launch to its
+            ``.events.jsonl`` peer via ``CONDUCTOR_RUN_ID``.
 
-    Args:
-        web_port: The port the child's dashboard will listen on. Recorded
-            in ``CONDUCTOR_WEB_PORT`` so the child can rebind if needed.
-
-    Returns:
-        A new environment dict suitable for passing to ``subprocess.Popen``.
+    Invariants (enforced in ``__post_init__``):
+        * ``run_id`` is exactly 8 lowercase hex characters.
+        * ``url`` is a localhost URL (``http://127.0.0.1:<port>``).
+        * ``run_id`` appears in both ``stderr_log.name`` and
+          ``stdout_log.name`` — this is what lets the bg log files and
+          the child's ``.events.jsonl`` correlate by filename. See
+          ``_open_bg_log_files``.
     """
-    env = os.environ.copy()
-    env["CONDUCTOR_WEB_BG"] = "1"
-    env["CONDUCTOR_WEB_PORT"] = str(web_port)
-    return env
+
+    url: str
+    stderr_log: Path
+    stdout_log: Path
+    run_id: str
+
+    def __post_init__(self) -> None:
+        if not _RUN_ID_PATTERN_LOCAL.fullmatch(self.run_id):
+            raise ValueError(
+                f"BackgroundLaunch.run_id must be 8 lowercase hex chars, got: {self.run_id!r}"
+            )
+        if not self.url.startswith("http://127.0.0.1:"):
+            raise ValueError(f"BackgroundLaunch.url must be a localhost URL, got: {self.url!r}")
+        if self.run_id not in self.stderr_log.name:
+            raise ValueError(
+                f"BackgroundLaunch.run_id {self.run_id!r} not embedded in "
+                f"stderr_log filename {self.stderr_log.name!r}"
+            )
+        if self.run_id not in self.stdout_log.name:
+            raise ValueError(
+                f"BackgroundLaunch.run_id {self.run_id!r} not embedded in "
+                f"stdout_log filename {self.stdout_log.name!r}"
+            )
 
 
 def _find_free_port() -> int:
@@ -210,22 +265,110 @@ def _terminate_child(proc: subprocess.Popen[Any]) -> None:
         pass
 
 
+# Filename pattern used by ``conductor.engine.event_log.EventLogSubscriber``
+# for the events JSONL file. The bg stderr/stdout log files share the same
+# ``<ts>-<runid>`` infix so all three artefacts for a single bg run sort
+# next to each other in ``$TMPDIR/conductor/``.
+_LOG_FILENAME_SAFE_NAME = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _sanitize_name(name: str) -> str:
+    """Strip path-unsafe characters out of a workflow filename stem."""
+    cleaned = _LOG_FILENAME_SAFE_NAME.sub("-", name).strip("-")
+    return cleaned or "workflow"
+
+
+def _open_bg_log_files(workflow_ref: Path) -> tuple[str, Path, Path, IOBase, IOBase]:
+    """Create the bg child's stderr/stdout log files and return open handles.
+
+    Generates a fresh 8-hex-character run id and opens two log files in
+    ``$TMPDIR/conductor/`` whose names match the convention used by
+    ``EventLogSubscriber`` (timestamp + run id) so all three artefacts of a
+    single bg run group together by filename.
+
+    The caller is responsible for closing the returned handles once
+    ``subprocess.Popen`` has returned (the child has its own inherited OS
+    handles by that point).
+
+    Args:
+        workflow_ref: The workflow file (or checkpoint) used to derive the
+            ``<name>`` segment of the filename.
+
+    Returns:
+        Tuple of ``(run_id, stderr_path, stdout_path, stderr_handle,
+        stdout_handle)``.
+
+    Raises:
+        OSError: If the log directory cannot be created or the files
+            cannot be opened. The caller is expected to surface this as a
+            ``RuntimeError`` with context.
+    """
+    run_id = secrets.token_hex(4)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    base = _sanitize_name(workflow_ref.stem) if workflow_ref.stem else "workflow"
+    log_dir = Path(tempfile.gettempdir()) / "conductor"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    stderr_path = log_dir / f"conductor-{base}-{ts}-{run_id}.bg.stderr.log"
+    stdout_path = log_dir / f"conductor-{base}-{ts}-{run_id}.bg.stdout.log"
+    # Line-buffered text mode so a tail of the file shows fresh output as
+    # the child writes it. ``errors="replace"`` keeps the file readable
+    # even if the child emits invalid UTF-8 (e.g. raw bytes from a
+    # mis-encoded subprocess).
+    stderr_handle = open(  # noqa: SIM115 - caller closes after Popen
+        stderr_path, "w", encoding="utf-8", errors="replace", buffering=1
+    )
+    stdout_handle = open(  # noqa: SIM115 - caller closes after Popen
+        stdout_path, "w", encoding="utf-8", errors="replace", buffering=1
+    )
+    return run_id, stderr_path, stdout_path, stderr_handle, stdout_handle
+
+
+def _close_quietly(*handles: IOBase) -> None:
+    """Close file handles, logging close errors to stderr but never raising.
+
+    The parent's stdout/stderr file handles for the bg child should be
+    released as soon as ``Popen`` returns (the child has its own duplicated
+    OS handles by then), but ``handle.close()`` can still raise — most
+    notably ``OSError`` from a buffer flush on a disk-full filesystem, or
+    a Windows ``PermissionError`` if antivirus is scanning the file. The
+    captured-log promise (#116) would be quietly broken in those cases,
+    so print a warning to the parent's real stderr instead of suppressing
+    silently. Never raise — callers run this in cleanup paths where
+    propagating would mask an earlier, more relevant exception.
+    """
+    for h in handles:
+        try:
+            h.close()
+        except Exception as exc:  # noqa: BLE001 - cleanup must not raise
+            name = getattr(h, "name", "<unknown handle>")
+            print(
+                f"conductor: WARNING: failed to close bg log handle {name}: {exc}",
+                file=sys.stderr,
+            )
+
+
 def _finalize_background_launch(
     proc: subprocess.Popen[Any],
     web_port: int,
     pid_workflow_ref: Path,
+    stderr_log: Path,
 ) -> None:
     """Wait for the dashboard to come up and write the PID file.
 
     On any failure (server didn't start, child died early, PID write raised),
     the still-running child is terminated to avoid orphaned processes holding
-    the dashboard port without a discoverable PID file.
+    the dashboard port without a discoverable PID file. The stderr log path
+    is included in the RuntimeError so callers can point users at the
+    captured crash output.
 
     Args:
         proc: The detached child process.
         web_port: The TCP port the child should be listening on.
         pid_workflow_ref: Path used to derive the PID file name and recorded
             inside it for ``conductor stop`` to display.
+        stderr_log: Path to the file capturing the child's stderr. Included
+            in failure messages so users know where to look.
 
     Raises:
         RuntimeError: If the child died early, the dashboard didn't start
@@ -236,12 +379,13 @@ def _finalize_background_launch(
         if retcode is not None:
             raise RuntimeError(
                 f"Background process exited immediately with code {retcode}. "
-                f"Check logs or run without --web-bg for details."
+                f"See child stderr log: {stderr_log}"
             )
         _terminate_child(proc)
         raise RuntimeError(
             f"Dashboard did not start within 15 seconds on port {web_port}. "
-            f"The background process was terminated."
+            f"The background process was terminated. "
+            f"See child stderr log: {stderr_log}"
         )
 
     from conductor.cli.pid import write_pid_file
@@ -250,7 +394,106 @@ def _finalize_background_launch(
         write_pid_file(proc.pid, web_port, pid_workflow_ref)
     except Exception as exc:
         _terminate_child(proc)
-        raise RuntimeError(f"Failed to write PID file for background process: {exc}") from exc
+        raise RuntimeError(
+            f"Failed to write PID file for background process: {exc}. "
+            f"See child stderr log: {stderr_log}"
+        ) from exc
+
+
+def _build_bg_env(
+    run_id: str,
+    web_port: int,
+    stderr_log: Path,
+    stdout_log: Path,
+) -> dict[str, str]:
+    """Compose the child's environment with the bg-diagnostics env vars.
+
+    Args:
+        run_id: 8-hex-character run id shared with ``EventLogSubscriber`` so
+            the events JSONL and bg log files use the same id in filenames
+            and ``workflow_started`` system metadata.
+        web_port: The TCP port the child should listen on.
+        stderr_log: Path to the child's captured stderr log file.
+        stdout_log: Path to the child's captured stdout log file.
+
+    Returns:
+        The new environment dict for ``subprocess.Popen``.
+    """
+    env = os.environ.copy()
+    env["CONDUCTOR_WEB_BG"] = "1"
+    env["CONDUCTOR_WEB_PORT"] = str(web_port)
+    env["CONDUCTOR_RUN_ID"] = run_id
+    env["CONDUCTOR_BG_STDERR_LOG"] = str(stderr_log)
+    env["CONDUCTOR_BG_STDOUT_LOG"] = str(stdout_log)
+    return env
+
+
+def _spawn_bg_child(
+    *,
+    cmd: list[str],
+    web_port: int,
+    pid_workflow_ref: Path,
+) -> BackgroundLaunch:
+    """Open the bg log files, spawn the detached child, and finalize the launch.
+
+    Shared tail of both ``launch_background`` and ``launch_background_resume``.
+    Keeping these steps in a single place is what guarantees the two paths
+    cannot drift apart on the detachment flags, the stderr/stdout redirect,
+    or the env-var contract that ``EventLogSubscriber`` and
+    ``WorkflowEngine._build_system_metadata`` depend on. See issue #116.
+
+    Args:
+        cmd: Fully assembled subprocess command (already includes ``--silent``,
+            the subcommand, ``--web``, ``--no-interactive``, etc.).
+        web_port: The TCP port the child should listen on.
+        pid_workflow_ref: Workflow or checkpoint path used both as the source
+            of the log filename stem and as the PID file's recorded reference.
+
+    Returns:
+        ``BackgroundLaunch`` describing the live launch.
+
+    Raises:
+        RuntimeError: If the log files cannot be created, the child fails to
+            start, or the dashboard doesn't become reachable.
+    """
+    try:
+        run_id, stderr_path, stdout_path, stderr_handle, stdout_handle = _open_bg_log_files(
+            pid_workflow_ref
+        )
+    except OSError as exc:
+        raise RuntimeError(f"Failed to create background log files: {exc}") from exc
+
+    # Spawn the detached child via the shared helper so the platform-
+    # appropriate detachment kwargs — including Windows job breakaway and
+    # the access-denied fallback — apply uniformly. Pass the log file
+    # handles as stdio overrides so the child's output is captured (see
+    # issue #116) instead of dropped on the floor.
+    try:
+        try:
+            proc = _spawn_detached(
+                cmd,
+                _build_bg_env(run_id, web_port, stderr_path, stdout_path),
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to start background process: {exc}. See child stderr log: {stderr_path}"
+            ) from exc
+
+        _finalize_background_launch(proc, web_port, pid_workflow_ref, stderr_path)
+    finally:
+        # The child has its own duplicated OS handles by now (or never got
+        # them, if Popen raised) — either way the parent's Python file
+        # objects can be released without affecting the child.
+        _close_quietly(stderr_handle, stdout_handle)
+
+    return BackgroundLaunch(
+        url=f"http://127.0.0.1:{web_port}",
+        stderr_log=stderr_path,
+        stdout_log=stdout_path,
+        run_id=run_id,
+    )
 
 
 def launch_background(
@@ -265,12 +508,13 @@ def launch_background(
     metadata: dict[str, str] | None = None,
     workspace_instructions: bool = False,
     cli_instructions: list[str] | None = None,
-) -> str:
+) -> BackgroundLaunch:
     """Fork a detached child process running the workflow with a web dashboard.
 
     The child executes ``conductor run <workflow> --web --web-port <port>``
     with all the caller-supplied options. The parent waits briefly for the
-    web server to become reachable, then returns the dashboard URL.
+    web server to become reachable, then returns the dashboard URL and the
+    path to the child's captured stderr log.
 
     Args:
         workflow_path: Path to the workflow YAML file.
@@ -285,7 +529,8 @@ def launch_background(
         cli_instructions: Optional list of instruction file paths.
 
     Returns:
-        The dashboard URL (e.g. ``http://127.0.0.1:8080``).
+        A ``BackgroundLaunch`` describing the launch (dashboard URL,
+        captured stderr/stdout log paths, run id).
 
     Raises:
         RuntimeError: If the child process fails to start or the server
@@ -337,15 +582,7 @@ def launch_background(
         for instr_path in cli_instructions:
             cmd.extend(["--instructions", instr_path])
 
-    # Launch detached child with platform-appropriate detachment kwargs.
-    try:
-        proc = _spawn_detached(cmd, _bg_child_env(web_port))
-    except Exception as exc:
-        raise RuntimeError(f"Failed to start background process: {exc}") from exc
-
-    _finalize_background_launch(proc, web_port, workflow_path)
-
-    return f"http://127.0.0.1:{web_port}"
+    return _spawn_bg_child(cmd=cmd, web_port=web_port, pid_workflow_ref=workflow_path)
 
 
 def launch_background_resume(
@@ -357,13 +594,14 @@ def launch_background_resume(
     log_file: Path | None = None,
     web_port: int = 0,
     metadata: dict[str, str] | None = None,
-) -> str:
+) -> BackgroundLaunch:
     """Fork a detached child process resuming the workflow with a web dashboard.
 
     The child executes ``conductor resume <workflow|--from path> --web ...``
     with all the caller-supplied options. ``--no-interactive`` is always
     appended since the detached child has no TTY. The parent waits briefly
-    for the web server to become reachable, then returns the dashboard URL.
+    for the web server to become reachable, then returns the dashboard URL
+    and the path to the child's captured stderr log.
 
     Either ``workflow_path`` or ``checkpoint_path`` (or both) must be
     provided — at least one is required by the resume command.
@@ -379,7 +617,8 @@ def launch_background_resume(
         metadata: Optional CLI metadata key=value pairs.
 
     Returns:
-        The dashboard URL (e.g. ``http://127.0.0.1:8080``).
+        A ``BackgroundLaunch`` describing the launch (dashboard URL,
+        captured stderr/stdout log paths, run id).
 
     Raises:
         ValueError: If neither ``workflow_path`` nor ``checkpoint_path`` is
@@ -437,24 +676,13 @@ def launch_background_resume(
     if log_file:
         cmd.extend(["--log-file", str(log_file)])
 
-    # Launch detached child with platform-appropriate detachment kwargs.
-    try:
-        proc = _spawn_detached(cmd, _bg_child_env(web_port))
-    except Exception as exc:
-        raise RuntimeError(f"Failed to start background process: {exc}") from exc
-
     # Use workflow_path if available, otherwise fall back to checkpoint_path
-    # for the PID file name and recorded reference.
-    pid_workflow_ref = workflow_path if workflow_path is not None else checkpoint_path
-    if pid_workflow_ref is None:  # pragma: no cover - guarded above
-        _terminate_child(proc)
-        raise ValueError(
-            "launch_background_resume requires either workflow_path or checkpoint_path"
-        )
+    # for the PID file name, log file naming, and recorded reference. The
+    # early guard at the top of this function already rejected the case
+    # where both are None; the ``or`` here picks the first non-None.
+    pid_workflow_ref: Path = workflow_path or checkpoint_path  # type: ignore[assignment]
 
-    _finalize_background_launch(proc, web_port, pid_workflow_ref)
-
-    return f"http://127.0.0.1:{web_port}"
+    return _spawn_bg_child(cmd=cmd, web_port=web_port, pid_workflow_ref=pid_workflow_ref)
 
 
 def _serialize_value(value: Any) -> str:

--- a/src/conductor/engine/event_log.py
+++ b/src/conductor/engine/event_log.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import re
+import secrets
 import tempfile
 import time
 from pathlib import Path
@@ -28,6 +31,13 @@ from typing import Any
 from conductor.events import WorkflowEvent
 
 logger = logging.getLogger(__name__)
+
+# ``CONDUCTOR_RUN_ID`` is set by ``conductor.cli.bg_runner`` when launching a
+# ``--web-bg`` child. We validate it as a short hex string before using it in
+# a filename, both to keep the filename path-safe and to reject accidental
+# injection via the env var. 32 hex characters is the upper bound — enough
+# for any reasonable run-id format including a SHA1 prefix.
+_RUN_ID_PATTERN = re.compile(r"[0-9a-fA-F]{1,32}")
 
 
 def _make_json_safe(obj: Any) -> Any:
@@ -81,9 +91,15 @@ class EventLogSubscriber:
             existing_run_id: The run identifier associated with
                 ``existing_path``. Reused (not regenerated) so log /
                 timeline correlation tools see one continuous run.
-        """
-        import secrets
 
+        When neither ``existing_path`` nor ``existing_run_id`` is
+        provided, the run id is taken from the ``CONDUCTOR_RUN_ID``
+        environment variable when it is set to a short hex string —
+        used by :mod:`conductor.cli.bg_runner` to propagate the
+        parent-chosen run id to the detached child so all artefacts
+        of a single bg run share the same id in their filenames (see
+        issue #116). Otherwise a fresh random id is generated.
+        """
         if (
             existing_path is not None
             and existing_run_id
@@ -105,15 +121,29 @@ class EventLogSubscriber:
                     exc_info=True,
                 )
 
+        # Fall through to a fresh log file. When a parent (e.g.
+        # ``conductor.cli.bg_runner``) launches us with ``CONDUCTOR_RUN_ID``
+        # set, honour it so the parent-created bg stderr/stdout log files
+        # and this child's ``.events.jsonl`` file share a run id in their
+        # filenames and cross-correlate. Fall back to a fresh random id
+        # otherwise. See issue #116.
+        env_run_id = os.environ.get("CONDUCTOR_RUN_ID", "")
+        if env_run_id and _RUN_ID_PATTERN.fullmatch(env_run_id):
+            self._run_id = env_run_id.lower()
+        else:
+            if env_run_id:
+                # Malformed env value — log so a typo in a wrapper script
+                # doesn't silently disable bg log correlation.
+                logger.debug(
+                    "Ignoring malformed CONDUCTOR_RUN_ID=%r; using random id",
+                    env_run_id,
+                )
+            self._run_id = secrets.token_hex(4)
         ts = time.strftime("%Y%m%d-%H%M%S")
-        # Append random suffix to avoid filename collisions
-        # when multiple runs start in the same second
-        self._run_id = secrets.token_hex(4)
-        ts = f"{ts}-{self._run_id}"
         self._path = (
             Path(tempfile.gettempdir())
             / "conductor"
-            / f"conductor-{workflow_name}-{ts}.events.jsonl"
+            / f"conductor-{workflow_name}-{ts}-{self._run_id}.events.jsonl"
         )
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._handle = open(self._path, "w", encoding="utf-8")  # noqa: SIM115

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -537,6 +537,17 @@ class WorkflowEngine:
         # Parent PID is useful in --web-bg to trace back to the forking CLI process
         if self._bg_mode:
             system["parent_pid"] = os.getppid()
+            # Surface the bg child's captured stderr/stdout log paths so a
+            # user looking at the dashboard or replaying the events JSONL
+            # can find the matching console output. Set by
+            # ``conductor.cli.bg_runner`` when launching the child. See
+            # issue #116.
+            bg_stderr_log = os.environ.get("CONDUCTOR_BG_STDERR_LOG")
+            if bg_stderr_log:
+                system["bg_stderr_log"] = bg_stderr_log
+            bg_stdout_log = os.environ.get("CONDUCTOR_BG_STDOUT_LOG")
+            if bg_stdout_log:
+                system["bg_stdout_log"] = bg_stdout_log
 
         return system
 
@@ -2630,6 +2641,69 @@ class WorkflowEngine:
             # Execute on_error hook for unexpected errors
             self._execute_hook("on_error", error=e)
             self._save_checkpoint_on_failure(e)
+            raise
+        except asyncio.CancelledError:
+            # Normal cancellation path (dashboard stop, parent process exit,
+            # outer ``asyncio.wait_for`` timeout). The caller — typically
+            # ``conductor.cli.run._run_with_stop_signal`` — re-frames the
+            # cancellation as a ConductorError and emits the appropriate
+            # event there. Do NOT emit ``workflow_failed`` here, or the
+            # dashboard would show a spurious "CancelledError" failure
+            # whenever a user clicks Stop.
+            #
+            # No checkpoint is saved on cancellation: cancelled workflows
+            # are not resumable from this point — the user explicitly chose
+            # to stop, and the wrapper-issued ConductorError will trigger
+            # checkpoint save through the ``except ConductorError`` arm on
+            # its way out. See issue #116 review.
+            raise
+        except BaseException as e:
+            # Catch-all for exception classes that don't derive from
+            # ``Exception`` (e.g. ``SystemExit`` raised by a misbehaving
+            # library, fatal runtime errors). Without this arm the silent
+            # Windows startup crash (#116) leaves no ``workflow_failed``
+            # event in the JSONL log, making the failure invisible.
+            #
+            # NOTE: we deliberately do NOT invoke ``on_error`` lifecycle
+            # hooks here. Their declared signature accepts ``Exception |
+            # None``, so user-defined hooks may assume ``e.args`` /
+            # ``traceback`` semantics that don't hold for ``SystemExit``,
+            # and surfacing a process-exit signal to them would change
+            # their contract. Users who need hook-like notification for
+            # ``BaseException`` failures should subscribe to the
+            # ``workflow_failed`` event and check ``is_base_exception``.
+            #
+            # The diagnostic side effects below (``_emit``,
+            # ``_save_checkpoint_on_failure``) are wrapped in their own
+            # ``try/except`` blocks: if either of them raised here, the
+            # raised side-effect exception would replace the original
+            # ``BaseException`` on its way out of this handler, masking
+            # the exact crash we're trying to surface. Print a warning to
+            # stderr instead so the diagnostic regression is visible, but
+            # the ``raise`` at the end always re-raises the *original* ``e``.
+            try:
+                self._emit(
+                    "workflow_failed",
+                    {
+                        "error_type": type(e).__name__,
+                        "message": str(e),
+                        "agent_name": self._current_agent_name,
+                        "is_base_exception": True,
+                    },
+                )
+            except Exception as emit_exc:  # noqa: BLE001 - must not mask `e`
+                print(
+                    f"conductor: WARNING: failed to emit workflow_failed for "
+                    f"{type(e).__name__}: {emit_exc}",
+                    file=sys.stderr,
+                )
+            try:
+                self._save_checkpoint_on_failure(e)
+            except Exception as ckpt_exc:  # noqa: BLE001 - must not mask `e`
+                print(
+                    f"conductor: WARNING: checkpoint save raised unexpectedly: {ckpt_exc}",
+                    file=sys.stderr,
+                )
             raise
 
     # Type-appropriate zero values for optional inputs with no declared default.

--- a/tests/test_cli/test_bg_runner.py
+++ b/tests/test_cli/test_bg_runner.py
@@ -1,24 +1,30 @@
-"""Tests for ``bg_runner`` helpers: detachment kwargs and detached spawn.
+"""Tests for ``conductor.cli.bg_runner``.
 
-Covers the Windows job-breakaway fix from issue #195:
+Covers two issues that landed together:
 
-- ``_detachment_kwargs`` returns the right kwargs for POSIX vs Windows.
-- ``_spawn_detached`` happy path requests breakaway on Windows.
-- ``_spawn_detached`` falls back to plain ``CREATE_NEW_PROCESS_GROUP`` and
+- **#195 / Windows job breakaway**: ``_detachment_kwargs`` returns the right
+  kwargs for POSIX vs Windows; ``_spawn_detached`` happy path requests
+  breakaway on Windows, falls back to plain ``CREATE_NEW_PROCESS_GROUP`` and
   prints a stderr warning when the parent's Windows job forbids breakaway
-  (``OSError`` with ``winerror == 5``).
-- Non-breakaway ``OSError`` (e.g. ``winerror == 2``, "file not found")
-  propagates from the first ``Popen`` call without a retry.
-- POSIX paths never retry on ``OSError``.
-- Both ``launch_background`` and ``launch_background_resume`` route their
-  Popen call through ``_spawn_detached`` (i.e., the Windows breakaway flag
-  is set in both run and resume paths).
+  (``OSError`` with ``winerror == 5``); non-breakaway ``OSError`` propagates
+  without retry; POSIX paths never retry on ``OSError``; both
+  ``launch_background`` and ``launch_background_resume`` route their Popen
+  call through ``_spawn_detached``.
+- **#116 / bg diagnostics**: parent-side bookkeeping for the captured
+  stderr/stdout log files — log-file creation, env-var wiring,
+  error-message threading, handle cleanup, and the ``_sanitize_name`` helper
+  used to build the log filename.
+
+Neither group of tests actually spawns a child process. ``subprocess.Popen``
+is patched in every test so nothing leaks into the test runner.
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -244,13 +250,13 @@ class TestLaunchBackgroundRoutesThroughSpawnDetached:
             patch.object(bg_runner, "_wait_for_server", return_value=True),
             patch("conductor.cli.pid.write_pid_file"),
         ):
-            url = bg_runner.launch_background(
+            launch = bg_runner.launch_background(
                 workflow_path=wf_path,
                 inputs={"q": "hello"},
                 web_port=9301,
             )
 
-        assert url == "http://127.0.0.1:9301"
+        assert launch.url == "http://127.0.0.1:9301"
         mock_spawn.assert_called_once()
         # _spawn_detached is called positionally: (cmd, env).
         cmd = mock_spawn.call_args.args[0]
@@ -273,13 +279,13 @@ class TestLaunchBackgroundRoutesThroughSpawnDetached:
             patch.object(bg_runner, "_wait_for_server", return_value=True),
             patch("conductor.cli.pid.write_pid_file"),
         ):
-            url = bg_runner.launch_background_resume(
+            launch = bg_runner.launch_background_resume(
                 workflow_path=wf_path,
                 checkpoint_path=None,
                 web_port=9302,
             )
 
-        assert url == "http://127.0.0.1:9302"
+        assert launch.url == "http://127.0.0.1:9302"
         mock_spawn.assert_called_once()
         cmd = mock_spawn.call_args.args[0]
         env = mock_spawn.call_args.args[1]
@@ -353,3 +359,286 @@ class TestCreationFlagConstants:
 
         assert bg_runner._CREATE_NEW_PROCESS_GROUP == subprocess.CREATE_NEW_PROCESS_GROUP
         assert bg_runner._CREATE_BREAKAWAY_FROM_JOB == subprocess.CREATE_BREAKAWAY_FROM_JOB
+
+
+def _write_workflow(tmp_path: Path) -> Path:
+    wf_path = tmp_path / "test-wf.yaml"
+    wf_path.write_text("workflow: {name: x, entry_point: a}\nagents: []\n")
+    return wf_path
+
+
+@pytest.fixture(autouse=True)
+def _clean_bg_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no parent CONDUCTOR_* bg env vars leak between tests."""
+    for key in (
+        "CONDUCTOR_RUN_ID",
+        "CONDUCTOR_BG_STDERR_LOG",
+        "CONDUCTOR_BG_STDOUT_LOG",
+        "CONDUCTOR_WEB_BG",
+        "CONDUCTOR_WEB_PORT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# launch_background diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchBackgroundDiagnostics:
+    """Diagnostics-side behaviour of ``launch_background`` (issue #116)."""
+
+    def test_returns_structured_launch_with_log_paths(self, tmp_path: Path) -> None:
+        """``launch_background`` returns a ``BackgroundLaunch`` with both log paths."""
+        from conductor.cli import bg_runner
+
+        wf_path = _write_workflow(tmp_path)
+
+        def _fake_popen(cmd: list[str], **kwargs: Any) -> MagicMock:
+            proc = MagicMock()
+            proc.pid = 1234
+            proc.poll.return_value = None
+            return proc
+
+        with (
+            patch("conductor.cli.bg_runner.subprocess.Popen", side_effect=_fake_popen),
+            patch("conductor.cli.bg_runner._wait_for_server", return_value=True),
+            patch("conductor.cli.pid.write_pid_file"),
+        ):
+            launch = bg_runner.launch_background(
+                workflow_path=wf_path,
+                inputs={},
+                web_port=9300,
+            )
+
+        assert launch.url == "http://127.0.0.1:9300"
+        assert launch.stderr_log.name.endswith(".bg.stderr.log")
+        assert launch.stdout_log.name.endswith(".bg.stdout.log")
+        # 8-hex-character run id, suitable for filename embedding.
+        assert re.fullmatch(r"[0-9a-f]{8}", launch.run_id), launch.run_id
+        # Filenames embed the same run id, so events JSONL (which honours
+        # CONDUCTOR_RUN_ID) can be correlated with the bg log files.
+        assert launch.run_id in launch.stderr_log.name
+        assert launch.run_id in launch.stdout_log.name
+        # The log files are siblings of the events JSONL under TMPDIR/conductor/
+        assert launch.stderr_log.parent.name == "conductor"
+        assert launch.stderr_log.parent.parent == Path(tempfile.gettempdir())
+
+    def test_popen_receives_file_handles_not_devnull(self, tmp_path: Path) -> None:
+        """stderr/stdout must NOT be ``DEVNULL`` — that's what causes #116's silent crash."""
+        from conductor.cli import bg_runner
+
+        wf_path = _write_workflow(tmp_path)
+
+        captured: dict[str, Any] = {}
+
+        def _fake_popen(cmd: list[str], **kwargs: Any) -> MagicMock:
+            captured.update(kwargs)
+            proc = MagicMock()
+            proc.pid = 1
+            proc.poll.return_value = None
+            return proc
+
+        with (
+            patch("conductor.cli.bg_runner.subprocess.Popen", side_effect=_fake_popen),
+            patch("conductor.cli.bg_runner._wait_for_server", return_value=True),
+            patch("conductor.cli.pid.write_pid_file"),
+        ):
+            bg_runner.launch_background(
+                workflow_path=wf_path,
+                inputs={},
+                web_port=9301,
+            )
+
+        assert captured["stdin"] is subprocess.DEVNULL  # no interactive input
+        for stream_name in ("stdout", "stderr"):
+            stream = captured[stream_name]
+            assert stream is not subprocess.DEVNULL
+            assert hasattr(stream, "write")
+            assert stream.name.endswith(".log")
+
+    def test_parent_handles_closed_after_popen(self, tmp_path: Path) -> None:
+        """Parent-side stdout/stderr file handles are closed after Popen returns.
+
+        The child has its own duplicated OS handles, so the parent's Python
+        file objects can — and should — be released immediately. Leaving
+        them open would leak file descriptors in the parent.
+        """
+        from conductor.cli import bg_runner
+
+        wf_path = _write_workflow(tmp_path)
+
+        captured: dict[str, Any] = {}
+
+        def _fake_popen(cmd: list[str], **kwargs: Any) -> MagicMock:
+            captured["stdout"] = kwargs["stdout"]
+            captured["stderr"] = kwargs["stderr"]
+            proc = MagicMock()
+            proc.pid = 1
+            proc.poll.return_value = None
+            return proc
+
+        with (
+            patch("conductor.cli.bg_runner.subprocess.Popen", side_effect=_fake_popen),
+            patch("conductor.cli.bg_runner._wait_for_server", return_value=True),
+            patch("conductor.cli.pid.write_pid_file"),
+        ):
+            bg_runner.launch_background(
+                workflow_path=wf_path,
+                inputs={},
+                web_port=9302,
+            )
+
+        assert captured["stdout"].closed
+        assert captured["stderr"].closed
+
+    def test_parent_handles_closed_on_finalize_failure(self, tmp_path: Path) -> None:
+        """Parent handles are closed even when ``_finalize_background_launch`` raises."""
+        from conductor.cli import bg_runner
+
+        wf_path = _write_workflow(tmp_path)
+
+        captured: dict[str, Any] = {}
+
+        def _fake_popen(cmd: list[str], **kwargs: Any) -> MagicMock:
+            captured["stdout"] = kwargs["stdout"]
+            captured["stderr"] = kwargs["stderr"]
+            proc = MagicMock()
+            proc.pid = 1
+            # Simulate child exited immediately — _finalize raises RuntimeError.
+            proc.poll.return_value = 7
+            return proc
+
+        with (
+            patch("conductor.cli.bg_runner.subprocess.Popen", side_effect=_fake_popen),
+            patch("conductor.cli.bg_runner._wait_for_server", return_value=False),
+            patch("conductor.cli.pid.write_pid_file"),
+            pytest.raises(RuntimeError, match="exited immediately with code 7"),
+        ):
+            bg_runner.launch_background(
+                workflow_path=wf_path,
+                inputs={},
+                web_port=9303,
+            )
+
+        assert captured["stdout"].closed
+        assert captured["stderr"].closed
+
+    def test_env_wires_correlation_vars(self, tmp_path: Path) -> None:
+        """``CONDUCTOR_RUN_ID`` / log paths are passed to the child via env."""
+        from conductor.cli import bg_runner
+
+        wf_path = _write_workflow(tmp_path)
+
+        captured: dict[str, Any] = {}
+
+        def _fake_popen(cmd: list[str], **kwargs: Any) -> MagicMock:
+            captured["env"] = kwargs["env"]
+            proc = MagicMock()
+            proc.pid = 1
+            proc.poll.return_value = None
+            return proc
+
+        with (
+            patch("conductor.cli.bg_runner.subprocess.Popen", side_effect=_fake_popen),
+            patch("conductor.cli.bg_runner._wait_for_server", return_value=True),
+            patch("conductor.cli.pid.write_pid_file"),
+        ):
+            launch = bg_runner.launch_background(
+                workflow_path=wf_path,
+                inputs={},
+                web_port=9304,
+            )
+
+        env = captured["env"]
+        assert env["CONDUCTOR_WEB_BG"] == "1"
+        assert env["CONDUCTOR_WEB_PORT"] == "9304"
+        assert env["CONDUCTOR_RUN_ID"] == launch.run_id
+        assert env["CONDUCTOR_BG_STDERR_LOG"] == str(launch.stderr_log)
+        assert env["CONDUCTOR_BG_STDOUT_LOG"] == str(launch.stdout_log)
+
+    def test_early_exit_error_mentions_stderr_log_path(self, tmp_path: Path) -> None:
+        """RuntimeError raised on early child exit includes the stderr log path."""
+        from conductor.cli import bg_runner
+
+        wf_path = _write_workflow(tmp_path)
+
+        def _fake_popen(cmd: list[str], **kwargs: Any) -> MagicMock:
+            proc = MagicMock()
+            proc.pid = 1
+            proc.poll.return_value = 42  # immediate exit code 42
+            return proc
+
+        with (
+            patch("conductor.cli.bg_runner.subprocess.Popen", side_effect=_fake_popen),
+            patch("conductor.cli.bg_runner._wait_for_server", return_value=False),
+            patch("conductor.cli.pid.write_pid_file"),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            bg_runner.launch_background(
+                workflow_path=wf_path,
+                inputs={},
+                web_port=9305,
+            )
+
+        # The message must point users at the captured log so they can find
+        # the traceback that previously vanished into DEVNULL.
+        msg = str(exc_info.value)
+        assert "exited immediately with code 42" in msg
+        assert "stderr log" in msg
+        assert ".bg.stderr.log" in msg
+
+    def test_dashboard_timeout_error_mentions_stderr_log_path(self, tmp_path: Path) -> None:
+        """RuntimeError raised on dashboard timeout includes the stderr log path."""
+        from conductor.cli import bg_runner
+
+        wf_path = _write_workflow(tmp_path)
+
+        def _fake_popen(cmd: list[str], **kwargs: Any) -> MagicMock:
+            proc = MagicMock()
+            proc.pid = 1
+            proc.poll.return_value = None  # still running
+            return proc
+
+        with (
+            patch("conductor.cli.bg_runner.subprocess.Popen", side_effect=_fake_popen),
+            patch("conductor.cli.bg_runner._wait_for_server", return_value=False),
+            patch("conductor.cli.bg_runner._terminate_child"),
+            patch("conductor.cli.pid.write_pid_file"),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            bg_runner.launch_background(
+                workflow_path=wf_path,
+                inputs={},
+                web_port=9306,
+            )
+
+        msg = str(exc_info.value)
+        assert "Dashboard did not start" in msg
+        assert "stderr log" in msg
+        assert ".bg.stderr.log" in msg
+
+
+# ---------------------------------------------------------------------------
+# Filename sanitisation
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeName:
+    """The bg log filename is derived from the workflow stem and must be safe."""
+
+    def test_strips_path_separators_and_specials(self) -> None:
+        from conductor.cli.bg_runner import _sanitize_name
+
+        assert _sanitize_name("my/weird:name") == "my-weird-name"
+        # In practice the caller passes ``Path(...).stem`` (e.g. "passwd"),
+        # so leading dots are uncommon — but the sanitizer must still
+        # leave the rest of the name intact if such a stem ever arrives.
+        assert _sanitize_name("../etc/passwd") == "..-etc-passwd"
+        assert _sanitize_name("normal-name.v1") == "normal-name.v1"
+
+    def test_empty_falls_back_to_workflow(self) -> None:
+        from conductor.cli.bg_runner import _sanitize_name
+
+        assert _sanitize_name("") == "workflow"
+        assert _sanitize_name("///") == "workflow"

--- a/tests/test_cli/test_resume_command.py
+++ b/tests/test_cli/test_resume_command.py
@@ -296,10 +296,17 @@ class TestResumeCommand:
 
     def test_resume_web_bg_invokes_launch_background_resume(self, tmp_path: Path) -> None:
         """Test that --web-bg dispatches to launch_background_resume."""
+        from conductor.cli.bg_runner import BackgroundLaunch
+
         wf_path = _write_workflow(tmp_path)
 
         with patch("conductor.cli.bg_runner.launch_background_resume") as mock_launch:
-            mock_launch.return_value = "http://127.0.0.1:9092"
+            mock_launch.return_value = BackgroundLaunch(
+                url="http://127.0.0.1:9092",
+                stderr_log=tmp_path / "stub-abcdef01.bg.stderr.log",
+                stdout_log=tmp_path / "stub-abcdef01.bg.stdout.log",
+                run_id="abcdef01",
+            )
             result = runner.invoke(
                 app,
                 [
@@ -329,11 +336,18 @@ class TestResumeCommand:
 
     def test_resume_web_bg_with_from_checkpoint(self, tmp_path: Path) -> None:
         """Test --web-bg forwards --from checkpoint path."""
+        from conductor.cli.bg_runner import BackgroundLaunch
+
         wf_path = _write_workflow(tmp_path)
         cp_path = _write_checkpoint(tmp_path, wf_path)
 
         with patch("conductor.cli.bg_runner.launch_background_resume") as mock_launch:
-            mock_launch.return_value = "http://127.0.0.1:9093"
+            mock_launch.return_value = BackgroundLaunch(
+                url="http://127.0.0.1:9093",
+                stderr_log=tmp_path / "stub-abcdef02.bg.stderr.log",
+                stdout_log=tmp_path / "stub-abcdef02.bg.stdout.log",
+                run_id="abcdef02",
+            )
             result = runner.invoke(app, ["resume", "--from", str(cp_path), "--web-bg"])
 
         assert result.exit_code == 0
@@ -378,7 +392,7 @@ class TestLaunchBackgroundResume:
             patch("conductor.cli.bg_runner._wait_for_server", return_value=True),
             patch("conductor.cli.pid.write_pid_file"),
         ):
-            url = bg_runner.launch_background_resume(
+            launch = bg_runner.launch_background_resume(
                 workflow_path=wf_path,
                 checkpoint_path=None,
                 provider_override="copilot",
@@ -387,7 +401,7 @@ class TestLaunchBackgroundResume:
                 web_port=9099,
             )
 
-        assert url == "http://127.0.0.1:9099"
+        assert launch.url == "http://127.0.0.1:9099"
         cmd = captured["cmd"]
         # ``--silent`` must NOT be injected: console output is already
         # suppressed by Popen ``stdout``/``stderr=DEVNULL``, and ``--silent``
@@ -771,7 +785,12 @@ class TestLaunchBackgroundResumeFailures:
         mock_write.assert_called_once_with(5556, 9202, cp_path)
 
     def test_subprocess_detachment_kwargs(self, tmp_path: Path) -> None:
-        """Verify Popen is called with detachment + DEVNULL + bg env vars."""
+        """Verify Popen is called with detachment + bg env vars + redirected stdout/stderr.
+
+        The child's stdout/stderr must be redirected to log files (NOT
+        ``DEVNULL``) so a silent crash leaves a forensic trail. See
+        issue #116.
+        """
         import sys as _sys
 
         from conductor.cli import bg_runner
@@ -800,9 +819,20 @@ class TestLaunchBackgroundResumeFailures:
 
         import subprocess as _sp
 
-        assert captured["stdout"] is _sp.DEVNULL
-        assert captured["stderr"] is _sp.DEVNULL
+        # stdin stays DEVNULL (detached child has no interactive input)
         assert captured["stdin"] is _sp.DEVNULL
+        # stdout/stderr must be redirected to writable text-mode file objects
+        # so Python tracebacks and faulthandler dumps from the child survive
+        # the parent's exit. DEVNULL is explicitly NOT allowed here.
+        for stream_name in ("stdout", "stderr"):
+            stream = captured[stream_name]
+            assert stream is not _sp.DEVNULL, (
+                f"{stream_name} must not be DEVNULL — issue #116 requires "
+                "capturing the child's output to a log file."
+            )
+            assert hasattr(stream, "write"), f"{stream_name} must be a writable file-like"
+            assert hasattr(stream, "name"), f"{stream_name} must expose a name attribute"
+            assert ".bg." in stream.name and stream.name.endswith(".log")
         if _sys.platform == "win32":
             expected_flags = _sp.CREATE_NEW_PROCESS_GROUP | _sp.CREATE_BREAKAWAY_FROM_JOB
             assert captured["creationflags"] == expected_flags
@@ -812,6 +842,12 @@ class TestLaunchBackgroundResumeFailures:
         assert isinstance(env, dict)
         assert env["CONDUCTOR_WEB_BG"] == "1"
         assert env["CONDUCTOR_WEB_PORT"] == "9203"
+        # New env vars wired by --web-bg so the child's EventLogSubscriber
+        # and workflow_started metadata cross-reference the bg log files.
+        assert env["CONDUCTOR_RUN_ID"]
+        assert len(env["CONDUCTOR_RUN_ID"]) == 8
+        assert env["CONDUCTOR_BG_STDERR_LOG"].endswith(".bg.stderr.log")
+        assert env["CONDUCTOR_BG_STDOUT_LOG"].endswith(".bg.stdout.log")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_web_flags.py
+++ b/tests/test_cli/test_web_flags.py
@@ -73,8 +73,17 @@ class TestWebFlagAcceptance:
 
     def test_web_bg_flag_passed(self, workflow_file: Path) -> None:
         """Test --web-bg flag forks a background process (does not call run_workflow_async)."""
+        from pathlib import Path as _Path
+
+        from conductor.cli.bg_runner import BackgroundLaunch
+
         with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
-            mock_launch.return_value = "http://127.0.0.1:9999"
+            mock_launch.return_value = BackgroundLaunch(
+                url="http://127.0.0.1:9999",
+                stderr_log=_Path("/tmp/conductor-test-deadbeef.bg.stderr.log"),
+                stdout_log=_Path("/tmp/conductor-test-deadbeef.bg.stdout.log"),
+                run_id="deadbeef",
+            )
 
             result = runner.invoke(app, ["run", str(workflow_file), "--web-bg"])
 
@@ -160,7 +169,7 @@ class TestLaunchBackgroundSilentFlag:
             patch("conductor.cli.bg_runner._wait_for_server", return_value=True),
             patch("conductor.cli.pid.write_pid_file"),
         ):
-            url = bg_runner.launch_background(
+            launch = bg_runner.launch_background(
                 workflow_path=wf_path,
                 inputs={"question": "hello"},
                 provider_override="copilot",
@@ -169,7 +178,7 @@ class TestLaunchBackgroundSilentFlag:
                 web_port=9099,
             )
 
-        assert url == "http://127.0.0.1:9099"
+        assert launch.url == "http://127.0.0.1:9099"
         cmd = captured["cmd"]
         # Issue #196: ``--silent`` must NOT be injected — see class docstring.
         assert "--silent" not in cmd

--- a/tests/test_engine/test_event_log.py
+++ b/tests/test_engine/test_event_log.py
@@ -96,6 +96,95 @@ class TestEventLogSubscriber:
         )
         sub.close()
 
+    def test_honours_conductor_run_id_env_var(self, tmp_path, monkeypatch):
+        """``CONDUCTOR_RUN_ID`` (set by bg_runner) is used in the filename and run_id.
+
+        This is what cross-correlates the bg ``.bg.stderr.log`` file with
+        the child's ``.events.jsonl`` file. See issue #116.
+        """
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("CONDUCTOR_RUN_ID", "abcdef01")
+
+        sub = EventLogSubscriber("env-runid-test")
+        try:
+            assert sub.run_id == "abcdef01"
+            assert "abcdef01" in sub.path.name
+        finally:
+            sub.close()
+
+    def test_lowercases_hex_run_id_from_env(self, tmp_path, monkeypatch):
+        """Mixed-case hex run ids are normalised to lowercase for filename consistency."""
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("CONDUCTOR_RUN_ID", "ABCDEF01")
+
+        sub = EventLogSubscriber("env-runid-case")
+        try:
+            assert sub.run_id == "abcdef01"
+        finally:
+            sub.close()
+
+    def test_rejects_invalid_run_id_env(self, tmp_path, monkeypatch):
+        """Non-hex / overlong env values are rejected; a fresh random id is used.
+
+        This keeps the filename safe from accidental injection via the env
+        var (e.g. path separators, control characters, very long values).
+        """
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("CONDUCTOR_RUN_ID", "../etc/passwd")
+
+        sub = EventLogSubscriber("env-runid-bad")
+        try:
+            assert sub.run_id != "../etc/passwd"
+            # Falls back to a fresh 8-hex random id.
+            import re
+
+            assert re.fullmatch(r"[0-9a-f]{8}", sub.run_id), sub.run_id
+        finally:
+            sub.close()
+
+    def test_empty_run_id_env_falls_back_to_random(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("CONDUCTOR_RUN_ID", "")
+
+        sub = EventLogSubscriber("env-runid-empty")
+        try:
+            import re
+
+            assert re.fullmatch(r"[0-9a-f]{8}", sub.run_id), sub.run_id
+        finally:
+            sub.close()
+
+    def test_accepts_32_char_hex_run_id(self, tmp_path, monkeypatch):
+        """Upper boundary: a 32-char hex string is the longest accepted run id."""
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("CONDUCTOR_RUN_ID", "a" * 32)
+
+        sub = EventLogSubscriber("env-runid-32")
+        try:
+            assert sub.run_id == "a" * 32
+            assert "a" * 32 in sub.path.name
+        finally:
+            sub.close()
+
+    def test_rejects_33_char_hex_run_id(self, tmp_path, monkeypatch):
+        """One past the upper boundary: 33-char hex is rejected, falls back to random.
+
+        Guards against an accidental relaxation of the regex to ``{1,}``
+        or removal of the upper bound, which would let arbitrary-length
+        env values into the filename.
+        """
+        import re
+
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("CONDUCTOR_RUN_ID", "a" * 33)
+
+        sub = EventLogSubscriber("env-runid-33")
+        try:
+            assert sub.run_id != "a" * 33
+            assert re.fullmatch(r"[0-9a-f]{8}", sub.run_id), sub.run_id
+        finally:
+            sub.close()
+
     def test_integrates_with_emitter(self, tmp_path, monkeypatch):
         from conductor.events import WorkflowEventEmitter
 

--- a/tests/test_engine/test_workflow.py
+++ b/tests/test_engine/test_workflow.py
@@ -8,6 +8,7 @@ Tests cover:
 - Error handling
 """
 
+import asyncio
 import sys
 
 import pytest
@@ -2506,3 +2507,223 @@ class TestProviderFactoryReasoningEffortWiring:
             assert provider._default_reasoning_effort == "high"
         finally:
             await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# Exception-handling arms in _execute_loop (issue #116)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteLoopExceptionArms:
+    """Tests for the SystemExit / BaseException / CancelledError arms.
+
+    Issue #116 added a final ``except BaseException`` arm so silent
+    startup crashes leave a ``workflow_failed`` event in the JSONL log,
+    plus an explicit ``except asyncio.CancelledError: raise`` arm so a
+    user-initiated dashboard stop is not labelled as a spurious failure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_systemexit_emits_workflow_failed_event(
+        self, simple_workflow_config: WorkflowConfig
+    ) -> None:
+        """A ``SystemExit`` from the provider is captured as ``workflow_failed``.
+
+        Without the ``except BaseException`` arm this exception would
+        propagate past the engine's existing ``except Exception`` arm and
+        the JSONL log would silently end after ``agent_started`` — the
+        exact symptom reported in issue #116.
+        """
+        from conductor.events import WorkflowEvent, WorkflowEventEmitter
+
+        def mock_handler(agent, prompt, context):
+            raise SystemExit("simulated startup crash")
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+
+        events: list[WorkflowEvent] = []
+        emitter = WorkflowEventEmitter()
+        emitter.subscribe(events.append)
+
+        engine = WorkflowEngine(simple_workflow_config, provider, event_emitter=emitter)
+
+        with pytest.raises(SystemExit):
+            await engine.run({"question": "anything"})
+
+        failed_events = [e for e in events if e.type == "workflow_failed"]
+        assert len(failed_events) == 1, (
+            f"expected exactly one workflow_failed event; got {[e.type for e in events]}"
+        )
+        fail = failed_events[0]
+        assert fail.data["error_type"] == "SystemExit"
+        assert fail.data.get("is_base_exception") is True
+        assert "simulated startup crash" in fail.data["message"]
+
+    @pytest.mark.asyncio
+    async def test_regular_exception_does_not_set_is_base_exception_flag(
+        self, simple_workflow_config: WorkflowConfig
+    ) -> None:
+        """A regular ``Exception`` must NOT set ``is_base_exception`` on workflow_failed.
+
+        This is the contract Phase 2 will rely on to tell genuine
+        ``BaseException`` crashes (e.g., ``SystemExit``) apart from regular
+        workflow errors. Without this baseline test, a buggy refactor could
+        set the flag unconditionally and the issue would go unnoticed.
+        """
+        from conductor.events import WorkflowEvent, WorkflowEventEmitter
+
+        def mock_handler(agent, prompt, context):
+            raise RuntimeError("regular failure, not a base exception")
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+
+        events: list[WorkflowEvent] = []
+        emitter = WorkflowEventEmitter()
+        emitter.subscribe(events.append)
+
+        engine = WorkflowEngine(simple_workflow_config, provider, event_emitter=emitter)
+
+        with pytest.raises(Exception):  # noqa: B017 - exception type varies by retry wrapping
+            await engine.run({"question": "anything"})
+
+        failed_events = [e for e in events if e.type == "workflow_failed"]
+        assert failed_events, "expected a workflow_failed event for a regular Exception"
+        # The provider's retry loop may wrap RuntimeError into ProviderError,
+        # so we don't assert on error_type — only on the flag's absence.
+        for ev in failed_events:
+            assert ev.data.get("is_base_exception") is not True, (
+                f"regular Exception must NOT set is_base_exception=True; got: {ev.data}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_cancellederror_via_external_task_cancel(
+        self, simple_workflow_config: WorkflowConfig
+    ) -> None:
+        """External ``task.cancel()`` propagates as ``CancelledError`` with no failure event.
+
+        This exercises the real dashboard-stop / parent-cancellation flow:
+        the engine task is running, external code calls ``task.cancel()``,
+        ``CancelledError`` is injected at the next ``await`` point inside
+        the engine, and it must hit the new ``except asyncio.CancelledError:
+        raise`` arm WITHOUT firing ``workflow_failed``.
+
+        We patch ``AgentExecutor.execute`` to be an async ``sleep`` so the
+        cancellation has a real ``await`` point to fire at — the
+        ``mock_handler`` path on the provider runs synchronously and would
+        not be cancellable from outside.
+        """
+        from unittest.mock import patch
+
+        from conductor.events import WorkflowEvent, WorkflowEventEmitter
+
+        started = asyncio.Event()
+
+        async def slow_execute(*args, **kwargs):
+            started.set()
+            await asyncio.sleep(60.0)  # cancellable await point
+            raise AssertionError("should never get here — the task is cancelled first")
+
+        def mock_handler(agent, prompt, context):  # pragma: no cover - patched out
+            return {"answer": "unused"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+
+        events: list[WorkflowEvent] = []
+        emitter = WorkflowEventEmitter()
+        emitter.subscribe(events.append)
+
+        engine = WorkflowEngine(simple_workflow_config, provider, event_emitter=emitter)
+
+        with patch(
+            "conductor.executor.agent.AgentExecutor.execute",
+            side_effect=slow_execute,
+        ):
+            task = asyncio.create_task(engine.run({"question": "anything"}))
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        failed_events = [e for e in events if e.type == "workflow_failed"]
+        assert failed_events == [], (
+            "External task.cancel() must propagate without emitting workflow_failed; "
+            f"got: {[e.data for e in failed_events]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bg_log_paths_in_workflow_started_system_metadata(
+        self,
+        simple_workflow_config: WorkflowConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When ``bg_mode=True``, ``CONDUCTOR_BG_*_LOG`` env vars surface in system metadata.
+
+        This is the contract the web dashboard relies on to display the
+        captured stderr/stdout log paths to the user (issue #116).
+        """
+        from conductor.engine.workflow import RunContext
+        from conductor.events import WorkflowEvent, WorkflowEventEmitter
+
+        monkeypatch.setenv("CONDUCTOR_BG_STDERR_LOG", "/tmp/conductor-test.bg.stderr.log")
+        monkeypatch.setenv("CONDUCTOR_BG_STDOUT_LOG", "/tmp/conductor-test.bg.stdout.log")
+
+        def mock_handler(agent, prompt, context):
+            return {"answer": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+
+        events: list[WorkflowEvent] = []
+        emitter = WorkflowEventEmitter()
+        emitter.subscribe(events.append)
+
+        engine = WorkflowEngine(
+            simple_workflow_config,
+            provider,
+            event_emitter=emitter,
+            run_context=RunContext(bg_mode=True),
+        )
+
+        await engine.run({"question": "anything"})
+
+        started = [e for e in events if e.type == "workflow_started"]
+        assert started, "expected a workflow_started event"
+        system = started[0].data["system"]
+        assert system["bg_mode"] is True
+        assert system["bg_stderr_log"] == "/tmp/conductor-test.bg.stderr.log"
+        assert system["bg_stdout_log"] == "/tmp/conductor-test.bg.stdout.log"
+
+    @pytest.mark.asyncio
+    async def test_bg_log_paths_omitted_when_bg_mode_false(
+        self,
+        simple_workflow_config: WorkflowConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When ``bg_mode=False``, ``CONDUCTOR_BG_*_LOG`` env vars are NOT surfaced.
+
+        Non-bg runs don't write to bg log files, so emitting these fields
+        with stale env values from a previous shell session would be
+        misleading. The metadata block is gated on ``bg_mode``.
+        """
+        from conductor.events import WorkflowEvent, WorkflowEventEmitter
+
+        monkeypatch.setenv("CONDUCTOR_BG_STDERR_LOG", "/tmp/stale.log")
+        monkeypatch.setenv("CONDUCTOR_BG_STDOUT_LOG", "/tmp/stale.log")
+
+        def mock_handler(agent, prompt, context):
+            return {"answer": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+
+        events: list[WorkflowEvent] = []
+        emitter = WorkflowEventEmitter()
+        emitter.subscribe(events.append)
+
+        engine = WorkflowEngine(simple_workflow_config, provider, event_emitter=emitter)
+
+        await engine.run({"question": "anything"})
+
+        started = [e for e in events if e.type == "workflow_started"]
+        assert started
+        system = started[0].data["system"]
+        assert "bg_stderr_log" not in system
+        assert "bg_stdout_log" not in system


### PR DESCRIPTION
## Summary

Phase 1 (diagnostics-only) for issue #116. **This PR does not yet fix the underlying Windows crash** — it makes the crash forensically traceable so Phase 2 can root-cause it from a real Windows repro.

Today, when a `conductor run <wf> --web-bg` (or `resume --web-bg`) child dies on Windows between `agent_started` and `agent_prompt_rendered` (~46% of runs of `pr-reviewer` per the report), it leaves:

- No traceback (parent redirects child stderr to `DEVNULL`).
- No native-crash dump (`faulthandler` was never enabled).
- No `workflow_failed` event (a `SystemExit` from a misbehaving library escapes the engine's `except Exception` arm).

This PR closes all three gaps.

## Changes

| File | Change |
|---|---|
| `src/conductor/__init__.py` | `faulthandler.enable(file=sys.__stderr__, all_threads=True)` at import time. Covers both `python -m conductor` and the installed `conductor` console script (which bypasses `__main__.py`). |
| `src/conductor/cli/bg_runner.py` | Capture child stdout/stderr to `\$TMPDIR/conductor/conductor-<name>-<ts>-<runid>.bg.{stderr,stdout}.log` instead of `DEVNULL`. Pass `CONDUCTOR_RUN_ID` / `CONDUCTOR_BG_STDERR_LOG` / `CONDUCTOR_BG_STDOUT_LOG` to the child via env so the events JSONL and bg log files share an 8-hex run id in their filenames. Close parent file handles in `try/finally`. Returns a new `BackgroundLaunch` dataclass (`url`, `stderr_log`, `stdout_log`, `run_id`). Threads the stderr-log path into every `RuntimeError` raised by `_finalize_background_launch`. |
| `src/conductor/engine/event_log.py` | `EventLogSubscriber` honours `CONDUCTOR_RUN_ID` (validated as 1–32 hex chars, lowercased), falls back to random when unset or malformed. |
| `src/conductor/engine/workflow.py` | `_build_system_metadata` surfaces `bg_stderr_log` / `bg_stdout_log`. `_execute_loop` gets `except asyncio.CancelledError: raise` (preserves dashboard-stop semantics) followed by `except BaseException` that emits `workflow_failed` with `is_base_exception: true`. `on_error` hook is deliberately **not** invoked for `BaseException` cases because its declared signature is `Exception \| None`. |
| `src/conductor/cli/app.py` | Both `--web-bg` callers updated for `BackgroundLaunch`; stderr-log path printed beside the dashboard URL. |

## Tests

**15 new, 5 updated.**

- `tests/test_cli/test_bg_runner.py` (new, 9 tests): `BackgroundLaunch` shape and filename pattern; file handles vs `DEVNULL` contract; parent-handle closure on success and on `_finalize_background_launch` failure; `CONDUCTOR_RUN_ID` / log-path env wiring; stderr-log path included in early-exit and dashboard-timeout `RuntimeError` messages; filename sanitisation.
- `tests/test_engine/test_event_log.py` (+4): `CONDUCTOR_RUN_ID` honoured, case-normalised, rejected when non-hex / overlong, empty falls back to random.
- `tests/test_engine/test_workflow.py` (+2): `TestExecuteLoopExceptionArms` covers `SystemExit` → `workflow_failed` with `is_base_exception=true`, and `CancelledError` → **no** spurious `workflow_failed` event.
- `tests/test_cli/test_web_flags.py` and `test_resume_command.py` updated for the new `BackgroundLaunch` return type and the no-DEVNULL contract (now asserts file-like stdout/stderr with `.bg.{stderr,stdout}.log` names and the new env vars).

All checks green locally on Python 3.14:
- \`make lint\` — clean.
- \`make typecheck\` — same single pre-existing unrelated warning in `dialog_evaluator.py:131`. Zero new diagnostics.
- \`uv run pytest -m "not real_api and not performance and not install_scripts"\` — **2627 passed, 3 skipped, 46 deselected** (baseline 2612; +15 new tests, no regressions).

## Docs

- `CHANGELOG.md` — entry under Unreleased / Fixed.
- `AGENTS.md` — `bg_runner.py` bullet describes the new capture behaviour and return type; new "Debugging \`--web-bg\` failures" section under Architecture / Key Patterns.

## API surface changes

- `launch_background()` and `launch_background_resume()` in `conductor.cli.bg_runner` now return a `BackgroundLaunch` dataclass instead of a bare URL string. Existing callers in `conductor.cli.app` are updated; external callers (if any) need to access `.url`.

## Intentionally NOT addressed

- **Root-cause fix for the Windows crash.** That's Phase 2, gated on having a real traceback from one of the new captured `.bg.stderr.log` files. Plan: ask the original reporter (\@franklixuefei) to retry on Windows once this lands, attach the captured log, and act on whatever it shows.
- **\`CREATE_BREAKAWAY_FROM_JOB\` on Windows Popen creationflags (#195).** Out of scope per direction — that's a separately tracked sibling bug with a different signature (one event before death, not two).

## Closes / refs

Refs #116 (diagnostics; the issue stays open until Phase 2 lands the actual fix).