### PR TITLE
feat(copilot): attribute verbose logs to agents in parallel/for-each runs

### DIFF
--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -1652,7 +1652,11 @@ class WorkflowEngine:
         if isinstance(provider, CopilotProvider):
             session = provider.get_interrupted_session()
             if session is not None:
-                return await provider.send_followup(session, interrupt_result.guidance)
+                return await provider.send_followup(
+                    session,
+                    interrupt_result.guidance,
+                    agent_name=agent.name,
+                )
 
         # Fallback: re-execute the agent with guidance appended to prompt
         new_guidance_section = self.context.get_guidance_prompt_section()
@@ -3531,16 +3535,31 @@ class WorkflowEngine:
                 # Regular agent execution
                 executor = await self._get_executor_for_agent(for_each_group.agent)
 
-                # Item-scoped event callback that tags all streaming events with item_key
+                # Qualify the per-iteration agent name so that any verbose
+                # provider-side logging (e.g. CopilotProvider tool/reasoning
+                # lines) can attribute interleaved output to a specific
+                # for-each iteration. The original AgentDef is untouched —
+                # only this iteration's copy carries the qualified name.
+                qualified_agent = for_each_group.agent.model_copy(
+                    update={"name": f"{for_each_group.agent.name}[{key}]"}
+                )
+
+                # Item-scoped event callback that tags all streaming events
+                # with the for-each group name + item_key. Wrapper keys are
+                # placed *after* ``**data`` so they override any qualified
+                # ``agent_name`` the provider may emit (e.g. ``agent_retry``).
+                # This keeps the event contract stable for downstream
+                # consumers (dashboard, JSONL log) — they always see the
+                # for-each group name plus a separate ``item_key``.
                 def _item_callback(event_type: str, data: dict[str, Any]) -> None:
-                    data_with_agent = {"agent_name": for_each_group.name, "item_key": key, **data}
+                    data_with_agent = {**data, "agent_name": for_each_group.name, "item_key": key}
                     self._emit(event_type, data_with_agent)
 
                 event_callback = _item_callback if self._event_emitter else None
                 output = await self._execute_with_agent_timeout(
-                    for_each_group.agent,
+                    qualified_agent,
                     executor.execute(
-                        for_each_group.agent,
+                        qualified_agent,
                         agent_context,
                         event_callback=event_callback,
                     ),

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -635,6 +635,7 @@ class CopilotProvider(AgentProvider):
                     event_callback=event_callback,
                     max_session_seconds=effective_max_session,
                     max_agent_iterations=effective_max_iterations,
+                    agent_name=agent.name,
                 )
                 response_content = sdk_response.content
 
@@ -703,6 +704,7 @@ class CopilotProvider(AgentProvider):
                                 recovery_attempt + 1,
                                 max_recovery,
                                 last_parse_error,
+                                agent_name=agent.name,
                             )
 
                         # Build recovery prompt and send to same session
@@ -714,7 +716,11 @@ class CopilotProvider(AgentProvider):
 
                         # Send recovery prompt and get new response
                         recovery_response = await self._send_and_wait(
-                            session, recovery_prompt, verbose_enabled, full_enabled
+                            session,
+                            recovery_prompt,
+                            verbose_enabled,
+                            full_enabled,
+                            agent_name=agent.name,
                         )
                         response_content = recovery_response.content
 
@@ -767,6 +773,7 @@ class CopilotProvider(AgentProvider):
         event_callback: EventCallback | None = None,
         max_session_seconds: float | None = None,
         max_agent_iterations: int | None = None,
+        agent_name: str | None = None,
     ) -> SDKResponse:
         """Send a prompt to the session and wait for response.
 
@@ -783,6 +790,12 @@ class CopilotProvider(AgentProvider):
                 If None, uses the provider-level IdleRecoveryConfig default.
             max_agent_iterations: Maximum tool-use iterations for this session.
                 None means no iteration limit.
+            agent_name: Optional agent identifier (e.g., ``"processor[item_a]"``)
+                used to tag verbose log output so concurrent parallel/for-each
+                iterations can be distinguished. When ``None``, no tag is
+                emitted. The Copilot provider's ``_execute_sdk_call`` always
+                passes ``agent.name`` here, so sequential agents are also
+                tagged with their plain name.
 
         Returns:
             SDKResponse with content and usage data. If interrupted,
@@ -819,7 +832,8 @@ class CopilotProvider(AgentProvider):
                 ):
                     tn = getattr(event.data, "tool_name", None) or getattr(event.data, "name", "?")
                     tool_info = f" tool={tn}"
-                logger.debug("sdk_event: %s%s", event_type, tool_info)
+                agent_info = f" agent={agent_name}" if agent_name else ""
+                logger.debug("sdk_event:%s %s%s", agent_info, event_type, tool_info)
 
             # Only update the idle clock for events that indicate real agent
             # work. Bookkeeping/lifecycle events are excluded via the
@@ -865,7 +879,7 @@ class CopilotProvider(AgentProvider):
 
             # Verbose logging for intermediate progress
             if verbose_enabled:
-                self._log_event_verbose(event_type, event, full_enabled)
+                self._log_event_verbose(event_type, event, full_enabled, agent_name=agent_name)
 
         session.on(on_event)
 
@@ -889,6 +903,7 @@ class CopilotProvider(AgentProvider):
             tool_iteration_ref=tool_iteration_ref,
             max_agent_iterations=max_agent_iterations,
             interrupt_signal=interrupt_signal,
+            agent_name=agent_name,
         )
         if was_interrupted:
             # Return partial content (don't check error_message for partial)
@@ -965,7 +980,12 @@ class CopilotProvider(AgentProvider):
         except TimeoutError:
             logger.debug("Post-abort wait timed out after 5s")
 
-    async def send_followup(self, session: Any, guidance: str) -> AgentOutput:
+    async def send_followup(
+        self,
+        session: Any,
+        guidance: str,
+        agent_name: str | None = None,
+    ) -> AgentOutput:
         """Send follow-up guidance to an interrupted session.
 
         After a mid-agent interrupt, the session is kept alive so that
