### PR TITLE
feat(script): allow script agents to declare output schemas (#118)

### DIFF
--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -223,6 +223,38 @@ agents:
 
 JSON arrays and scalars are ignored (only objects merge). Non-JSON stdout is unchanged. Parsed fields shadow `stdout`/`stderr`/`exit_code` if a script outputs those as JSON keys.
 
+**Declared output schema (strict mode)** — script steps can also declare an `output:` schema using the same syntax as LLM agents. When declared, stdout MUST be a valid JSON object that matches the schema, otherwise the workflow fails with a `ValidationError`:
+
+```yaml
+agents:
+  - name: detector
+    type: script
+    command: pwsh
+    args: ["-File", "{{ workflow.dir }}/scripts/detect.ps1"]
+    output:
+      route:
+        type: string
+        description: Which phase to enter next
+      issue_count:
+        type: number
+    routes:
+      - to: planner
+        when: "route == 'planning'"
+      - to: scaler
+        when: "issue_count > 100"
+      - to: $end
+```
+
+Strict-mode semantics:
+
+- **stdout must be a JSON object.** Non-JSON, empty stdout, JSON arrays, and JSON scalars all fail validation. Write logs to `stderr` so they don't interfere with the JSON contract.
+- **Missing or wrong-typed fields fail validation.** Extra fields beyond the schema are kept in `output_content` (matching LLM-agent behavior).
+- **Built-in `stdout`/`stderr`/`exit_code` are validated on the merged dict.** Declaring `exit_code: { type: number }` asserts the built-in matches; if the script emits a shadowing JSON key (e.g. `{"exit_code": "ok"}`), the schema validates the shadowed value.
+- **Failure semantics.** On schema-validation failure, the engine emits `script_failed` (not `script_completed`) and aborts the workflow. The failure event carries the captured stdout, stderr, and exit_code so dashboards and logs can show what the script actually wrote.
+- **`output: {}` opts into strict mode with zero required fields** — useful when you want the JSON-object enforcement without listing fields yet.
+
+Without a declared `output:` schema, the legacy auto-merge behavior described above still applies.
+
 Access in downstream agents:
 
 ```yaml
@@ -243,7 +275,7 @@ routes:
   - to: $end
 ```
 
-**Restrictions** — script steps cannot have `prompt`, `model`, `provider`, `tools`, `system_prompt`, `output` schema, or `options`. Script steps also cannot be used inside `parallel` groups or `for_each` groups.
+**Restrictions** — script steps cannot have `prompt`, `model`, `provider`, `tools`, `system_prompt`, or `options`. Script steps also cannot be used inside `parallel` groups or `for_each` groups.
 
 **Environment variable note** — values in `env` are passed as-is to the subprocess (they are not rendered as Jinja2 templates). Use `${VAR}` syntax in the workflow YAML loader if you need environment variable substitution in env values.
 

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -223,7 +223,7 @@ agents:
 
 JSON arrays and scalars are ignored (only objects merge). Non-JSON stdout is unchanged. Parsed fields shadow `stdout`/`stderr`/`exit_code` if a script outputs those as JSON keys.
 
-**Declared output schema (strict mode)** — script steps can also declare an `output:` schema using the same syntax as LLM agents. When declared, stdout MUST be a valid JSON object that matches the schema, otherwise the workflow fails with a `ValidationError`:
+**Declared output schema (strict mode)** — script steps can also declare an `output:` schema using the same syntax as LLM agents. When declared, conductor enforces a strict contract: stdout must be a single JSON object, the JSON gets merged onto the `{stdout, stderr, exit_code}` baseline, and the **merged dict** is validated against the schema. If any check fails the workflow aborts with a `ValidationError`:
 
 ```yaml
 agents:
@@ -247,11 +247,13 @@ agents:
 
 Strict-mode semantics:
 
-- **stdout must be a JSON object.** Non-JSON, empty stdout, JSON arrays, and JSON scalars all fail validation. Write logs to `stderr` so they don't interfere with the JSON contract.
-- **Missing or wrong-typed fields fail validation.** Extra fields beyond the schema are kept in `output_content` (matching LLM-agent behavior).
-- **Built-in `stdout`/`stderr`/`exit_code` are validated on the merged dict.** Declaring `exit_code: { type: number }` asserts the built-in matches; if the script emits a shadowing JSON key (e.g. `{"exit_code": "ok"}`), the schema validates the shadowed value.
+- **stdout must be a single JSON object.** Non-JSON, empty stdout, JSON arrays, JSON scalars, and JSON followed by additional text (e.g. log lines) all fail validation with the underlying JSON parser error surfaced for diagnostics. Reserve stdout for the JSON payload and write logs to `stderr`.
+- **Missing or wrong-typed fields fail validation.** Extra fields beyond the schema are kept in the output dict (the validator only enforces declared fields — the same loose-extras policy that LLM-agent structured outputs use).
+- **Validation runs on the merged dict, not the raw JSON.** The `stdout`/`stderr`/`exit_code` built-ins are always present in the dict, with parsed JSON keys overlaid on top. Declaring `exit_code: { type: number }` asserts the built-in matches; if the script emits a shadowing JSON key (e.g. `{"exit_code": "ok"}`), the schema validates the shadowed value.
 - **Failure semantics.** On schema-validation failure, the engine emits `script_failed` (not `script_completed`) and aborts the workflow. The failure event carries the captured stdout, stderr, and exit_code so dashboards and logs can show what the script actually wrote.
 - **`output: {}` opts into strict mode with zero required fields** — useful when you want the JSON-object enforcement without listing fields yet.
+
+Note: this is **structural** parity with LLM agents — the script must emit clean JSON to stdout. The JSON-recovery heuristics LLM agents use (extracting JSON from code fences, wrapping non-object payloads) intentionally do not apply to scripts, which are deterministic.
 
 Without a declared `output:` schema, the legacy auto-merge behavior described above still applies.
 

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -255,7 +255,7 @@ Strict-mode semantics:
 
 Note: this is **structural** parity with LLM agents — the script must emit clean JSON to stdout. The JSON-recovery heuristics LLM agents use (extracting JSON from code fences, wrapping non-object payloads) intentionally do not apply to scripts, which are deterministic.
 
-Without a declared `output:` schema, the legacy auto-merge behavior described above still applies.
+Omit `output:` to keep the lenient auto-merge behavior described above.
 
 Access in downstream agents:
 

--- a/examples/script-typed-output.yaml
+++ b/examples/script-typed-output.yaml
@@ -1,9 +1,11 @@
 # Script Step with Typed Output Schema Example
 #
-# This example demonstrates a script agent that declares an `output:`
-# schema (issue #118). The script writes a JSON object to stdout; conductor
-# parses it and validates it against the declared schema. Downstream agents
-# and route conditions can then reference typed fields by name instead of
+# This example shows a script agent that declares an `output:` schema,
+# enabling typed downstream access to its fields. The script's STDOUT is
+# reserved for a single JSON object (logs belong on STDERR); conductor
+# parses the JSON, merges it onto the {stdout, stderr, exit_code} baseline,
+# and validates the merged dict against the schema. Downstream agents and
+# route conditions can then reference typed fields by name instead of
 # relying on opaque exit codes or raw stdout strings.
 #
 # This workflow:

--- a/examples/script-typed-output.yaml
+++ b/examples/script-typed-output.yaml
@@ -1,0 +1,94 @@
+# Script Step with Typed Output Schema Example
+#
+# This example demonstrates a script agent that declares an `output:`
+# schema (issue #118). The script writes a JSON object to stdout; conductor
+# parses it and validates it against the declared schema. Downstream agents
+# and route conditions can then reference typed fields by name instead of
+# relying on opaque exit codes or raw stdout strings.
+#
+# This workflow:
+# 1. Runs a deterministic detector script that emits a JSON state object
+# 2. Routes on a declared field (`phase`) instead of an exit code
+# 3. An LLM agent uses the typed fields to summarise the state
+#
+# Usage:
+#   conductor run examples/script-typed-output.yaml
+
+workflow:
+  name: script-typed-output-demo
+  description: Script agent with declared output schema for typed routing
+  version: "1.0.0"
+  entry_point: detect_state
+
+  runtime:
+    provider: copilot
+
+  limits:
+    max_iterations: 10
+
+agents:
+  - name: detect_state
+    type: script
+    description: Detect the current workspace state and emit typed JSON
+    command: python3
+    args:
+      - "-c"
+      - |
+        import json
+        # A real script would inspect files, run tests, query an API, etc.
+        # Here we just emit a fixed object so the example is hermetic.
+        print(json.dumps({
+            "phase": "planning",
+            "issue_count": 3,
+            "has_plan": False,
+        }))
+    output:
+      phase:
+        type: string
+        description: Which phase the workflow should enter next
+      issue_count:
+        type: number
+        description: Number of unresolved issues detected
+      has_plan:
+        type: boolean
+        description: Whether a plan file already exists
+    routes:
+      - to: planner
+        when: "phase == 'planning'"
+      - to: implementer
+        when: "phase == 'implementation'"
+      - to: $end
+
+  - name: planner
+    description: Summarise the detector output and recommend next steps
+    model: claude-haiku-4.5
+    prompt: |
+      The detector script reports:
+
+      - phase: {{ detect_state.output.phase }}
+      - issue_count: {{ detect_state.output.issue_count }}
+      - has_plan: {{ detect_state.output.has_plan }}
+
+      Recommend the next concrete action for the user.
+    output:
+      recommendation:
+        type: string
+        description: Recommended next action
+    routes:
+      - to: $end
+
+  - name: implementer
+    description: Placeholder for the implementation phase
+    model: claude-haiku-4.5
+    prompt: |
+      The detector reports we're in implementation phase with
+      {{ detect_state.output.issue_count }} open issues. Acknowledge briefly.
+    output:
+      acknowledgement:
+        type: string
+    routes:
+      - to: $end
+
+output:
+  next_action: >-
+    {{ planner.output.recommendation | default('') }}{{ implementer.output.acknowledgement | default('') }}

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -708,11 +708,6 @@ class AgentDef(BaseModel):
                 raise ValueError("script agents cannot have 'model'")
             if self.tools is not None:
                 raise ValueError("script agents cannot have 'tools'")
-            if self.output:
-                raise ValueError(
-                    "script agents cannot have 'output' schema "
-                    "(output is always stdout/stderr/exit_code)"
-                )
             if self.system_prompt:
                 raise ValueError("script agents cannot have 'system_prompt'")
             if self.options:

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -2216,7 +2216,24 @@ class WorkflowEngine:
                                                 "Arrays and scalars are not accepted."
                                             ),
                                         )
-                                    validate_output(output_content, agent.output)
+                                    try:
+                                        validate_output(output_content, agent.output)
+                                    except ValidationError as schema_exc:
+                                        # validate_output is shared with LLM agents
+                                        # and its error wording is LLM-flavored
+                                        # ("agent returns ..."). Wrap so script
+                                        # users see the script name and the
+                                        # stdout-JSON contract.
+                                        raise ValidationError(
+                                            f"Script '{agent.name}' stdout JSON "
+                                            f"failed schema validation: "
+                                            f"{schema_exc.args[0]}",
+                                            suggestion=(
+                                                "Emit a JSON object to stdout "
+                                                "with the declared fields and "
+                                                "types. Write logs to stderr."
+                                            ),
+                                        ) from schema_exc
                                 except ValidationError as exc:
                                     self._emit(
                                         "script_failed",

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -29,12 +29,14 @@ from conductor.exceptions import (
     ExecutionError,
     InterruptError,
     MaxIterationsError,
+    ValidationError,
 )
 from conductor.exceptions import (
     TimeoutError as ConductorTimeoutError,
 )
 from conductor.executor.agent import AgentExecutor
 from conductor.executor.linkify import linkify_markdown
+from conductor.executor.output import validate_output
 from conductor.executor.script import ScriptExecutor, ScriptOutput
 from conductor.executor.template import TemplateRenderer
 from conductor.gates.human import (
@@ -2151,6 +2153,85 @@ class WorkflowEngine:
                                 raise
                             _script_elapsed = _time.time() - _script_start
 
+                            # Build structured output: stdout/stderr/exit_code baseline,
+                            # with parsed JSON object fields (if present) merged on top.
+                            output_content: dict[str, Any] = {
+                                "stdout": script_output.stdout,
+                                "stderr": script_output.stderr,
+                                "exit_code": script_output.exit_code,
+                            }
+                            # Auto-parse JSON stdout: if stdout is a valid JSON
+                            # object, merge its fields into output so they're
+                            # accessible as output.field_name in templates and
+                            # route conditions (matching LLM structured outputs).
+                            # When an output schema is declared (issue #118), the
+                            # parse must succeed AND yield a dict, otherwise we
+                            # raise ValidationError below.
+                            parsed_json: Any = None
+                            json_parse_error: Exception | None = None
+                            try:
+                                parsed_json = json.loads(script_output.stdout)
+                            except json.JSONDecodeError as exc:
+                                json_parse_error = exc
+
+                            if isinstance(parsed_json, dict):
+                                shadowed = set(parsed_json.keys()) & {
+                                    "stdout",
+                                    "stderr",
+                                    "exit_code",
+                                }
+                                if shadowed:
+                                    logger.debug(
+                                        "Script '%s' JSON output shadows built-in fields: %s",
+                                        agent.name,
+                                        ", ".join(sorted(shadowed)),
+                                    )
+                                output_content.update(parsed_json)
+
+                            # Validate against declared output schema (issue #118).
+                            # Use `is not None` so an explicit `output: {}` opts
+                            # into strict JSON-object mode with zero declared fields.
+                            if agent.output is not None:
+                                try:
+                                    if json_parse_error is not None:
+                                        raise ValidationError(
+                                            f"Script '{agent.name}' declares an "
+                                            "output schema but stdout is not valid "
+                                            f"JSON: {json_parse_error}",
+                                            suggestion=(
+                                                "When 'output:' is declared, the "
+                                                "script must write a JSON object "
+                                                "to stdout. Write logs to stderr."
+                                            ),
+                                        )
+                                    if not isinstance(parsed_json, dict):
+                                        type_name = type(parsed_json).__name__
+                                        raise ValidationError(
+                                            f"Script '{agent.name}' declares an "
+                                            "output schema but stdout is a JSON "
+                                            f"{type_name}, not an object",
+                                            suggestion=(
+                                                "Emit a JSON object (e.g. "
+                                                '{"field": value}) to stdout. '
+                                                "Arrays and scalars are not accepted."
+                                            ),
+                                        )
+                                    validate_output(output_content, agent.output)
+                                except ValidationError as exc:
+                                    self._emit(
+                                        "script_failed",
+                                        {
+                                            "agent_name": agent.name,
+                                            "elapsed": _script_elapsed,
+                                            "error_type": type(exc).__name__,
+                                            "message": str(exc),
+                                            "stdout": script_output.stdout,
+                                            "stderr": script_output.stderr,
+                                            "exit_code": script_output.exit_code,
+                                        },
+                                    )
+                                    raise
+
                             self._emit(
                                 "script_completed",
                                 {
@@ -2162,29 +2243,6 @@ class WorkflowEngine:
                                 },
                             )
 
-                            # Store structured output in context
-                            output_content = {
-                                "stdout": script_output.stdout,
-                                "stderr": script_output.stderr,
-                                "exit_code": script_output.exit_code,
-                            }
-                            # Auto-parse JSON stdout: if stdout is valid JSON
-                            # object, merge its fields into output so they're
-                            # accessible as output.field_name in templates and
-                            # route conditions (like LLM structured outputs).
-                            try:
-                                parsed = json.loads(script_output.stdout)
-                                if isinstance(parsed, dict):
-                                    shadowed = set(parsed.keys()) & set(output_content.keys())
-                                    if shadowed:
-                                        logger.debug(
-                                            "Script '%s' JSON output shadows built-in fields: %s",
-                                            agent.name,
-                                            ", ".join(sorted(shadowed)),
-                                        )
-                                    output_content.update(parsed)
-                            except json.JSONDecodeError:
-                                pass
                             self.context.store(agent.name, output_content)
                             self.limits.record_execution(agent.name)
                             self.limits.check_timeout()

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -605,6 +605,65 @@ class WorkflowEngine:
             operation_name=f"script '{agent.name}'",
         )
 
+    def _validate_script_output_schema(
+        self,
+        agent: AgentDef,
+        parsed_json: Any,
+        json_parse_error: Exception | None,
+        output_content: dict[str, Any],
+    ) -> None:
+        """Validate script stdout against the declared output schema (issue #118).
+
+        Validation runs against the merged ``output_content`` dict (with the
+        ``stdout``/``stderr``/``exit_code`` baseline plus parsed-JSON overlay)
+        so shadowed built-ins are checked too. The wrapped error from
+        ``validate_output`` is re-raised with script-oriented wording so the
+        user sees the script name and the stdout-JSON contract instead of the
+        LLM-flavored "Ensure agent returns ..." default.
+
+        Args:
+            agent: The script agent definition. ``agent.output`` must be a dict
+                (callers check ``is not None``).
+            parsed_json: Result of ``json.loads(stdout)``, or ``None`` if
+                parsing failed.
+            json_parse_error: The ``JSONDecodeError`` instance if parsing
+                failed, else ``None``.
+            output_content: The merged dict to validate.
+
+        Raises:
+            ValidationError: If stdout was not valid JSON, was a JSON
+                array/scalar, or failed schema validation.
+        """
+        if json_parse_error is not None:
+            raise ValidationError(
+                f"Script '{agent.name}' declares an output schema but stdout "
+                f"is not valid JSON: {json_parse_error}",
+                suggestion=(
+                    "When 'output:' is declared, the script must write a JSON "
+                    "object to stdout. Write logs to stderr."
+                ),
+            )
+        if not isinstance(parsed_json, dict):
+            raise ValidationError(
+                f"Script '{agent.name}' declares an output schema but stdout "
+                f"is a JSON {type(parsed_json).__name__}, not an object",
+                suggestion=(
+                    'Emit a JSON object (e.g. {"field": value}) to stdout. '
+                    "Arrays and scalars are not accepted."
+                ),
+            )
+        assert agent.output is not None  # guaranteed by callers
+        try:
+            validate_output(output_content, agent.output)
+        except ValidationError as schema_exc:
+            raise ValidationError(
+                f"Script '{agent.name}' stdout JSON failed schema validation: {schema_exc.args[0]}",
+                suggestion=(
+                    "Emit a JSON object to stdout with the declared fields "
+                    "and types. Write logs to stderr."
+                ),
+            ) from schema_exc
+
     async def _execute_with_agent_timeout(
         self,
         agent: AgentDef,
@@ -2153,20 +2212,17 @@ class WorkflowEngine:
                                 raise
                             _script_elapsed = _time.time() - _script_start
 
-                            # Build structured output: stdout/stderr/exit_code baseline,
-                            # with parsed JSON object fields (if present) merged on top.
+                            # Build structured output: stdout/stderr/exit_code
+                            # baseline, with parsed JSON object fields merged
+                            # on top so they're addressable as `output.field`
+                            # in templates and routes (matching LLM structured
+                            # outputs). Strict validation against `agent.output`
+                            # runs below when declared.
                             output_content: dict[str, Any] = {
                                 "stdout": script_output.stdout,
                                 "stderr": script_output.stderr,
                                 "exit_code": script_output.exit_code,
                             }
-                            # Auto-parse JSON stdout: if stdout is a valid JSON
-                            # object, merge its fields into output so they're
-                            # accessible as output.field_name in templates and
-                            # route conditions (matching LLM structured outputs).
-                            # When an output schema is declared (issue #118), the
-                            # parse must succeed AND yield a dict, otherwise we
-                            # raise ValidationError below.
                             parsed_json: Any = None
                             json_parse_error: Exception | None = None
                             try:
@@ -2189,51 +2245,18 @@ class WorkflowEngine:
                                 output_content.update(parsed_json)
 
                             # Validate against declared output schema (issue #118).
-                            # Use `is not None` so an explicit `output: {}` opts
-                            # into strict JSON-object mode with zero declared fields.
+                            # `is not None` so an explicit `output: {}` opts
+                            # into strict JSON-object mode with zero declared
+                            # fields. See `_validate_script_output_schema` for
+                            # the validation rules and wrapping rationale.
                             if agent.output is not None:
                                 try:
-                                    if json_parse_error is not None:
-                                        raise ValidationError(
-                                            f"Script '{agent.name}' declares an "
-                                            "output schema but stdout is not valid "
-                                            f"JSON: {json_parse_error}",
-                                            suggestion=(
-                                                "When 'output:' is declared, the "
-                                                "script must write a JSON object "
-                                                "to stdout. Write logs to stderr."
-                                            ),
-                                        )
-                                    if not isinstance(parsed_json, dict):
-                                        type_name = type(parsed_json).__name__
-                                        raise ValidationError(
-                                            f"Script '{agent.name}' declares an "
-                                            "output schema but stdout is a JSON "
-                                            f"{type_name}, not an object",
-                                            suggestion=(
-                                                "Emit a JSON object (e.g. "
-                                                '{"field": value}) to stdout. '
-                                                "Arrays and scalars are not accepted."
-                                            ),
-                                        )
-                                    try:
-                                        validate_output(output_content, agent.output)
-                                    except ValidationError as schema_exc:
-                                        # validate_output is shared with LLM agents
-                                        # and its error wording is LLM-flavored
-                                        # ("agent returns ..."). Wrap so script
-                                        # users see the script name and the
-                                        # stdout-JSON contract.
-                                        raise ValidationError(
-                                            f"Script '{agent.name}' stdout JSON "
-                                            f"failed schema validation: "
-                                            f"{schema_exc.args[0]}",
-                                            suggestion=(
-                                                "Emit a JSON object to stdout "
-                                                "with the declared fields and "
-                                                "types. Write logs to stderr."
-                                            ),
-                                        ) from schema_exc
+                                    self._validate_script_output_schema(
+                                        agent,
+                                        parsed_json,
+                                        json_parse_error,
+                                        output_content,
+                                    )
                                 except ValidationError as exc:
                                     self._emit(
                                         "script_failed",

--- a/tests/test_config/test_script_schema.py
+++ b/tests/test_config/test_script_schema.py
@@ -104,10 +104,11 @@ class TestScriptAgentDef:
             AgentDef(name="bad", type="script", command="echo", tools=["web_search"])
 
     def test_script_with_output_accepted(self) -> None:
-        """Script agents may declare an `output:` schema (issue #118).
+        """Script agents may declare an `output:` schema at config time (issue #118).
 
-        When a schema is declared, the engine validates JSON stdout against
-        it at runtime. The schema declaration itself should construct cleanly.
+        This test only covers the schema-construction path. Runtime validation
+        of the JSON stdout against the schema is exercised in
+        ``tests/test_engine/test_script_workflow.py::TestScriptOutputSchema``.
         """
         agent = AgentDef(
             name="detector",
@@ -125,7 +126,12 @@ class TestScriptAgentDef:
         assert agent.output["issue_count"].type == "number"
 
     def test_script_with_empty_output_accepted(self) -> None:
-        """Empty `output: {}` opts into strict JSON-object mode with zero fields."""
+        """Empty `output: {}` is accepted at config time.
+
+        Runtime behavior (strict JSON-object mode with zero declared fields)
+        is exercised in
+        ``test_engine/test_script_workflow.py::test_empty_schema_requires_json_object``.
+        """
         agent = AgentDef(
             name="probe",
             type="script",

--- a/tests/test_config/test_script_schema.py
+++ b/tests/test_config/test_script_schema.py
@@ -103,15 +103,37 @@ class TestScriptAgentDef:
         with pytest.raises(ValidationError, match="script agents cannot have 'tools'"):
             AgentDef(name="bad", type="script", command="echo", tools=["web_search"])
 
-    def test_script_with_output_raises(self) -> None:
-        """Test that script agent with output schema raises ValidationError."""
-        with pytest.raises(ValidationError, match="script agents cannot have 'output'"):
-            AgentDef(
-                name="bad",
-                type="script",
-                command="echo",
-                output={"result": OutputField(type="string")},
-            )
+    def test_script_with_output_accepted(self) -> None:
+        """Script agents may declare an `output:` schema (issue #118).
+
+        When a schema is declared, the engine validates JSON stdout against
+        it at runtime. The schema declaration itself should construct cleanly.
+        """
+        agent = AgentDef(
+            name="detector",
+            type="script",
+            command="python",
+            args=["-c", "import json; print(json.dumps({'route': 'planning'}))"],
+            output={
+                "route": OutputField(type="string", description="Next phase"),
+                "issue_count": OutputField(type="number"),
+            },
+        )
+        assert agent.output is not None
+        assert "route" in agent.output
+        assert agent.output["route"].type == "string"
+        assert agent.output["issue_count"].type == "number"
+
+    def test_script_with_empty_output_accepted(self) -> None:
+        """Empty `output: {}` opts into strict JSON-object mode with zero fields."""
+        agent = AgentDef(
+            name="probe",
+            type="script",
+            command="echo",
+            args=["{}"],
+            output={},
+        )
+        assert agent.output == {}
 
     def test_script_with_system_prompt_raises(self) -> None:
         """Test that script agent with system_prompt raises ValidationError."""

--- a/tests/test_engine/test_script_workflow.py
+++ b/tests/test_engine/test_script_workflow.py
@@ -644,6 +644,14 @@ class TestScriptOutputSchema:
         emitter.subscribe(events.append)
         return emitter, events
 
+    @staticmethod
+    async def _run_expect_validation_error(config: WorkflowConfig) -> ValidationError:
+        """Run the workflow and assert it raises ValidationError; return the error."""
+        engine = WorkflowEngine(config, MagicMock())
+        with pytest.raises(ValidationError) as exc_info:
+            await engine.run({})
+        return exc_info.value
+
     @pytest.mark.asyncio
     async def test_valid_json_matches_schema(self) -> None:
         """Happy path: stdout JSON matches declared schema → fields available."""
@@ -675,12 +683,9 @@ class TestScriptOutputSchema:
             args=["-c", "print('not json')"],
             output={"route": OutputField(type="string")},
         )
-        engine = WorkflowEngine(config, MagicMock())
 
-        with pytest.raises(ValidationError) as exc_info:
-            await engine.run({})
+        err = await self._run_expect_validation_error(config)
 
-        err = exc_info.value
         msg = str(err)
         assert "detector" in msg
         assert "not valid JSON" in msg
@@ -699,12 +704,10 @@ class TestScriptOutputSchema:
             args=["-c", 'print(\'{"route": "plan\')'],
             output={"route": OutputField(type="string")},
         )
-        engine = WorkflowEngine(config, MagicMock())
 
-        with pytest.raises(ValidationError) as exc_info:
-            await engine.run({})
+        err = await self._run_expect_validation_error(config)
 
-        msg = str(exc_info.value)
+        msg = str(err)
         # Underlying JSONDecodeError text describes the unterminated string.
         assert "Unterminated" in msg or "delimiter" in msg or "line 1" in msg
 
@@ -715,12 +718,9 @@ class TestScriptOutputSchema:
             args=["-c", "pass"],
             output={"route": OutputField(type="string")},
         )
-        engine = WorkflowEngine(config, MagicMock())
 
-        with pytest.raises(ValidationError) as exc_info:
-            await engine.run({})
+        err = await self._run_expect_validation_error(config)
 
-        err = exc_info.value
         assert "detector" in str(err)
         assert err.suggestion is not None
         assert "stderr" in err.suggestion.lower()
@@ -737,12 +737,10 @@ class TestScriptOutputSchema:
             args=["-c", f"print({stdout_payload!r})"],
             output={"route": OutputField(type="string")},
         )
-        engine = WorkflowEngine(config, MagicMock())
 
-        with pytest.raises(ValidationError) as exc_info:
-            await engine.run({})
+        err = await self._run_expect_validation_error(config)
 
-        assert "object" in str(exc_info.value).lower()
+        assert "object" in str(err).lower()
 
     @pytest.mark.asyncio
     async def test_missing_required_field_raises(self) -> None:
@@ -754,12 +752,9 @@ class TestScriptOutputSchema:
                 "count": OutputField(type="number"),
             },
         )
-        engine = WorkflowEngine(config, MagicMock())
 
-        with pytest.raises(ValidationError) as exc_info:
-            await engine.run({})
+        err = await self._run_expect_validation_error(config)
 
-        err = exc_info.value
         msg = str(err)
         # Wrapping in workflow.py adds the script name and stdout-JSON suggestion
         # on top of the generic validate_output() message.
@@ -781,12 +776,10 @@ class TestScriptOutputSchema:
                 "count": OutputField(type="number"),
             },
         )
-        engine = WorkflowEngine(config, MagicMock())
 
-        with pytest.raises(ValidationError) as exc_info:
-            await engine.run({})
+        err = await self._run_expect_validation_error(config)
 
-        msg = str(exc_info.value)
+        msg = str(err)
         assert "detector" in msg
         assert "route" in msg
 

--- a/tests/test_engine/test_script_workflow.py
+++ b/tests/test_engine/test_script_workflow.py
@@ -670,7 +670,7 @@ class TestScriptOutputSchema:
 
     @pytest.mark.asyncio
     async def test_non_json_stdout_raises_validation_error(self) -> None:
-        """Schema declared + non-JSON stdout → ValidationError with stderr guidance."""
+        """Schema declared + non-JSON stdout → ValidationError surfaces parser detail."""
         config = self._config_with_schema(
             args=["-c", "print('not json')"],
             output={"route": OutputField(type="string")},
@@ -680,13 +680,37 @@ class TestScriptOutputSchema:
         with pytest.raises(ValidationError) as exc_info:
             await engine.run({})
 
-        msg = str(exc_info.value)
+        err = exc_info.value
+        msg = str(err)
         assert "detector" in msg
-        assert "not valid JSON" in msg or "JSON" in msg
+        assert "not valid JSON" in msg
+        # The underlying json.JSONDecodeError text is surfaced so users can
+        # see WHY the parse failed (e.g. "Expecting value: line 1 column 1").
+        assert "line 1" in msg or "Expecting" in msg
+        # The suggestion explicitly mentions writing logs to stderr.
+        assert err.suggestion is not None
+        assert "stderr" in err.suggestion.lower()
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_surfaces_parser_detail(self) -> None:
+        """Truncated/malformed JSON: parser error column/position appears in message."""
+        # Truncated object missing the closing brace.
+        config = self._config_with_schema(
+            args=["-c", 'print(\'{"route": "plan\')'],
+            output={"route": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock())
+
+        with pytest.raises(ValidationError) as exc_info:
+            await engine.run({})
+
+        msg = str(exc_info.value)
+        # Underlying JSONDecodeError text describes the unterminated string.
+        assert "Unterminated" in msg or "delimiter" in msg or "line 1" in msg
 
     @pytest.mark.asyncio
     async def test_empty_stdout_raises_validation_error(self) -> None:
-        """Empty stdout + schema → ValidationError."""
+        """Empty stdout + schema → ValidationError with stderr-for-logs suggestion."""
         config = self._config_with_schema(
             args=["-c", "pass"],
             output={"route": OutputField(type="string")},
@@ -696,9 +720,10 @@ class TestScriptOutputSchema:
         with pytest.raises(ValidationError) as exc_info:
             await engine.run({})
 
-        # The actionable suggestion should mention stderr for logs.
-        msg = str(exc_info.value)
-        assert "detector" in msg
+        err = exc_info.value
+        assert "detector" in str(err)
+        assert err.suggestion is not None
+        assert "stderr" in err.suggestion.lower()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -721,7 +746,7 @@ class TestScriptOutputSchema:
 
     @pytest.mark.asyncio
     async def test_missing_required_field_raises(self) -> None:
-        """JSON missing a declared field → ValidationError."""
+        """JSON missing a declared field → ValidationError mentions script + field."""
         config = self._config_with_schema(
             args=["-c", 'import json; print(json.dumps({"route": "planning"}))'],
             output={
@@ -731,12 +756,21 @@ class TestScriptOutputSchema:
         )
         engine = WorkflowEngine(config, MagicMock())
 
-        with pytest.raises(ValidationError, match="count"):
+        with pytest.raises(ValidationError) as exc_info:
             await engine.run({})
+
+        err = exc_info.value
+        msg = str(err)
+        # Wrapping in workflow.py adds the script name and stdout-JSON suggestion
+        # on top of the generic validate_output() message.
+        assert "detector" in msg
+        assert "count" in msg
+        assert err.suggestion is not None
+        assert "stderr" in err.suggestion.lower()
 
     @pytest.mark.asyncio
     async def test_wrong_field_type_raises(self) -> None:
-        """JSON field has wrong type → ValidationError."""
+        """JSON field has wrong type → ValidationError mentions script + field."""
         config = self._config_with_schema(
             args=[
                 "-c",
@@ -749,12 +783,16 @@ class TestScriptOutputSchema:
         )
         engine = WorkflowEngine(config, MagicMock())
 
-        with pytest.raises(ValidationError, match="route"):
+        with pytest.raises(ValidationError) as exc_info:
             await engine.run({})
+
+        msg = str(exc_info.value)
+        assert "detector" in msg
+        assert "route" in msg
 
     @pytest.mark.asyncio
     async def test_extra_fields_allowed(self) -> None:
-        """Extra JSON fields beyond schema are kept (matches LLM agent behavior)."""
+        """Extra JSON fields beyond schema are kept (parity with LLM agent output handling)."""
         config = self._config_with_schema(
             args=[
                 "-c",

--- a/tests/test_engine/test_script_workflow.py
+++ b/tests/test_engine/test_script_workflow.py
@@ -24,6 +24,7 @@ from conductor.config.schema import (
     AgentDef,
     ContextConfig,
     LimitsConfig,
+    OutputField,
     ParallelGroup,
     RouteDef,
     RuntimeConfig,
@@ -31,7 +32,8 @@ from conductor.config.schema import (
     WorkflowDef,
 )
 from conductor.engine.workflow import WorkflowEngine
-from conductor.exceptions import ConfigurationError
+from conductor.events import WorkflowEvent, WorkflowEventEmitter
+from conductor.exceptions import ConfigurationError, ValidationError
 from conductor.providers.copilot import CopilotProvider
 
 
@@ -599,3 +601,318 @@ class TestScriptJsonStdout:
         out = engine.context.agent_outputs["detector"]
         assert set(out.keys()) == {"stdout", "stderr", "exit_code"}
         assert out["stdout"] == ""
+
+
+class TestScriptOutputSchema:
+    """Tests for declared `output:` schemas on script agents (issue #118).
+
+    When a script declares an output schema, the engine validates JSON stdout
+    against it before emitting `script_completed`. Validation failures raise
+    ValidationError and emit `script_failed` instead.
+    """
+
+    @staticmethod
+    def _config_with_schema(
+        args: list[str],
+        output: dict[str, OutputField],
+    ) -> WorkflowConfig:
+        """Build a single-script workflow config with the given args + schema."""
+        return WorkflowConfig(
+            workflow=WorkflowDef(
+                name="schema-script",
+                entry_point="detector",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="detector",
+                    type="script",
+                    command=sys.executable,
+                    args=args,
+                    output=output,
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+
+    @staticmethod
+    def _make_collector() -> tuple[WorkflowEventEmitter, list[WorkflowEvent]]:
+        events: list[WorkflowEvent] = []
+        emitter = WorkflowEventEmitter()
+        emitter.subscribe(events.append)
+        return emitter, events
+
+    @pytest.mark.asyncio
+    async def test_valid_json_matches_schema(self) -> None:
+        """Happy path: stdout JSON matches declared schema → fields available."""
+        config = self._config_with_schema(
+            args=[
+                "-c",
+                'import json; print(json.dumps({"route": "planning", "count": 3}))',
+            ],
+            output={
+                "route": OutputField(type="string"),
+                "count": OutputField(type="number"),
+            },
+        )
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        out = engine.context.agent_outputs["detector"]
+        assert out["route"] == "planning"
+        assert out["count"] == 3
+        # Built-ins still present alongside declared fields.
+        assert out["exit_code"] == 0
+        assert "stdout" in out
+        assert "stderr" in out
+
+    @pytest.mark.asyncio
+    async def test_non_json_stdout_raises_validation_error(self) -> None:
+        """Schema declared + non-JSON stdout → ValidationError with stderr guidance."""
+        config = self._config_with_schema(
+            args=["-c", "print('not json')"],
+            output={"route": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock())
+
+        with pytest.raises(ValidationError) as exc_info:
+            await engine.run({})
+
+        msg = str(exc_info.value)
+        assert "detector" in msg
+        assert "not valid JSON" in msg or "JSON" in msg
+
+    @pytest.mark.asyncio
+    async def test_empty_stdout_raises_validation_error(self) -> None:
+        """Empty stdout + schema → ValidationError."""
+        config = self._config_with_schema(
+            args=["-c", "pass"],
+            output={"route": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock())
+
+        with pytest.raises(ValidationError) as exc_info:
+            await engine.run({})
+
+        # The actionable suggestion should mention stderr for logs.
+        msg = str(exc_info.value)
+        assert "detector" in msg
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "stdout_payload",
+        ["[1, 2, 3]", "42", '"a string"', "true"],
+        ids=["array", "int", "string", "bool"],
+    )
+    async def test_json_non_object_raises_validation_error(self, stdout_payload: str) -> None:
+        """JSON arrays/scalars at top level + schema → ValidationError."""
+        config = self._config_with_schema(
+            args=["-c", f"print({stdout_payload!r})"],
+            output={"route": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock())
+
+        with pytest.raises(ValidationError) as exc_info:
+            await engine.run({})
+
+        assert "object" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_required_field_raises(self) -> None:
+        """JSON missing a declared field → ValidationError."""
+        config = self._config_with_schema(
+            args=["-c", 'import json; print(json.dumps({"route": "planning"}))'],
+            output={
+                "route": OutputField(type="string"),
+                "count": OutputField(type="number"),
+            },
+        )
+        engine = WorkflowEngine(config, MagicMock())
+
+        with pytest.raises(ValidationError, match="count"):
+            await engine.run({})
+
+    @pytest.mark.asyncio
+    async def test_wrong_field_type_raises(self) -> None:
+        """JSON field has wrong type → ValidationError."""
+        config = self._config_with_schema(
+            args=[
+                "-c",
+                'import json; print(json.dumps({"route": 42, "count": 3}))',
+            ],
+            output={
+                "route": OutputField(type="string"),
+                "count": OutputField(type="number"),
+            },
+        )
+        engine = WorkflowEngine(config, MagicMock())
+
+        with pytest.raises(ValidationError, match="route"):
+            await engine.run({})
+
+    @pytest.mark.asyncio
+    async def test_extra_fields_allowed(self) -> None:
+        """Extra JSON fields beyond schema are kept (matches LLM agent behavior)."""
+        config = self._config_with_schema(
+            args=[
+                "-c",
+                'import json; print(json.dumps({"route": "planning", "extra": "ok"}))',
+            ],
+            output={"route": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        out = engine.context.agent_outputs["detector"]
+        assert out["route"] == "planning"
+        assert out["extra"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_empty_schema_requires_json_object(self) -> None:
+        """`output: {}` opts into strict mode: any JSON object passes, non-JSON fails."""
+        # Empty schema + JSON object → passes.
+        config_ok = self._config_with_schema(
+            args=["-c", 'import json; print(json.dumps({"anything": 1}))'],
+            output={},
+        )
+        engine = WorkflowEngine(config_ok, MagicMock())
+        await engine.run({})
+        assert engine.context.agent_outputs["detector"]["anything"] == 1
+
+        # Empty schema + non-JSON → ValidationError.
+        config_bad = self._config_with_schema(
+            args=["-c", "print('hi')"],
+            output={},
+        )
+        engine = WorkflowEngine(config_bad, MagicMock())
+        with pytest.raises(ValidationError):
+            await engine.run({})
+
+    @pytest.mark.asyncio
+    async def test_builtin_fields_preserved_when_not_shadowed(self) -> None:
+        """Declared schema with non-builtin fields still exposes stdout/stderr/exit_code."""
+        config = self._config_with_schema(
+            args=[
+                "-c",
+                "import sys, json;"
+                ' sys.stderr.write("warning"); '
+                'print(json.dumps({"route": "planning"}))',
+            ],
+            output={"route": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        out = engine.context.agent_outputs["detector"]
+        assert out["route"] == "planning"
+        assert "warning" in out["stderr"]
+        assert out["exit_code"] == 0
+        assert isinstance(out["stdout"], str)
+
+    @pytest.mark.asyncio
+    async def test_schema_validates_shadowed_builtin(self) -> None:
+        """Validation runs on the merged dict, so shadowed built-ins are validated."""
+        # Script emits {"exit_code": "ok"} which shadows the built-in int.
+        # Schema says exit_code should be a string → passes (validates merged value).
+        config = self._config_with_schema(
+            args=["-c", 'import json; print(json.dumps({"exit_code": "ok"}))'],
+            output={"exit_code": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+        assert engine.context.agent_outputs["detector"]["exit_code"] == "ok"
+
+        # Conversely: if schema requires exit_code as number but script shadows
+        # it with a string → ValidationError on the merged value.
+        config_bad = self._config_with_schema(
+            args=["-c", 'import json; print(json.dumps({"exit_code": "ok"}))'],
+            output={"exit_code": OutputField(type="number")},
+        )
+        engine = WorkflowEngine(config_bad, MagicMock())
+        with pytest.raises(ValidationError, match="exit_code"):
+            await engine.run({})
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_emits_script_failed_not_completed(self) -> None:
+        """On validation failure: script_failed emitted, script_completed is NOT."""
+        emitter, events = self._make_collector()
+        config = self._config_with_schema(
+            args=["-c", "print('not json')"],
+            output={"route": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock(), event_emitter=emitter)
+
+        with pytest.raises(ValidationError):
+            await engine.run({})
+
+        event_types = [e.type for e in events]
+        assert "script_started" in event_types
+        assert "script_failed" in event_types
+        assert "script_completed" not in event_types
+
+        # script_failed should carry stdout/stderr/exit_code so the dashboard
+        # can show what the script actually wrote.
+        failed = next(e for e in events if e.type == "script_failed")
+        assert failed.data["agent_name"] == "detector"
+        assert failed.data["error_type"] == "ValidationError"
+        assert "stdout" in failed.data
+        assert "stderr" in failed.data
+        assert "exit_code" in failed.data
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_does_not_store_context(self) -> None:
+        """On validation failure: agent output is NOT stored in context."""
+        config = self._config_with_schema(
+            args=["-c", "print('not json')"],
+            output={"route": OutputField(type="string")},
+        )
+        engine = WorkflowEngine(config, MagicMock())
+
+        with pytest.raises(ValidationError):
+            await engine.run({})
+
+        # detector should not appear in stored outputs.
+        assert "detector" not in engine.context.agent_outputs
+
+    @pytest.mark.asyncio
+    async def test_schema_field_drives_route(self) -> None:
+        """End-to-end: declared field drives routing to a downstream agent."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="schema-route",
+                entry_point="detector",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="detector",
+                    type="script",
+                    command=sys.executable,
+                    args=[
+                        "-c",
+                        'import json; print(json.dumps({"phase": "planning"}))',
+                    ],
+                    output={"phase": OutputField(type="string")},
+                    routes=[
+                        RouteDef(to="planner", when="phase == 'planning'"),
+                        RouteDef(to="$end"),
+                    ],
+                ),
+                AgentDef(
+                    name="planner",
+                    type="script",
+                    command=sys.executable,
+                    args=["-c", "print('planning done')"],
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        engine = WorkflowEngine(config, MagicMock())
+        await engine.run({})
+
+        assert engine.context.agent_outputs["detector"]["phase"] == "planning"
+        assert "planner" in engine.context.agent_outputs


### PR DESCRIPTION
Closes #118.

## Summary

Script agents can now optionally declare an `output:` schema using the
same `OutputField` syntax as LLM agents. When declared, the engine parses
stdout as JSON and validates against the schema *before* emitting
`script_completed`; missing fields, wrong types, non-JSON stdout, empty
stdout, and JSON arrays/scalars all raise `ValidationError` and emit
`script_failed` (carrying the captured stdout/stderr/exit_code) instead
of completing.

This unlocks self-documenting typed outputs for deterministic
detector/router/validator scripts, so routing conditions can reference
declared fields directly:

```yaml
- name: detect_state
  type: script
  command: python3
  args: ["-c", "import json; print(json.dumps({...}))"]
  output:
    phase:
      type: string
    issue_count:
      type: number
  routes:
    - to: planner
      when: "phase == 'planning'"
    - to: $end
```

…instead of routing on opaque `exit_code == 10` patterns.

## Behavior contract

- **No `output:`** → unchanged. The auto-merge of JSON-object stdout
  added in #122 still happens, non-JSON stdout is preserved as-is, no
  validation errors.
- **`output:` declared** → strict mode:
  - stdout MUST be a JSON object; arrays/scalars/empty/non-JSON fail.
  - Missing required fields and wrong types fail.
  - Extra fields beyond the schema are kept (matches LLM-agent semantics).
  - Validation runs on the **merged** dict, so declaring
    `exit_code: { type: number }` asserts the built-in matches, and a
    script that shadows `exit_code` with a JSON key validates the
    shadowed value (preserving #122's contract).
  - `output: {}` opts into strict mode with zero required fields.
- **Failure events:** validation failures emit `script_failed`
  (with `stdout`/`stderr`/`exit_code` in the event data) and skip
  `script_completed`, so dashboards and JSONL logs show what the
  script actually wrote.

## Out of scope

- Field-level Jinja template validation (`{{ script.output.fooo }}`
  typo detection) — not done for LLM agents today either.
- Lifting the `parallel` / `for_each` script restrictions.

## Changes

- `src/conductor/config/schema.py` — drop the `script + output`
  rejection in `AgentDef.validate_agent_type`.
- `src/conductor/engine/workflow.py` — restructure the script step so
  parse + `validate_output(output_content, schema)` runs before
  `script_completed`; emits `script_failed` on `ValidationError` with
  stdout/stderr/exit_code carried in the event data.
- `tests/test_config/test_script_schema.py` — flip
  `test_script_with_output_raises` → `test_script_with_output_accepted`,
  add `test_script_with_empty_output_accepted`.
- `tests/test_engine/test_script_workflow.py` — new
  `TestScriptOutputSchema` class with 13 tests covering happy path,
  non-JSON stdout, empty stdout, JSON arrays/scalars, missing/
  wrong-type fields, extra fields, empty schema, builtin field
  preservation, shadowed builtin validation, event ordering, no
  context store on failure, and end-to-end routing on declared fields.
- `docs/workflow-syntax.md` — drop `output` from the Restrictions list;
  add the "Declared output schema (strict mode)" subsection with
  semantics and stderr-for-logs guidance.
- `examples/script-typed-output.yaml` — new example mirroring the
  issue's use case.

## Verification

- `make lint` — clean.
- `make typecheck` — only the pre-existing `dialog_evaluator.py`
  diagnostic (verified by stash test against the base branch).
- `make test` — **2636 passed, 15 skipped, 29 deselected** (no failures).
- `make validate-examples` — all examples (including the new
  `script-typed-output.yaml`) validate.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>