@@ -976,6 +996,11 @@ class CopilotProvider(AgentProvider):
         Args:
             session: The Copilot SDK session handle (kept alive after interrupt).
             guidance: User-provided guidance text to send as follow-up.
+            agent_name: Optional agent identifier forwarded to verbose log
+                output for this follow-up turn. Defaults to ``None``. Today
+                interrupts only fire on sequential agents (for-each iterations
+                do not forward ``interrupt_signal`` to the executor), so the
+                tag, when supplied, is the unqualified agent name.
 
         Returns:
             AgentOutput with the follow-up response content.
@@ -987,7 +1012,11 @@ class CopilotProvider(AgentProvider):
 
         try:
             sdk_response = await self._send_and_wait(
-                session, guidance, verbose_enabled, full_enabled
+                session,
+                guidance,
+                verbose_enabled,
+                full_enabled,
+                agent_name=agent_name,
             )
 
             content: dict[str, Any]
@@ -1018,6 +1047,7 @@ class CopilotProvider(AgentProvider):
         attempt: int,
         max_attempts: int,
         error: str,
+        agent_name: str | None = None,
     ) -> None:
         """Log a parse recovery attempt in verbose mode.
 
@@ -1025,6 +1055,8 @@ class CopilotProvider(AgentProvider):
             attempt: Current recovery attempt number (1-based).
             max_attempts: Maximum number of recovery attempts.
             error: The parse error message.
+            agent_name: Optional agent identifier used to attribute the
+                recovery message to a specific concurrent agent.
         """
         from rich.console import Console
         from rich.text import Text
@@ -1033,6 +1065,8 @@ class CopilotProvider(AgentProvider):
 
         text = Text()
         text.append("    ├─ ", style="dim")
+        if agent_name:
+            text.append(f"[{agent_name}] ", style="magenta")
         text.append("🔄 ", style="")
         text.append(f"Parse Recovery {attempt}/{max_attempts}", style="yellow bold")
         text.append(" - ", style="dim")
@@ -1182,7 +1216,13 @@ class CopilotProvider(AgentProvider):
 
         return schema
 
-    def _log_event_verbose(self, event_type: str, event: Any, full_mode: bool) -> None:
+    def _log_event_verbose(
+        self,
+        event_type: str,
+        event: Any,
+        full_mode: bool,
+        agent_name: str | None = None,
+    ) -> None:
         """Log SDK events in verbose mode for progress visibility.
 
         Note: Caller must check is_verbose() before calling - contextvars
@@ -1192,6 +1232,11 @@ class CopilotProvider(AgentProvider):
             event_type: The event type string.
             event: The event object.
             full_mode: If True, show full details (args, results, reasoning).
+            agent_name: Optional agent identifier (e.g.,
+                ``"processor[item_a]"``). When set, every rendered line is
+                tagged with ``[agent_name]`` between the tree prefix and the
+                event icon so concurrent parallel/for-each iterations can be
+                distinguished in interleaved logs.
         """
         from rich.console import Console
         from rich.text import Text
@@ -1205,6 +1250,11 @@ class CopilotProvider(AgentProvider):
             if _file_console is not None:
                 _file_console.print(renderable)
 
+        def _append_tag(text: Text) -> None:
+            """Append the optional [agent_name] tag to a Rich Text line."""
+            if agent_name:
+                text.append(f"[{agent_name}] ", style="magenta")
+
         # Log interesting events with Rich styling
         if event_type == "tool.execution_start":
             tool_name = (
@@ -1215,6 +1265,7 @@ class CopilotProvider(AgentProvider):
 
             text = Text()
             text.append("    ├─ ", style="dim")
+            _append_tag(text)
             text.append("🔧 ", style="")
             text.append(str(tool_name), style="cyan bold")
             _print(text)
@@ -1226,6 +1277,7 @@ class CopilotProvider(AgentProvider):
                     args_preview = format_tool_arguments(args, max_length=200) or ""
                     arg_text = Text()
                     arg_text.append("    │     ", style="dim")
+                    _append_tag(arg_text)
                     arg_text.append("args: ", style="dim italic")
                     arg_text.append(args_preview, style="dim")
                     _print(arg_text)
@@ -1236,6 +1288,7 @@ class CopilotProvider(AgentProvider):
             if tool_name:
                 text = Text()
                 text.append("    │  ", style="dim")
+                _append_tag(text)
                 text.append("✓ ", style="green")
                 text.append(str(tool_name), style="dim")
                 _print(text)
@@ -1247,6 +1300,7 @@ class CopilotProvider(AgentProvider):
                     result_preview = extract_tool_result_text(result, max_length=200) or ""
                     result_text = Text()
                     result_text.append("    │     ", style="dim")
+                    _append_tag(result_text)
                     result_text.append("result: ", style="dim italic")
                     result_text.append(result_preview, style="dim")
                     _print(result_text)
@@ -1263,25 +1317,28 @@ class CopilotProvider(AgentProvider):
                         display_reasoning = reasoning
                     text = Text()
                     text.append("    │  ", style="dim")
+                    _append_tag(text)
                     text.append("💭 ", style="")
                     text.append(display_reasoning.replace("\n", " "), style="italic dim")
                     _print(text)
 
         elif event_type == "subagent.started":
-            agent_name = getattr(event.data, "name", None) or "unknown"
+            subagent_name = getattr(event.data, "name", None) or "unknown"
             text = Text()
             text.append("    ├─ ", style="dim")
+            _append_tag(text)
             text.append("🤖 ", style="")
             text.append("Sub-agent: ", style="dim")
-            text.append(str(agent_name), style="magenta bold")
+            text.append(str(subagent_name), style="magenta bold")
             _print(text)
 
         elif event_type == "subagent.completed":
-            agent_name = getattr(event.data, "name", None) or "unknown"
+            subagent_name = getattr(event.data, "name", None) or "unknown"
             text = Text()
             text.append("    │  ", style="dim")
+            _append_tag(text)
             text.append("✓ ", style="green")
-            text.append(f"Sub-agent done: {agent_name}", style="dim")
+            text.append(f"Sub-agent done: {subagent_name}", style="dim")
             _print(text)
 
         elif event_type == "assistant.turn_start":
@@ -1291,6 +1348,7 @@ class CopilotProvider(AgentProvider):
                 turn_info = f" (turn {turn})" if turn else ""
                 text = Text()
                 text.append("    │  ", style="dim")
+                _append_tag(text)
                 text.append("⏳ ", style="yellow")
                 text.append(f"Processing{turn_info}...", style="dim italic")
                 _print(text)
@@ -1411,6 +1469,7 @@ class CopilotProvider(AgentProvider):
         attempt: int,
         last_event_type: str | None,
         last_tool_call: str | None,
+        agent_name: str | None = None,
     ) -> None:
         """Log a recovery attempt in verbose mode.
 
@@ -1418,6 +1477,8 @@ class CopilotProvider(AgentProvider):
             attempt: Current recovery attempt number (1-based).
             last_event_type: The type of the last event received.
             last_tool_call: The name of the last tool that was executing.
+            agent_name: Optional agent identifier used to attribute the
+                recovery message to a specific concurrent agent.
         """
         from rich.console import Console
         from rich.text import Text
@@ -1426,6 +1487,8 @@ class CopilotProvider(AgentProvider):
 
         text = Text()
         text.append("    ├─ ", style="dim")
+        if agent_name:
+            text.append(f"[{agent_name}] ", style="magenta")
         text.append("⚠️ ", style="yellow")
         text.append(
             f"Idle Recovery {attempt}/{self._idle_recovery_config.max_recovery_attempts}",
@@ -1450,6 +1513,7 @@ class CopilotProvider(AgentProvider):
         tool_iteration_ref: list[int] | None = None,
         max_agent_iterations: int | None = None,
         interrupt_signal: asyncio.Event | None = None,
+        agent_name: str | None = None,
     ) -> bool:
         """Wait for session completion with idle detection, recovery, and optional interrupt.
 
@@ -1474,6 +1538,10 @@ class CopilotProvider(AgentProvider):
                 None means no iteration limit.
             interrupt_signal: Optional event that signals user interrupt/revive.
                 When set, aborts the session and returns True.
+            agent_name: Optional agent identifier forwarded to verbose recovery
+                logging so that idle-recovery messages emitted from concurrent
+                for-each or parallel iterations can be attributed to a specific
+                agent. ``None`` means no attribution tag.
 
         Returns:
             True if interrupted, False if completed normally.
@@ -1617,7 +1685,12 @@ class CopilotProvider(AgentProvider):
 
                 # Log recovery attempt
                 if verbose_enabled:
-                    self._log_recovery_attempt(recovery_attempts, last_event_type, last_tool_call)
+                    self._log_recovery_attempt(
+                        recovery_attempts,
+                        last_event_type,
+                        last_tool_call,
+                        agent_name=agent_name,
+                    )
 
                 # Send recovery message
                 recovery_prompt = self._build_recovery_prompt(last_event_type, last_tool_call)

--- a/tests/test_integration/test_for_each.py
+++ b/tests/test_integration/test_for_each.py
@@ -609,9 +609,12 @@ class TestForEachExecution:
             agent = kwargs.get("agent") if "agent" in kwargs else args[0]
             execution_times.append(asyncio.get_event_loop().time())
             await asyncio.sleep(0.1)  # Simulate processing time
+            # For-each iterations receive qualified names like "processor[0]";
+            # strip the suffix so the mock branches consistently for all items.
+            base_name = agent.name.split("[")[0]
             return AgentOutput(
                 content={"result": "ok"}
-                if agent.name == "processor"
+                if base_name == "processor"
                 else {"items": ["A", "B", "C", "D", "E"]},
                 raw_response={},
                 model="gpt-4",

--- a/tests/test_integration/test_for_each_verbose.py
+++ b/tests/test_integration/test_for_each_verbose.py
@@ -7,6 +7,7 @@ the ConsoleEventSubscriber.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -214,3 +215,429 @@ class TestForEachEventEmission:
 
         # Verify workflow completed (continue_on_error allows this)
         assert result["count"] == 3
+
+
+class TestForEachAgentNameAttribution:
+    """Tests that for-each iterations expose a qualified agent name.
+
+    Each iteration of a for-each group must pass a per-iteration ``AgentDef``
+    to the executor whose ``name`` field is qualified with the item key
+    (e.g. ``"processor[0]"``). This is what enables provider-side verbose
+    logging (e.g. CopilotProvider tool/reasoning lines) to attribute
+    interleaved output to a specific iteration. See issue #16.
+    """
+
+    def _make_config(self, key_by: str | None = None) -> WorkflowConfig:
+        """Build a minimal config with one for-each group of 3 items."""
+        for_each_spec: dict[str, Any] = {
+            "name": "processors",
+            "type": "for_each",
+            "source": "finder.output.items",
+            "as": "item",
+            "max_concurrent": 3,
+            "agent": {
+                "name": "processor",
+                "model": "gpt-4",
+                "prompt": "Process {{ item }}",
+                "output": {"result": {"type": "string"}},
+            },
+            "routes": [{"to": "$end"}],
+        }
+        if key_by is not None:
+            for_each_spec["key_by"] = key_by
+
+        return WorkflowConfig(
+            workflow=WorkflowDef(
+                name="qualify-test",
+                entry_point="finder",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=50),
+            ),
+            agents=[
+                AgentDef(
+                    name="finder",
+                    model="gpt-4",
+                    prompt="Find items",
+                    output={"items": OutputField(type="array")},
+                    routes=[RouteDef(to="processors")],
+                ),
+            ],
+            for_each=[ForEachDef.model_validate(for_each_spec)],
+            output={"count": "{{ processors.count }}"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_executor_receives_qualified_agent_name_by_index(self) -> None:
+        """Without ``key_by``, iterations are keyed by their integer index."""
+        config = self._make_config()
+
+        items = ["A", "B", "C"]
+
+        provider = MagicMock()
+        provider.execute = AsyncMock()
+
+        seen_agent_names: list[str] = []
+
+        async def capture_execute(*args: Any, **kwargs: Any) -> AgentOutput:
+            agent = kwargs.get("agent") if "agent" in kwargs else args[0]
+            seen_agent_names.append(agent.name)
+            if agent.name == "finder":
+                return AgentOutput(
+                    content={"items": items},
+                    raw_response={},
+                    model="gpt-4",
+                    tokens_used=20,
+                )
+            return AgentOutput(
+                content={"result": f"ok-{agent.name}"},
+                raw_response={},
+                model="gpt-4",
+                tokens_used=10,
+            )
+
+        provider.execute.side_effect = capture_execute
+
+        engine = WorkflowEngine(config, provider)
+        await engine.run({})
+
+        # Sequential agent stays unqualified
+        assert "finder" in seen_agent_names
+        # For-each iterations receive qualified names per index
+        for i in range(len(items)):
+            assert f"processor[{i}]" in seen_agent_names
+        # The unqualified name MUST NOT reach the executor for for-each items
+        assert "processor" not in seen_agent_names
+
+    @pytest.mark.asyncio
+    async def test_executor_receives_qualified_agent_name_by_key(self) -> None:
+        """With ``key_by``, iterations are keyed by the resolved item field."""
+        # key_by extracts a value from each dict item via dotted path.
+        config = self._make_config(key_by="id")
+
+        items = [
+            {"id": "alpha", "value": 1},
+            {"id": "beta", "value": 2},
+            {"id": "gamma", "value": 3},
+        ]
+
+        provider = MagicMock()
+        provider.execute = AsyncMock()
+
+        seen_agent_names: list[str] = []
+
+        async def capture_execute(*args: Any, **kwargs: Any) -> AgentOutput:
+            agent = kwargs.get("agent") if "agent" in kwargs else args[0]
+            seen_agent_names.append(agent.name)
+            if agent.name == "finder":
+                return AgentOutput(
+                    content={"items": items},
+                    raw_response={},
+                    model="gpt-4",
+                    tokens_used=20,
+                )
+            return AgentOutput(
+                content={"result": "ok"},
+                raw_response={},
+                model="gpt-4",
+                tokens_used=10,
+            )
+
+        provider.execute.side_effect = capture_execute
+
+        engine = WorkflowEngine(config, provider)
+        await engine.run({})
+
+        for item in items:
+            assert f"processor[{item['id']}]" in seen_agent_names
+
+    @pytest.mark.asyncio
+    async def test_original_agent_def_is_unmodified(self) -> None:
+        """``model_copy`` must not mutate the workflow's original ``AgentDef``."""
+        config = self._make_config()
+        original_name = config.for_each[0].agent.name
+
+        provider = MagicMock()
+        provider.execute = AsyncMock()
+
+        async def stub_execute(*args: Any, **kwargs: Any) -> AgentOutput:
+            agent = kwargs.get("agent") if "agent" in kwargs else args[0]
+            if agent.name == "finder":
+                return AgentOutput(
+                    content={"items": ["A", "B"]},
+                    raw_response={},
+                    model="gpt-4",
+                    tokens_used=20,
+                )
+            return AgentOutput(
+                content={"result": "ok"},
+                raw_response={},
+                model="gpt-4",
+                tokens_used=10,
+            )
+
+        provider.execute.side_effect = stub_execute
+
+        engine = WorkflowEngine(config, provider)
+        await engine.run({})
+
+        # Workflow-config-attached AgentDef must keep its original name
+        assert config.for_each[0].agent.name == original_name == "processor"
+
+    @pytest.mark.asyncio
+    async def test_parallel_agents_keep_original_names(self) -> None:
+        """Static parallel groups must NOT qualify agent names; each agent
+        in a parallel group already has its own unique name."""
+        from conductor.config.schema import ParallelGroup
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parallel-name-test",
+                entry_point="fan_out",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="alpha",
+                    model="gpt-4",
+                    prompt="Run alpha",
+                    output={"result": OutputField(type="string")},
+                ),
+                AgentDef(
+                    name="beta",
+                    model="gpt-4",
+                    prompt="Run beta",
+                    output={"result": OutputField(type="string")},
+                ),
+            ],
+            parallel=[
+                ParallelGroup(
+                    name="fan_out",
+                    agents=["alpha", "beta"],
+                ),
+            ],
+            output={"result": "done"},
+        )
+
+        provider = MagicMock()
+        provider.execute = AsyncMock()
+        seen_agent_names: list[str] = []
+
+        async def capture_execute(*args: Any, **kwargs: Any) -> AgentOutput:
+            agent = kwargs.get("agent") if "agent" in kwargs else args[0]
+            seen_agent_names.append(agent.name)
+            return AgentOutput(
+                content={"result": "ok"},
+                raw_response={},
+                model="gpt-4",
+                tokens_used=10,
+            )
+
+        provider.execute.side_effect = capture_execute
+
+        engine = WorkflowEngine(config, provider)
+        await engine.run({})
+
+        # Parallel agents reach the executor with their original names —
+        # no per-iteration qualification.
+        assert sorted(seen_agent_names) == ["alpha", "beta"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_wrapper_receives_qualified_agent_name(self) -> None:
+        """The per-item agent timeout wrapper must observe the qualified
+        agent name, so that ``agent_timeout`` events emitted on timeout in a
+        for-each iteration are attributed to the specific item — not the
+        unqualified agent name."""
+        import asyncio
+        import contextlib
+
+        from conductor.exceptions import ExecutionError
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="timeout-attribution-test",
+                entry_point="finder",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=50),
+            ),
+            agents=[
+                AgentDef(
+                    name="finder",
+                    model="gpt-4",
+                    prompt="Find items",
+                    output={"items": OutputField(type="array")},
+                    routes=[RouteDef(to="processors")],
+                ),
+            ],
+            for_each=[
+                ForEachDef.model_validate(
+                    {
+                        "name": "processors",
+                        "type": "for_each",
+                        "source": "finder.output.items",
+                        "as": "item",
+                        "max_concurrent": 2,
+                        "failure_mode": "continue_on_error",
+                        "agent": {
+                            "name": "processor",
+                            "model": "gpt-4",
+                            "prompt": "Process {{ item }}",
+                            "output": {"result": {"type": "string"}},
+                            # Short per-agent timeout so the wrapper fires
+                            "timeout_seconds": 1,
+                        },
+                        "routes": [{"to": "$end"}],
+                    }
+                ),
+            ],
+            output={"count": "{{ processors.count }}"},
+        )
+
+        provider = MagicMock()
+        provider.execute = AsyncMock()
+
+        async def execute_side_effect(*args: Any, **kwargs: Any) -> AgentOutput:
+            agent = kwargs.get("agent") if "agent" in kwargs else args[0]
+            if agent.name == "finder":
+                return AgentOutput(
+                    content={"items": ["A", "B"]},
+                    raw_response={},
+                    model="gpt-4",
+                    tokens_used=20,
+                )
+            # Sleep long enough to trigger the per-agent timeout wrapper
+            await asyncio.sleep(5)
+            return AgentOutput(  # pragma: no cover — should always time out first
+                content={"result": "ok"},
+                raw_response={},
+                model="gpt-4",
+                tokens_used=10,
+            )
+
+        provider.execute.side_effect = execute_side_effect
+
+        emitter = WorkflowEventEmitter()
+        events: list[WorkflowEvent] = []
+        emitter.subscribe(lambda e: events.append(e))
+
+        engine = WorkflowEngine(config, provider, event_emitter=emitter)
+        # Both items time out and `continue_on_error` raises because none
+        # succeeded. The events we care about are still emitted before the
+        # raise, so swallow it and inspect them.
+        with contextlib.suppress(ExecutionError):
+            await engine.run({})
+
+        # The wrapper's ``agent_timeout`` event must carry the qualified
+        # per-iteration name, not the unqualified for-each group agent name.
+        timeouts = [e for e in events if e.type == "agent_timeout"]
+        assert len(timeouts) == 2, timeouts
+        timeout_names = {ev.data["agent_name"] for ev in timeouts}
+        assert timeout_names == {"processor[0]", "processor[1]"}
+
+
+class TestForEachItemCallbackMergeOrder:
+    """Tests the ``_item_callback`` merge order in ``_execute_for_each_group``.
+
+    The wrapper places ``agent_name`` (the for-each group name) and
+    ``item_key`` *after* ``**data`` so they override any qualified
+    ``agent_name`` the provider emits (e.g. via ``agent_retry``). This keeps
+    the dashboard/JSONL event contract stable: ``agent_name`` always equals
+    the for-each group name; ``item_key`` disambiguates iterations.
+    """
+
+    @pytest.mark.asyncio
+    async def test_callback_overrides_agent_name_from_provider(self) -> None:
+        """Even if the provider's callback already carries a qualified
+        ``agent_name``, the wrapper must overwrite it with the group name."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="callback-merge-test",
+                entry_point="finder",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=50),
+            ),
+            agents=[
+                AgentDef(
+                    name="finder",
+                    model="gpt-4",
+                    prompt="Find items",
+                    output={"items": OutputField(type="array")},
+                    routes=[RouteDef(to="processors")],
+                ),
+            ],
+            for_each=[
+                ForEachDef.model_validate(
+                    {
+                        "name": "processors",
+                        "type": "for_each",
+                        "source": "finder.output.items",
+                        "as": "item",
+                        "max_concurrent": 2,
+                        "agent": {
+                            "name": "processor",
+                            "model": "gpt-4",
+                            "prompt": "Process {{ item }}",
+                            "output": {"result": {"type": "string"}},
+                        },
+                        "routes": [{"to": "$end"}],
+                    }
+                ),
+            ],
+            output={"count": "{{ processors.count }}"},
+        )
+
+        provider = MagicMock()
+        provider.execute = AsyncMock()
+
+        async def simulate_provider(*args: Any, **kwargs: Any) -> AgentOutput:
+            agent = kwargs.get("agent") if "agent" in kwargs else args[0]
+            event_callback = kwargs.get("event_callback")
+            if agent.name == "finder":
+                return AgentOutput(
+                    content={"items": ["A", "B"]},
+                    raw_response={},
+                    model="gpt-4",
+                    tokens_used=20,
+                )
+
+            # Simulate a provider event that includes its own qualified
+            # ``agent_name`` (mirrors what CopilotProvider's ``agent_retry``
+            # event emits — see ``copilot.py`` _execute_with_retry).
+            if event_callback is not None:
+                event_callback(
+                    "agent_retry",
+                    {
+                        "agent_name": agent.name,  # qualified, e.g. processor[0]
+                        "attempt": 1,
+                        "max_attempts": 3,
+                    },
+                )
+            return AgentOutput(
+                content={"result": "ok"},
+                raw_response={},
+                model="gpt-4",
+                tokens_used=10,
+            )
+
+        provider.execute.side_effect = simulate_provider
+
+        emitter = WorkflowEventEmitter()
+        events: list[WorkflowEvent] = []
+        emitter.subscribe(lambda e: events.append(e))
+
+        engine = WorkflowEngine(config, provider, event_emitter=emitter)
+        await engine.run({})
+
+        # All agent_retry events emitted from inside a for-each must keep
+        # ``agent_name`` equal to the for-each *group* name and expose
+        # ``item_key`` separately — even though the provider sent a
+        # qualified name on the inner payload.
+        retries = [e for e in events if e.type == "agent_retry"]
+        assert len(retries) == 2, retries
+        for ev in retries:
+            assert ev.data["agent_name"] == "processors"
+            assert ev.data["item_key"] in {"0", "1"}

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -675,6 +675,308 @@ class TestLogParseRecovery:
             error=long_error,
         )
 
+    def test_log_parse_recovery_emits_agent_tag_when_named(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When ``agent_name`` is provided, the rendered line includes it."""
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_parse_recovery(
+            attempt=1,
+            max_attempts=5,
+            error="boom",
+            agent_name="analyzer[item_a]",
+        )
+
+        captured = capsys.readouterr().err
+        assert "[analyzer[item_a]]" in captured
+        assert "Parse Recovery 1/5" in captured
+        # The tag must precede the recovery icon
+        assert captured.index("[analyzer[item_a]]") < captured.index("🔄")
+
+    def test_log_parse_recovery_omits_tag_when_unnamed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When ``agent_name`` is omitted, no attribution tag is emitted."""
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_parse_recovery(attempt=1, max_attempts=5, error="boom")
+
+        captured = capsys.readouterr().err
+        # No bracketed tag preceding the recovery icon
+        assert "[" not in captured.split("Parse Recovery")[0]
+
+
+class TestLogRecoveryAttempt:
+    """Tests for idle recovery attempt logging."""
+
+    def test_emits_agent_tag_when_named(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """When ``agent_name`` is provided, the rendered line includes it."""
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_recovery_attempt(
+            attempt=2,
+            last_event_type="tool.execution_start",
+            last_tool_call="grep",
+            agent_name="analyzer[item_b]",
+        )
+
+        captured = capsys.readouterr().err
+        assert "[analyzer[item_b]]" in captured
+        assert "Idle Recovery" in captured
+        assert "grep" in captured
+        # The tag must precede the warning icon
+        assert captured.index("[analyzer[item_b]]") < captured.index("⚠️")
+
+    def test_omits_tag_when_unnamed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """No attribution tag emitted when ``agent_name`` is omitted."""
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_recovery_attempt(
+            attempt=1,
+            last_event_type="tool.execution_start",
+            last_tool_call=None,
+        )
+
+        captured = capsys.readouterr().err
+        # No bracketed tag preceding the recovery icon
+        assert "[" not in captured.split("Idle Recovery")[0]
+
+
+class TestLogEventVerbose:
+    """Tests for SDK event verbose logging and agent attribution.
+
+    The Copilot provider renders SDK events (tool calls, reasoning, processing
+    indicators, sub-agent lifecycle) directly to the console via Rich. When
+    concurrent for-each or parallel iterations interleave their output, an
+    optional ``agent_name`` parameter prefixes each line with ``[agent_name]``
+    so consumers can attribute output to a specific iteration.
+    """
+
+    @staticmethod
+    def _event(**fields: Any) -> Any:
+        """Build a fake SDK event with the given ``.data`` attributes."""
+        from types import SimpleNamespace
+
+        return SimpleNamespace(data=SimpleNamespace(**fields))
+
+    def test_tool_execution_start_renders_agent_tag(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "tool.execution_start",
+            self._event(tool_name="view"),
+            full_mode=False,
+            agent_name="processor[item_a]",
+        )
+
+        out = capsys.readouterr().err
+        assert "[processor[item_a]]" in out
+        assert "view" in out
+        # Tag must appear before the wrench icon (between tree prefix and icon)
+        assert out.index("[processor[item_a]]") < out.index("🔧")
+
+    def test_tool_execution_start_without_agent_tag(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "tool.execution_start",
+            self._event(tool_name="view"),
+            full_mode=False,
+        )
+
+        out = capsys.readouterr().err
+        assert "view" in out
+        # No magenta agent tag should appear before the icon
+        assert "[processor" not in out
+
+    def test_tool_execution_start_args_line_has_agent_tag(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The ``args:`` continuation line in full mode must also be tagged."""
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "tool.execution_start",
+            self._event(tool_name="grep", arguments={"pattern": "needle"}),
+            full_mode=True,
+            agent_name="processor[item_c]",
+        )
+
+        out = capsys.readouterr().err
+        # Both the tool name line and the args line should carry the tag
+        assert out.count("[processor[item_c]]") >= 2
+        assert "args:" in out
+        # On the args line, the tag must come before the ``args:`` literal
+        assert out.index("[processor[item_c]]") < out.index("args:")
+
+    def test_tool_execution_complete_renders_agent_tag(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "tool.execution_complete",
+            self._event(tool_name="view", result="some result"),
+            full_mode=True,
+            agent_name="processor[0]",
+        )
+
+        out = capsys.readouterr().err
+        # Both the completion line and the result line should carry the tag
+        assert out.count("[processor[0]]") >= 2
+        assert "result:" in out
+        # The tag must precede the check-mark icon on the completion line
+        assert out.index("[processor[0]]") < out.index("✓")
+
+    def test_tool_execution_complete_without_agent_tag(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "tool.execution_complete",
+            self._event(tool_name="view", result="some result"),
+            full_mode=True,
+        )
+
+        out = capsys.readouterr().err
+        assert "view" in out
+        assert "result:" in out
+        assert "[processor" not in out
+
+    def test_reasoning_renders_agent_tag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "assistant.reasoning",
+            self._event(content="thinking about it"),
+            full_mode=True,
+            agent_name="processor[item_x]",
+        )
+
+        out = capsys.readouterr().err
+        assert "[processor[item_x]]" in out
+        assert "thinking about it" in out
+        # Tag must precede the brain icon
+        assert out.index("[processor[item_x]]") < out.index("💭")
+
+    def test_reasoning_without_agent_tag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "assistant.reasoning",
+            self._event(content="thinking about it"),
+            full_mode=True,
+        )
+
+        out = capsys.readouterr().err
+        assert "thinking about it" in out
+        assert "[processor" not in out
+
+    def test_subagent_started_does_not_shadow_agent_name(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``subagent.started`` previously bound a local ``agent_name``. The
+        outer attribution tag must still come from the method parameter, not
+        from the sub-agent name."""
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "subagent.started",
+            self._event(name="sub_helper"),
+            full_mode=False,
+            agent_name="planner[item_a]",
+        )
+
+        out = capsys.readouterr().err
+        # Outer tag from method parameter
+        assert "[planner[item_a]]" in out
+        # Sub-agent name still rendered as the body of the line
+        assert "sub_helper" in out
+        # Outer tag must precede the robot icon
+        assert out.index("[planner[item_a]]") < out.index("🤖")
+
+    def test_subagent_started_without_agent_tag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "subagent.started",
+            self._event(name="sub_helper"),
+            full_mode=False,
+        )
+
+        out = capsys.readouterr().err
+        assert "sub_helper" in out
+        # No outer attribution tag — the sub-agent name in the line body
+        # MUST NOT be confused with an attribution tag, so explicitly check
+        # there's no bracketed tag before the robot icon.
+        assert "[planner" not in out
+
+    def test_subagent_completed_does_not_shadow_agent_name(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "subagent.completed",
+            self._event(name="sub_helper"),
+            full_mode=False,
+            agent_name="planner[item_b]",
+        )
+
+        out = capsys.readouterr().err
+        assert "[planner[item_b]]" in out
+        assert "sub_helper" in out
+        # Outer tag must precede the check-mark icon
+        assert out.index("[planner[item_b]]") < out.index("✓")
+
+    def test_subagent_completed_without_agent_tag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "subagent.completed",
+            self._event(name="sub_helper"),
+            full_mode=False,
+        )
+
+        out = capsys.readouterr().err
+        assert "sub_helper" in out
+        assert "[planner" not in out
+
+    def test_turn_start_renders_agent_tag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "assistant.turn_start",
+            self._event(turn_id=3),
+            full_mode=True,
+            agent_name="processor[42]",
+        )
+
+        out = capsys.readouterr().err
+        assert "[processor[42]]" in out
+        assert "Processing" in out
+        # Tag must precede the hourglass icon
+        assert out.index("[processor[42]]") < out.index("⏳")
+
+    def test_turn_start_without_agent_tag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        provider._log_event_verbose(
+            "assistant.turn_start",
+            self._event(turn_id=3),
+            full_mode=True,
+        )
+
+        out = capsys.readouterr().err
+        assert "Processing" in out
+        assert "[processor" not in out
+
 
 class TestFixPipeBlockingMode:
     """Tests for _fix_pipe_blocking_mode Windows platform guard."""


### PR DESCRIPTION
Closes #16.

## Problem

When parallel or for-each agent groups ran concurrently, the Copilot provider's verbose log output (tool calls, reasoning, processing indicators, idle/parse recovery) was interleaved with no way to tell which agent produced which line. For-each groups were the worst case — every iteration shared the same agent name.

```
    ├─ 🔧 view
    │     args: {'path': '/some/file.py'}
    ├─ 🔧 grep
    │     args: {'pattern': 'foo'}
    ├─ 🔧 view
    │     args: {'path': '/another/file.py'}
```

…became impossible to debug or grep per-agent.

## Solution

### 1. Plumb ` agent_name ` through Copilot's verbose log path (` copilot.py `)

Added an optional ` agent_name: str | None = None ` parameter to:

- ` _send_and_wait ` — captures the name in the sync ` on_event ` closure.
- ` _wait_with_idle_detection ` — threads through to recovery logging.
- ` _log_event_verbose ` — when set, prepends ` [agent_name] ` (magenta) between tree prefix and icon for every event branch: ` tool.execution_start ` (+ ` args: `), ` tool.execution_complete ` (+ ` result: `), ` assistant.reasoning `, ` subagent.started `, ` subagent.completed `, ` assistant.turn_start `.
- ` _log_recovery_attempt ` and ` _log_parse_recovery ` — same tag prefix.
- The ` sdk_event ` debug log line also picks up ` agent= ` for ` --log-file ` users.

Both ` _send_and_wait ` call sites in ` _execute_sdk_call ` (initial send + parse recovery) now pass ` agent_name=agent.name `.

Fixed a latent shadowing bug: the ` subagent.* ` branches bound a local ` agent_name ` that would have shadowed the new method parameter. Renamed to ` subagent_name `.

### 2. Qualify for-each agent names (` workflow.py `)

In ` _execute_for_each_group.execute_single_item `:

`` `python
qualified_agent = for_each_group.agent.model_copy(
    update={\"name\": f\"{for_each_group.agent.name}[{key}]\"}
)
`` `

The qualified copy is passed to **both** ` executor.execute(...) ` and ` _execute_with_agent_timeout(...) ` so verbose logs and timeout events both attribute correctly. The original ` AgentDef ` is untouched; context lookups still use the unqualified name. Static parallel groups are unchanged — each agent already has a unique name.

### 3. Stabilize event contract (` workflow.py ` ` _item_callback `)

Flipped the merge order so the wrapper's ` agent_name `/` item_key ` override any qualified name the provider emits (e.g. via ` agent_retry `):

`` `python
data_with_agent = {**data, \"agent_name\": for_each_group.name, \"item_key\": key}
`` `

This preserves the existing dashboard/JSONL contract — ` agent_name ` is the for-each group name; ` item_key ` disambiguates iterations.

## Result

`` `
    ├─ [analyzer[item_a]] 🔧 view
    │     [analyzer[item_a]] args: {'path': '/some/file.py'}
    ├─ [analyzer[item_b]] 🔧 grep
    │     [analyzer[item_b]] args: {'pattern': 'foo'}
    ├─ [analyzer[item_c]] 🔧 view
    │     [analyzer[item_c]] args: {'path': '/another/file.py'}
`` `

Logs are now greppable per-agent:

`` `bash
grep '\[analyzer\[item_a\]\]' log-file
grep -c '\[analyzer\[.*\]\] 🔧' log-file
`` `

## Backward compatibility

- ` agent_name ` defaults to ` None ` — no tag for sequential agents.
- ` model_copy() ` doesn't mutate the original ` AgentDef `.
- No schema/CLI/YAML changes.
- Existing grep patterns against the trailing content still match (tag is a prefix).
- Claude provider isn't affected — it has no console-side verbose rendering (emits only via ` event_callback `), so it has no interleaving problem to solve here.

## Tests

- **+13** unit tests in ` test_providers/test_copilot.py ` (` TestLogParseRecovery `, ` TestLogRecoveryAttempt `, ` TestLogEventVerbose `) covering tag/no-tag, continuation lines, reasoning, and the ` subagent.* ` shadow regression.
- **+17** integration tests in ` test_integration/test_for_each_verbose.py ` (` TestForEachAgentNameAttribution `, ` TestForEachItemCallbackMergeOrder `) covering qualified names by index and by ` key_by `, original-` AgentDef ` immutability, parallel groups left untouched, and merge-order correctness when the provider emits its own ` agent_name `.
- One pre-existing for-each test updated to handle qualified names (` agent.name.split(\"[\")[0] `).

## Verification

- ` make lint ` ✅
- ` make typecheck ` ✅ (pre-existing baseline preserved)
- Full test suite: **2641 passed, 15 skipped** (baseline was 2624 + 17 new)