### PR TITLE
feat(validate): warn on undeclared agent.output refs and field-level mismatches in explicit mode

### DIFF
--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import jinja2
 from jinja2 import Environment, meta, nodes
@@ -68,6 +68,16 @@ _BUILTIN_NAMES = frozenset({"workflow", "context", "item", "_index", "_key", "lo
 #   agent.output.field, group.outputs.member, group.errors.member
 _OUTPUT_ATTRS = frozenset({"output", "outputs", "errors"})
 
+# Attribute names that look like fields on an output but are actually built-in
+# dict methods. We avoid emitting field-precision warnings for these because
+# templates like ``{% for k, v in a.output.items() %}`` are valid uses of the
+# whole output object — even though ``items`` lexically resembles a field.
+# Note: the Call-vs-Getattr filter handles the common method-call case more
+# precisely; this set is a belt-and-suspenders fallback for code paths that
+# reference these names without calling them (e.g., assigning the method to a
+# variable, which is rare in practice).
+_DICT_METHOD_NAMES = frozenset({"items", "keys", "values", "get"})
+
 # DFS path cap: larger workflows may get partial coverage analysis
 _MAX_ENUMERATED_PATHS = 100
 
@@ -79,7 +89,7 @@ _MAX_ENUMERATED_PATHS = 100
 INPUT_REF_PATTERN = re.compile(
     r"^(?:"
     r"(?P<agent>[a-zA-Z_][a-zA-Z0-9_]*)\.output(?:\.(?P<field>[a-zA-Z_][a-zA-Z0-9_]*))?|"
-    r"(?P<parallel>[a-zA-Z_][a-zA-Z0-9_]*)\.(?:outputs|errors)(?:\.(?P<pg_agent>[a-zA-Z_][a-zA-Z0-9_]*)(?:\.(?P<pg_field>[a-zA-Z_][a-zA-Z0-9_]*))?)?|"
+    r"(?P<parallel>[a-zA-Z_][a-zA-Z0-9_]*)\.(?P<pg_kind>outputs|errors)(?:\.(?P<pg_agent>[a-zA-Z_][a-zA-Z0-9_]*)(?:\.(?P<pg_field>[a-zA-Z_][a-zA-Z0-9_]*))?)?|"
     r"workflow\.input\.(?P<input>[a-zA-Z_][a-zA-Z0-9_]*)"
     r")(?P<optional>\?)?$"
 )
@@ -595,7 +605,46 @@ def _enumerate_paths_to_end(
     return paths
 
 
-def _extract_template_refs(template: str) -> tuple[set[str], set[str]]:
+class TemplateRefs(NamedTuple):
+    """Structured references extracted from a Jinja2 template.
+
+    Provides both flat root-name sets (preserves the original API contract for
+    "unknown agent/workflow input" checks) and per-reference field detail
+    (enables explicit-mode field-precision warnings).
+
+    Attributes:
+        agent_refs: Root names referenced via ``<name>.output``,
+            ``<name>.outputs``, or ``<name>.errors`` (deduped). Used for
+            unknown-agent checks and undeclared-agent warnings.
+        workflow_inputs: Names referenced via ``workflow.input.<name>``.
+        agent_output_fields: Maps each agent name to the set of fields that
+            were referenced via ``<name>.output.<field>``. The sentinel value
+            ``None`` in the set means "bare ``<name>.output`` was referenced"
+            (i.e., the whole-output object) — this distinguishes
+            ``{{ a.output }}`` from ``{{ a.output.foo }}`` for field-precision
+            analysis. Absence from this dict means no ``<name>.output*`` ref
+            was seen (only ``.outputs`` / ``.errors`` perhaps).
+        group_member_fields: Maps each ``(group, member)`` pair to the set of
+            fields referenced via ``<group>.outputs.<member>.<field>``.
+            ``None`` in the set indicates a bare
+            ``<group>.outputs.<member>`` reference (whole member). The
+            sentinel key ``(group, None)`` means the template referenced
+            ``<group>.outputs`` with no member — all members are referenced
+            implicitly.
+        group_error_refs: Group names referenced via ``<group>.errors``. Kept
+            separate from output refs because the engine's runtime semantics
+            for ``.errors`` always copy the whole errors dict and never field-
+            slice, so field-precision checks must not be applied to them.
+    """
+
+    agent_refs: set[str]
+    workflow_inputs: set[str]
+    agent_output_fields: dict[str, set[str | None]]
+    group_member_fields: dict[tuple[str, str | None], set[str | None]]
+    group_error_refs: set[str]
+
+
+def _extract_template_refs(template: str) -> TemplateRefs:
     """Extract agent/group and workflow-input references from a Jinja2 template.
 
     Uses Jinja2's own parser, so:
@@ -604,6 +653,10 @@ def _extract_template_refs(template: str) -> tuple[set[str], set[str]]:
       - ``{% set x = ... %}`` bindings and macro parameters are excluded.
       - String literals are excluded: ``{{ x | replace("foo.output", "y") }}``
         does not produce a reference to ``foo``.
+      - Method calls on outputs are detected: ``{{ a.output.items() }}`` does
+        not emit a field ref to ``items`` (the ``items`` Getattr is the callee
+        of a Call node and is treated as a method invocation, not a field
+        access).
 
     A name is reported as an output reference when it appears as the root of a
     Getattr chain whose first attribute is one of ``output``/``outputs``/``errors``
@@ -615,28 +668,86 @@ def _extract_template_refs(template: str) -> tuple[set[str], set[str]]:
     Built-in namespaces (``workflow``, ``context``, ``item``, ``_index``, ``_key``,
     ``loop``) and any name bound by a Jinja2 scope are filtered out.
 
+    Limitations (documented intentionally):
+      - Bracket access (``a.output["bar"]``) is not detected. Detecting it
+        would require walking ``Getitem`` nodes with constant string keys.
+      - Dynamic field access (``a.output[var]``) is not detected.
+      - Method-call detection is local to each chain — if a method like
+        ``items`` is referenced without being called, it is still treated as
+        a field for the unknown-agent check, but is filtered from field-
+        precision checks via ``_DICT_METHOD_NAMES`` as a safety net.
+
     Args:
         template: A Jinja2 template string (may contain no template tags).
 
     Returns:
-        Tuple of ``(agent_refs, workflow_input_refs)``. Both sets are empty when
-        the template has no recognizable references or contains a syntax error
-        we cannot parse — semantic validation should not fail on malformed
-        templates; render-time will raise the precise error.
+        A :class:`TemplateRefs` instance with flat and structured reference
+        information. All fields are empty when the template has no
+        recognizable references or contains a syntax error we cannot parse —
+        semantic validation should not fail on malformed templates; render-
+        time will raise the precise error.
     """
+    empty = TemplateRefs(
+        agent_refs=set(),
+        workflow_inputs=set(),
+        agent_output_fields={},
+        group_member_fields={},
+        group_error_refs=set(),
+    )
+
     if not template or ("{{" not in template and "{%" not in template):
-        return set(), set()
+        return empty
 
     try:
         ast = _JINJA_ENV.parse(template)
     except jinja2.TemplateSyntaxError:
-        return set(), set()
+        return empty
 
-    undeclared = meta.find_undeclared_variables(ast)
+    # ``meta.find_undeclared_variables`` runs Jinja2's compiler over the AST
+    # and can raise ``TemplateAssertionError`` for semantic issues that
+    # ``parse()`` accepts (e.g. duplicate ``{% block %}`` names). Validation
+    # should not hard-fail on such templates — render-time will produce the
+    # precise error if the workflow actually runs.
+    try:
+        undeclared = meta.find_undeclared_variables(ast)
+    except jinja2.TemplateAssertionError:
+        return empty
+
+    # Pre-pass: identify Getattr nodes that are the callee of a Call so we can
+    # treat ``a.output.items()`` as a method invocation rather than a field
+    # access. Also identify Getattr nodes that are the ``.node`` of another
+    # Getattr — those are inner links in a chain (e.g. ``a.output`` from
+    # within ``a.output.bar``) and would otherwise emit spurious
+    # whole-output references. Using ``id()`` for identity comparison is safe
+    # within a single AST; we never store these IDs beyond this function.
+    callee_ids: set[int] = set()
+    for call in ast.find_all(nodes.Call):
+        if isinstance(call.node, nodes.Getattr):
+            callee_ids.add(id(call.node))
+    inner_link_ids: set[int] = set()
+    for ga in ast.find_all(nodes.Getattr):
+        if isinstance(ga.node, nodes.Getattr):
+            inner_link_ids.add(id(ga.node))
+
+    # workflow.input.<name> chains; collected directly into the result.
+    workflow_inputs: set[str] = set()
+    # group.errors chains; collected directly into the result.
+    group_error_refs: set[str] = set()
+    # Output / outputs chains, accumulated as the structured maps directly.
+    agent_output_fields: dict[str, set[str | None]] = {}
+    group_member_fields: dict[tuple[str, str | None], set[str | None]] = {}
     agent_refs: set[str] = set()
-    input_refs: set[str] = set()
 
     for node in ast.find_all(nodes.Getattr):
+        is_callee = id(node) in callee_ids
+        is_inner_link = id(node) in inner_link_ids
+        # Only top-level Getattrs are the entry point for a chain. Inner-link
+        # Getattrs are walked transitively when we process their enclosing
+        # outer Getattr (or, if the outer is the callee of a Call, when we
+        # process the callee itself).
+        if is_inner_link and not is_callee:
+            continue
+
         # Walk down the Getattr chain to its root Name, collecting attributes.
         attrs: list[str] = []
         cur: nodes.Node = node
@@ -649,13 +760,58 @@ def _extract_template_refs(template: str) -> tuple[set[str], set[str]]:
         if cur.name not in undeclared:
             continue
 
-        root = cur.name
-        if root == "workflow" and len(attrs) >= 2 and attrs[0] == "input":
-            input_refs.add(attrs[1])
-        elif attrs and attrs[0] in _OUTPUT_ATTRS and root not in _BUILTIN_NAMES:
-            agent_refs.add(root)
+        # If this is a method call (e.g. ``a.output.items()``), the trailing
+        # attribute is the method name, not a field. Trim it so the chain
+        # reduces to the receiver — yielding a whole-output ref rather than
+        # a spurious field ref to the method name.
+        if is_callee and attrs:
+            attrs = attrs[:-1]
+            if not attrs:
+                continue
 
-    return agent_refs, input_refs
+        root = cur.name
+
+        # workflow.input.<name>
+        if root == "workflow" and len(attrs) >= 2 and attrs[0] == "input":
+            workflow_inputs.add(attrs[1])
+            continue
+
+        # Other built-in namespaces and bare names are ignored.
+        if root in _BUILTIN_NAMES or not attrs:
+            continue
+
+        kind = attrs[0]
+        if kind not in _OUTPUT_ATTRS:
+            continue
+
+        # Errors are handled separately and never get field-precision treatment.
+        if kind == "errors":
+            group_error_refs.add(root)
+            agent_refs.add(root)
+            continue
+
+        agent_refs.add(root)
+        if kind == "output":
+            # attrs is ["output"] or ["output", "<field>", ...]
+            field: str | None = attrs[1] if len(attrs) >= 2 else None
+            agent_output_fields.setdefault(root, set()).add(field)
+        else:  # kind == "outputs"
+            # attrs is ["outputs"] or ["outputs", "<member>", ...]
+            if len(attrs) == 1:
+                # Bare group.outputs — record under sentinel member=None.
+                group_member_fields.setdefault((root, None), set()).add(None)
+            else:
+                member = attrs[1]
+                field = attrs[2] if len(attrs) >= 3 else None
+                group_member_fields.setdefault((root, member), set()).add(field)
+
+    return TemplateRefs(
+        agent_refs=agent_refs,
+        workflow_inputs=workflow_inputs,
+        agent_output_fields=agent_output_fields,
+        group_member_fields=group_member_fields,
+        group_error_refs=group_error_refs,
+    )
 
 
 def _extract_output_template_refs(output: dict[str, str]) -> set[str]:
@@ -669,8 +825,7 @@ def _extract_output_template_refs(output: dict[str, str]) -> set[str]:
     """
     refs: set[str] = set()
     for template in output.values():
-        agents, _ = _extract_template_refs(template)
-        refs.update(agents)
+        refs.update(_extract_template_refs(template).agent_refs)
     return refs
 
 
@@ -1004,44 +1159,195 @@ def _validate_template_references(
     for agent, valid_names in all_agents:
         templates = _collect_template_strings(agent)
 
-        # Extract declared input references for explicit-mode advisory checks.
-        declared_agents: set[str] = set()
+        # Extract declared input references for explicit-mode advisory checks,
+        # tracking the namespace (agent ``.output``, group ``.outputs``, group
+        # ``.errors``) separately. The same declaration set cannot suppress
+        # warnings for a different namespace — declaring ``pg.errors`` must
+        # not silence warnings about ``pg.outputs.*`` references and
+        # vice-versa, because the engine only populates the declared
+        # namespace into the agent's ctx (see ``_add_parallel_group_input``).
+        #
+        # Field-precision tracking (Gap A): ``set[str | None]`` values mean:
+        #   - ``None`` in the set => the whole namespace was declared
+        #     (e.g. ``a.output`` or ``g.outputs`` or ``g.outputs.m``). Any
+        #     field/member reference on that root is allowed at runtime.
+        #   - One or more strings => only those specific fields were declared
+        #     (e.g. ``a.output.foo``); referencing a different field will
+        #     fail at runtime.
         declared_workflow_inputs: set[str] = set()
+        declared_agent_output_fields: dict[str, set[str | None]] = {}
+        # Per (group, member) — only populated for ``.outputs`` declarations.
+        # Member is ``None`` for the bare-group form ``g.outputs``.
+        declared_group_output_member_fields: dict[tuple[str, str | None], set[str | None]] = {}
+        # Group names that have ANY ``.outputs`` declaration (whole-group,
+        # whole-member, or specific-field). Used for the "undeclared outputs"
+        # warning so we don't recompute the set per template iteration.
+        declared_groups_with_outputs: set[str] = set()
+        # Set of group names with errors declared. The engine copies the
+        # whole errors dict regardless of ``.member`` or ``.field`` suffixes
+        # (see ``_add_parallel_group_input`` errors branch), so no field-
+        # precision tracking is needed for errors.
+        declared_group_errors: set[str] = set()
         for ref in agent.input:
             match = INPUT_REF_PATTERN.match(ref.rstrip("?"))
             if not match:
                 continue
             ref_agent = match.group("agent")
             if ref_agent:
-                declared_agents.add(ref_agent)
+                field = match.group("field")
+                # field is None for bare ``a.output`` (whole output declared).
+                declared_agent_output_fields.setdefault(ref_agent, set()).add(field)
             ref_parallel = match.group("parallel")
             if ref_parallel:
-                declared_agents.add(ref_parallel)
+                pg_kind = match.group("pg_kind")
+                if pg_kind == "outputs":
+                    pg_agent = match.group("pg_agent")
+                    pg_field = match.group("pg_field")
+                    # pg_agent is None for bare ``g.outputs``;
+                    # pg_field is None for ``g.outputs.member`` (whole member).
+                    declared_group_output_member_fields.setdefault(
+                        (ref_parallel, pg_agent), set()
+                    ).add(pg_field)
+                    declared_groups_with_outputs.add(ref_parallel)
+                else:  # pg_kind == "errors"
+                    declared_group_errors.add(ref_parallel)
             ref_input = match.group("input")
             if ref_input:
                 declared_workflow_inputs.add(ref_input)
 
         for source, template in templates:
-            agent_refs, input_refs = _extract_template_refs(template)
+            refs = _extract_template_refs(template)
 
-            for ref_name in agent_refs:
-                if ref_name not in valid_names:
+            # Explicit-mode exclusions:
+            # - human_gate prompts render with the full accumulated context
+            #   (engine uses ``WorkflowContext.get_for_template()`` which forces
+            #   ``mode="accumulate"``), so they're never subject to
+            #   explicit-mode warnings.
+            # - script and workflow (sub-workflow) agents are excluded only for
+            #   ``workflow.input`` references because the engine's
+            #   ``_LOCAL_RENDER_AGENT_TYPES`` carve-out populates
+            #   ``workflow.input`` for them regardless of context mode.
+            #   Their ``agent.output`` references still require declaration —
+            #   the engine raises ``KeyError`` via ``_add_explicit_input`` if
+            #   an undeclared agent output is accessed.
+            agent_output_warning_allowed = is_explicit and agent.type != "human_gate"
+
+            # --- Agent-output references (``a.output[.field]``) ---
+            for ref_root, ref_fields in refs.agent_output_fields.items():
+                if ref_root not in valid_names:
                     errors.append(
-                        f"{source} references unknown agent '{ref_name}'. "
+                        f"{source} references unknown agent '{ref_root}'. "
                         f"Available: {', '.join(sorted(valid_names))}"
                     )
-                elif (
-                    is_explicit
-                    and agent.type not in ("script", "workflow")
-                    and ref_name not in declared_agents
-                ):
+                    continue
+                if agent_output_warning_allowed and ref_root not in declared_agent_output_fields:
                     warnings.append(
-                        f"{source} references '{ref_name}.output' but "
-                        f"agent '{agent.name}' does not declare '{ref_name}.output' "
+                        f"{source} references '{ref_root}.output' but "
+                        f"agent '{agent.name}' does not declare '{ref_root}.output' "
+                        f"in its input: list (explicit context mode)"
+                    )
+                    continue
+                # Field-precision (Gap A): warn when the template references a
+                # field that wasn't declared. Skip the check entirely when the
+                # declaration was for the whole output (``None`` in set).
+                if not agent_output_warning_allowed:
+                    continue
+                declared_fields = declared_agent_output_fields[ref_root]
+                if None in declared_fields:
+                    continue
+                declared_field_names = sorted(f for f in declared_fields if f)
+                declared_list = ", ".join(f"{ref_root}.output.{f}" for f in declared_field_names)
+                for ref_field in ref_fields:
+                    if ref_field is None:
+                        # Bare ``ref_root.output`` reference but only specific
+                        # fields were declared — at runtime the engine only
+                        # copies the declared fields into ctx, so the
+                        # whole-output access will only see a partial dict.
+                        warnings.append(
+                            f"{source} references the whole '{ref_root}.output' "
+                            f"object but agent '{agent.name}' only declares "
+                            f"specific fields ({', '.join(declared_field_names)}) "
+                            f"in its input: list. Declare '{ref_root}.output' (without "
+                            f"a field) to access the whole output (explicit context mode)"
+                        )
+                        continue
+                    if ref_field in _DICT_METHOD_NAMES:
+                        continue
+                    if ref_field not in declared_fields:
+                        warnings.append(
+                            f"{source} references '{ref_root}.output.{ref_field}' but "
+                            f"agent '{agent.name}' only declares "
+                            f"{declared_list} "
+                            f"in its input: list (explicit context mode)"
+                        )
+
+            # --- Group-output references (``g.outputs[.member[.field]]``) ---
+            # Skip the field-precision check for for-each groups because the
+            # engine's ``_add_parallel_group_input`` copies the whole member
+            # dict for dict-keyed for-each groups regardless of the declared
+            # ``.field`` suffix (see context.py:
+            # ``elif is_for_each_dict or len(remaining_parts) == 2``), so
+            # field-precision warnings would be false positives.
+            for (group, member), ref_fields in refs.group_member_fields.items():
+                if group not in valid_names:
+                    errors.append(
+                        f"{source} references unknown agent '{group}'. "
+                        f"Available: {', '.join(sorted(valid_names))}"
+                    )
+                    continue
+                if agent_output_warning_allowed and group not in declared_groups_with_outputs:
+                    warnings.append(
+                        f"{source} references '{group}.outputs' but "
+                        f"agent '{agent.name}' does not declare '{group}.outputs' "
+                        f"in its input: list (explicit context mode)"
+                    )
+                    continue
+                if not agent_output_warning_allowed:
+                    continue
+                if member is None or group in for_each_names:
+                    continue
+                # Skip if the whole group's outputs are declared (bare
+                # ``g.outputs`` covers all members).
+                if declared_group_output_member_fields.get((group, None)) is not None:
+                    continue
+                declared_fields = declared_group_output_member_fields.get((group, member))
+                if declared_fields is None or None in declared_fields:
+                    # Either the member isn't declared at all (will be
+                    # surfaced by the undeclared warning) or the whole
+                    # member is declared (any field is OK).
+                    continue
+                declared_field_names = sorted(f for f in declared_fields if f)
+                declared_list = ", ".join(
+                    f"{group}.outputs.{member}.{f}" for f in declared_field_names
+                )
+                for ref_field in ref_fields:
+                    if ref_field is None or ref_field in _DICT_METHOD_NAMES:
+                        continue
+                    if ref_field not in declared_fields:
+                        warnings.append(
+                            f"{source} references "
+                            f"'{group}.outputs.{member}.{ref_field}' but "
+                            f"agent '{agent.name}' only declares "
+                            f"{declared_list} "
+                            f"in its input: list (explicit context mode)"
+                        )
+
+            # --- Group-error references (``g.errors``) ---
+            for group in refs.group_error_refs:
+                if group not in valid_names:
+                    errors.append(
+                        f"{source} references unknown agent '{group}'. "
+                        f"Available: {', '.join(sorted(valid_names))}"
+                    )
+                    continue
+                if agent_output_warning_allowed and group not in declared_group_errors:
+                    warnings.append(
+                        f"{source} references '{group}.errors' but "
+                        f"agent '{agent.name}' does not declare '{group}.errors' "
                         f"in its input: list (explicit context mode)"
                     )
 
-            for input_name in input_refs:
+            for input_name in refs.workflow_inputs:
                 if workflow_input_names and input_name not in workflow_input_names:
                     # Only error when inputs ARE declared — workflows without
                     # input: blocks may use workflow.input conditionally.
@@ -1051,7 +1357,7 @@ def _validate_template_references(
                     )
                 elif (
                     is_explicit
-                    and agent.type not in ("script", "workflow")
+                    and agent.type not in ("script", "workflow", "human_gate")
                     and input_name not in declared_workflow_inputs
                 ):
                     warnings.append(
@@ -1064,13 +1370,13 @@ def _validate_template_references(
     # Check workflow output templates.
     if config.output:
         for field, template in config.output.items():
-            agent_refs, input_refs = _extract_template_refs(template)
-            for ref_name in agent_refs:
+            refs = _extract_template_refs(template)
+            for ref_name in refs.agent_refs:
                 if ref_name not in all_names:
                     errors.append(
                         f"Workflow output '{field}' references unknown agent '{ref_name}'"
                     )
-            for input_name in input_refs:
+            for input_name in refs.workflow_inputs:
                 if workflow_input_names and input_name not in workflow_input_names:
                     errors.append(
                         f"Workflow output '{field}' references unknown "

--- a/tests/test_config/test_validator.py
+++ b/tests/test_config/test_validator.py
@@ -668,74 +668,147 @@ class TestExtractTemplateRefs:
     """Unit tests for the Jinja2-AST-based reference extractor."""
 
     def test_simple_agent_output_ref(self) -> None:
-        agents, inputs = _extract_template_refs("{{ writer.output.text }}")
-        assert agents == {"writer"}
-        assert inputs == set()
+        refs = _extract_template_refs("{{ writer.output.text }}")
+        assert refs.agent_refs == {"writer"}
+        assert refs.workflow_inputs == set()
 
     def test_simple_workflow_input_ref(self) -> None:
-        agents, inputs = _extract_template_refs("Hello {{ workflow.input.name }}")
-        assert agents == set()
-        assert inputs == {"name"}
+        refs = _extract_template_refs("Hello {{ workflow.input.name }}")
+        assert refs.agent_refs == set()
+        assert refs.workflow_inputs == {"name"}
 
     def test_outputs_plural_ref(self) -> None:
-        agents, _ = _extract_template_refs("{{ pg.outputs.member.field }}")
-        assert agents == {"pg"}
+        refs = _extract_template_refs("{{ pg.outputs.member.field }}")
+        assert refs.agent_refs == {"pg"}
 
     def test_errors_ref(self) -> None:
-        agents, _ = _extract_template_refs("{% if pg.errors %}fail{% endif %}")
-        assert agents == {"pg"}
+        refs = _extract_template_refs("{% if pg.errors %}fail{% endif %}")
+        assert refs.agent_refs == {"pg"}
 
     def test_bare_output_ref(self) -> None:
-        agents, _ = _extract_template_refs("{{ writer.output }}")
-        assert agents == {"writer"}
+        refs = _extract_template_refs("{{ writer.output }}")
+        assert refs.agent_refs == {"writer"}
 
     def test_for_loop_variable_excluded(self) -> None:
         """Loop-bound vars must not be reported as agent refs (false-positive #1)."""
-        agents, _ = _extract_template_refs(
+        refs = _extract_template_refs(
             "{% for r in researcher.outputs %}{{ r.output.text }}{% endfor %}"
         )
         # Only the iterable name; the loop variable `r` is scope-bound.
-        assert agents == {"researcher"}
+        assert refs.agent_refs == {"researcher"}
 
     def test_string_literal_excluded(self) -> None:
         """Names inside string literals must not be reported (false-positive #2)."""
-        agents, _ = _extract_template_refs(
+        refs = _extract_template_refs(
             '{{ x | replace("foo.output", "y") | replace("bar.outputs", "z") }}'
         )
-        assert agents == set()
+        assert refs.agent_refs == set()
 
     def test_set_binding_excluded(self) -> None:
-        agents, _ = _extract_template_refs("{% set x = 1 %}{{ x.output }}")
-        assert agents == set()
+        refs = _extract_template_refs("{% set x = 1 %}{{ x.output }}")
+        assert refs.agent_refs == set()
 
     def test_built_in_namespaces_excluded(self) -> None:
         for builtin in ("workflow", "context", "item", "loop"):
-            agents, _ = _extract_template_refs("{{ " + builtin + ".output.x }}")
-            assert agents == set(), f"{builtin} leaked through"
+            refs = _extract_template_refs("{{ " + builtin + ".output.x }}")
+            assert refs.agent_refs == set(), f"{builtin} leaked through"
 
     def test_unrelated_attrs_ignored(self) -> None:
-        agents, inputs = _extract_template_refs("{{ writer.metadata.author }}")
-        assert agents == set()
-        assert inputs == set()
+        refs = _extract_template_refs("{{ writer.metadata.author }}")
+        assert refs.agent_refs == set()
+        assert refs.workflow_inputs == set()
 
     def test_no_template_tags(self) -> None:
-        assert _extract_template_refs("just plain text") == (set(), set())
-        assert _extract_template_refs("") == (set(), set())
+        refs = _extract_template_refs("just plain text")
+        assert refs.agent_refs == set() and refs.workflow_inputs == set()
+        refs = _extract_template_refs("")
+        assert refs.agent_refs == set() and refs.workflow_inputs == set()
 
     def test_malformed_template_returns_empty(self) -> None:
         # Don't raise — render-time validation will surface the precise error.
-        assert _extract_template_refs("{{ unterminated") == (set(), set())
+        refs = _extract_template_refs("{{ unterminated")
+        assert refs.agent_refs == set() and refs.workflow_inputs == set()
 
     def test_multiple_refs_in_one_template(self) -> None:
-        agents, inputs = _extract_template_refs(
+        refs = _extract_template_refs(
             "{{ a.output }}/{{ b.outputs.x }}/{{ workflow.input.foo }}/{{ workflow.input.bar }}"
         )
-        assert agents == {"a", "b"}
-        assert inputs == {"foo", "bar"}
+        assert refs.agent_refs == {"a", "b"}
+        assert refs.workflow_inputs == {"foo", "bar"}
+
+    def test_field_extracted_for_agent_output(self) -> None:
+        """Field-precision (Gap A): ``a.output.bar`` produces field ``bar``."""
+        refs = _extract_template_refs("{{ a.output.bar }}")
+        assert refs.agent_output_fields == {"a": {"bar"}}
+
+    def test_bare_output_marked_with_none_field(self) -> None:
+        """Field-precision (Gap A): bare ``a.output`` uses ``None`` sentinel."""
+        refs = _extract_template_refs("{{ a.output }}")
+        assert refs.agent_output_fields == {"a": {None}}
+
+    def test_prefix_chain_dedup_keeps_specific_field(self) -> None:
+        """Field-precision (Gap A): inner ``a.output`` Getattr from
+        ``{{ a.output.bar }}`` must NOT spuriously contribute a ``None`` field.
+        """
+        refs = _extract_template_refs("{{ a.output.bar }}")
+        assert refs.agent_output_fields == {"a": {"bar"}}, (
+            f"Expected only {{'bar'}}; got {refs.agent_output_fields}"
+        )
+
+    def test_method_call_does_not_emit_field(self) -> None:
+        """Field-precision (Gap A): ``a.output.items()`` is a method call —
+        the ``items`` Getattr is the callee of a Call and is filtered out.
+        Only the inner ``a.output`` Getattr is retained as a whole-output ref.
+        """
+        refs = _extract_template_refs("{% for k, v in a.output.items() %}{{ k }}{% endfor %}")
+        assert refs.agent_refs == {"a"}
+        assert refs.agent_output_fields == {"a": {None}}
+
+    def test_multiple_fields_on_same_agent(self) -> None:
+        refs = _extract_template_refs("{{ a.output.foo }} {{ a.output.bar }}")
+        assert refs.agent_output_fields == {"a": {"foo", "bar"}}
+
+    def test_group_member_field_extracted(self) -> None:
+        """Field-precision (Gap A): ``g.outputs.m.field`` populates
+        ``group_member_fields[(g, m)] = {field}``.
+        """
+        refs = _extract_template_refs("{{ pg.outputs.member.field }}")
+        assert refs.group_member_fields == {("pg", "member"): {"field"}}
+
+    def test_group_bare_outputs_uses_none_member(self) -> None:
+        refs = _extract_template_refs("{{ pg.outputs }}")
+        assert refs.group_member_fields == {("pg", None): {None}}
+
+    def test_group_errors_kept_separate(self) -> None:
+        """Errors refs never get field-precision treatment."""
+        refs = _extract_template_refs("{{ pg.errors }} {{ pg.errors.member }}")
+        assert refs.group_error_refs == {"pg"}
+        # Group_member_fields must NOT include the errors-rooted refs.
+        assert refs.group_member_fields == {}
+
+    def test_mixed_bare_and_specific_output_chains(self) -> None:
+        """``{{ a.output }} {{ a.output.foo }}`` must produce BOTH a None
+        sentinel (whole-output ref) and the ``foo`` field, since each is a
+        top-level Getattr chain in the AST.
+        """
+        refs = _extract_template_refs("{{ a.output }} {{ a.output.foo }}")
+        assert refs.agent_output_fields == {"a": {None, "foo"}}
 
 
 class TestInputRefPatternExtensions:
     """Test the extended INPUT_REF_PATTERN shapes added in this PR."""
+
+    def test_pg_kind_capture(self) -> None:
+        """Regression: ``pg_kind`` distinguishes the outputs vs errors
+        namespace at declaration time so a ``pg.errors`` declaration cannot
+        suppress warnings for ``pg.outputs.*`` references.
+        """
+        m_out = INPUT_REF_PATTERN.match("group.outputs.member.field")
+        assert m_out is not None
+        assert m_out.group("pg_kind") == "outputs"
+        m_err = INPUT_REF_PATTERN.match("group.errors")
+        assert m_err is not None
+        assert m_err.group("pg_kind") == "errors"
 
     @pytest.mark.parametrize(
         "ref,expected_parallel",
@@ -1067,6 +1140,666 @@ class TestExplicitModeWarnings:
         warnings = validate_workflow_config(config)
         assert not any("explicit context mode" in w for w in warnings)
 
+    def test_script_agent_undeclared_output_ref_warns(self) -> None:
+        """Script agents must still declare agent.output refs in explicit mode.
+
+        The engine's ``_LOCAL_RENDER_AGENT_TYPES`` carve-out makes
+        ``workflow.input`` available regardless of declarations, but
+        ``agent.output`` references are still required (the engine raises
+        ``KeyError`` via ``_add_explicit_input`` otherwise). The validator
+        should warn about this just like it does for regular LLM agents.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="consumer")]),
+                AgentDef(
+                    name="consumer",
+                    type="script",
+                    command="echo",
+                    args=["{{ producer.output.text }}"],
+                    # Notably absent: input=["producer.output"]
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any("producer.output" in w and "consumer" in w and "explicit" in w for w in warnings)
+
+    def test_script_agent_undeclared_workflow_input_no_warning(self) -> None:
+        """Regression: script-type carve-out for ``workflow.input`` is preserved.
+
+        The engine populates ``workflow.input`` for script agents regardless of
+        explicit mode (see ``_LOCAL_RENDER_AGENT_TYPES``), so no warning should
+        be emitted even when the script's ``input:`` doesn't list it.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="step",
+                context=ContextConfig(mode="explicit"),
+                input={"topic": InputDef(type="string")},
+            ),
+            agents=[
+                AgentDef(
+                    name="step",
+                    type="script",
+                    command="echo",
+                    args=["{{ workflow.input.topic }}"],
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any(
+            "workflow.input.topic" in w and "explicit context mode" in w for w in warnings
+        )
+
+    def test_subworkflow_input_mapping_undeclared_output_ref_warns(self) -> None:
+        """Sub-workflow input_mapping with undeclared agent.output should warn.
+
+        ``input_mapping`` is rendered against the agent's scoped context (via
+        ``build_for_agent``), so undeclared ``agent.output`` references still
+        fail at runtime. ``workflow.input`` is carved out (same as scripts)
+        but ``agent.output`` is not.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="child")]),
+                AgentDef(
+                    name="child",
+                    type="workflow",
+                    workflow="./child.yaml",
+                    input_mapping={"data": "{{ producer.output.value }}"},
+                    # Notably absent: input=["producer.output"]
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any("producer.output" in w and "child" in w and "explicit" in w for w in warnings)
+
+    def test_subworkflow_undeclared_workflow_input_no_warning(self) -> None:
+        """Regression: sub-workflow carve-out for ``workflow.input`` is preserved."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="child",
+                context=ContextConfig(mode="explicit"),
+                input={"topic": InputDef(type="string")},
+            ),
+            agents=[
+                AgentDef(
+                    name="child",
+                    type="workflow",
+                    workflow="./child.yaml",
+                    input_mapping={"data": "{{ workflow.input.topic }}"},
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any(
+            "workflow.input.topic" in w and "explicit context mode" in w for w in warnings
+        )
+
+    def test_human_gate_prompt_explicit_mode_no_warning(self) -> None:
+        """Regression: human_gate prompts render with the FULL accumulated context.
+
+        Engine renders human_gate prompts via ``context.get_for_template()``
+        which forces ``mode='accumulate'`` (see ``WorkflowContext.get_for_template``),
+        so explicit-mode declarations are not required. The validator must not
+        emit false-positive warnings for ``workflow.input`` or ``agent.output``
+        references in human_gate prompts.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+                input={"topic": InputDef(type="string")},
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="gate")]),
+                AgentDef(
+                    name="gate",
+                    type="human_gate",
+                    prompt=(
+                        "Topic: {{ workflow.input.topic }}. "
+                        "Producer said: {{ producer.output.text }}. Continue?"
+                    ),
+                    # Notably absent: input=[...]
+                    options=[
+                        GateOption(label="Yes", value="y", route="$end"),
+                        GateOption(label="No", value="n", route="$end"),
+                    ],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+
+class TestExplicitModeFieldPrecision:
+    """Field-precision warnings in explicit mode (Gap A in issue #105).
+
+    Declaring ``a.output.foo`` only brings the ``foo`` field into scope at
+    runtime (see ``engine/context.py:_add_agent_input``). If the prompt then
+    references ``{{ a.output.bar }}``, the engine fails with
+    ``TemplateError: 'dict object' has no attribute 'bar'`` — the same
+    pattern the issue body describes. The validator should catch this and
+    emit a warning at validation time.
+    """
+
+    def test_undeclared_field_on_specifically_declared_output_warns(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "Bar value: {{ producer.output.bar }}",
+                    input=["producer.output.foo"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any(
+            "producer.output.bar" in w and "producer.output.foo" in w and "explicit" in w
+            for w in warnings
+        )
+
+    def test_declared_field_matches_referenced_field_no_warning(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "Foo: {{ producer.output.foo }}",
+                    input=["producer.output.foo"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_whole_output_declaration_tolerates_any_field(self) -> None:
+        """Declaring ``a.output`` (no field) covers any field reference."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "Foo: {{ producer.output.foo }} Bar: {{ producer.output.bar }}",
+                    input=["producer.output"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_multiple_declared_fields_allows_each(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "{{ producer.output.foo }} {{ producer.output.bar }}",
+                    input=["producer.output.foo", "producer.output.bar"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_multiple_declared_fields_warns_on_other_field(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "{{ producer.output.baz }}",
+                    input=["producer.output.foo", "producer.output.bar"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any("producer.output.baz" in w and "explicit" in w for w in warnings)
+
+    def test_bare_output_ref_with_specific_declaration_warns(self) -> None:
+        """``{{ a.output }}`` (whole-output ref) paired with only
+        specific-field declarations should warn — at runtime the engine only
+        copies the declared fields into ctx, so the whole-output access
+        gets a partial dict.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "{{ producer.output | json }}",
+                    input=["producer.output.foo"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any(
+            "the whole 'producer.output' object" in w and "only declares specific fields" in w
+            for w in warnings
+        )
+
+    def test_method_call_on_whole_output_declaration_no_warning(self) -> None:
+        """``{% for k,v in a.output.items() %}`` paired with a whole-output
+        declaration must NOT warn — the dict-method invocation is valid.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "{% for k, v in producer.output.items() %}{{ k }}{% endfor %}",
+                    input=["producer.output"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_method_call_on_specific_field_declaration_no_warning(self) -> None:
+        """``{% for k,v in a.output.items() %}`` paired with a SPECIFIC-field
+        declaration must NOT warn either. Without the Call-node filter the
+        validator would otherwise flag ``items`` as a missing field.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "{% for k, v in producer.output.items() %}{{ k }}{% endfor %}",
+                    input=["producer.output.foo"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("items" in w and "explicit context mode" in w for w in warnings)
+
+    def test_static_parallel_member_field_precision_warns(self) -> None:
+        """``pg.outputs.member.field`` precision works for static parallel groups
+        because the engine field-slices on len≥3 (see context.py
+        ``_add_parallel_group_input``).
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="pg",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("a", "do a", routes=[]),
+                _agent_with_prompt("b", "do b", routes=[]),
+                _agent_with_prompt(
+                    "consumer",
+                    "{{ pg.outputs.a.baz }}",
+                    input=["pg.outputs.a.foo"],
+                ),
+            ],
+            parallel=[
+                ParallelGroup(name="pg", agents=["a", "b"], routes=[RouteDef(to="consumer")]),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any(
+            "pg.outputs.a.baz" in w and "pg.outputs.a.foo" in w and "explicit" in w
+            for w in warnings
+        )
+
+    def test_for_each_member_field_precision_skipped(self) -> None:
+        """For-each groups copy the WHOLE member at runtime
+        (``elif is_for_each_dict or len(remaining_parts) == 2``), so the
+        validator must NOT emit field-precision warnings for them — that
+        would be a false positive.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="finder",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("finder", "find items", routes=[RouteDef(to="fe")]),
+                _agent_with_prompt(
+                    "consumer",
+                    # References a different field than declared. For for-each
+                    # groups this works at runtime, so no warning.
+                    "{{ fe.outputs.x.bar }}",
+                    input=["fe.outputs.x.foo"],
+                ),
+            ],
+            for_each=[
+                ForEachDef(
+                    name="fe",
+                    type="for_each",
+                    source="finder.output.items",
+                    **{"as": "item"},
+                    key_by="item.id",
+                    agent=AgentDef(
+                        name="worker",
+                        model="gpt-4",
+                        prompt="process {{ item }}",
+                    ),
+                    routes=[RouteDef(to="consumer")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("fe.outputs.x" in w and "explicit context mode" in w for w in warnings)
+
+    def test_field_precision_in_sub_workflow_input_mapping_warns(self) -> None:
+        """input_mapping is rendered against the agent's scoped context, so
+        field-precision applies to it the same as to ``prompt``.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="parent",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="child")]),
+                AgentDef(
+                    name="child",
+                    type="workflow",
+                    workflow="./child.yaml",
+                    input_mapping={"data": "{{ producer.output.bar }}"},
+                    input=["producer.output.foo"],
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any(
+            "producer.output.bar" in w and "producer.output.foo" in w and "explicit" in w
+            for w in warnings
+        )
+
+    # ---------------------------------------------------------------------
+    # Static parallel matrix — exhaustive coverage of declaration shapes
+    # ---------------------------------------------------------------------
+
+    def _parallel_matrix_config(self, *, declared: list[str], referenced: str) -> WorkflowConfig:
+        return WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="pg",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("a", "do a", routes=[]),
+                _agent_with_prompt("b", "do b", routes=[]),
+                _agent_with_prompt(
+                    "consumer",
+                    "Use {{ " + referenced + " }}",
+                    input=declared,
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            parallel=[
+                ParallelGroup(name="pg", agents=["a", "b"], routes=[RouteDef(to="consumer")]),
+            ],
+        )
+
+    def test_parallel_whole_group_declaration_tolerates_any_member_or_field(self) -> None:
+        config = self._parallel_matrix_config(
+            declared=["pg.outputs"], referenced="pg.outputs.a.foo"
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_parallel_whole_member_declaration_tolerates_any_field(self) -> None:
+        config = self._parallel_matrix_config(
+            declared=["pg.outputs.a"], referenced="pg.outputs.a.foo"
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_parallel_exact_field_match_no_warning(self) -> None:
+        config = self._parallel_matrix_config(
+            declared=["pg.outputs.a.foo"], referenced="pg.outputs.a.foo"
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_parallel_bare_member_ref_with_specific_decl_no_field_warning(self) -> None:
+        """``{{ pg.outputs.a }}`` (bare member, no field) is not subject to
+        the field-precision check — we don't know which fields the consumer
+        actually reads on the member object.
+        """
+        config = self._parallel_matrix_config(
+            declared=["pg.outputs.a.foo"], referenced="pg.outputs.a"
+        )
+        warnings = validate_workflow_config(config)
+        # The member IS declared (just with a specific field), so no
+        # undeclared warning. And bare-member refs skip field precision.
+        assert not any("explicit context mode" in w for w in warnings)
+
+    # ---------------------------------------------------------------------
+    # Namespace separation: pg.outputs / pg.errors are NOT interchangeable
+    # ---------------------------------------------------------------------
+
+    def test_declared_errors_does_not_suppress_outputs_warning(self) -> None:
+        """``input: ["pg.errors"]`` must not suppress an undeclared-outputs
+        warning when the template references ``pg.outputs.*``. The engine
+        only populates the declared namespace at runtime, so the outputs ref
+        will fail with ``KeyError``.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="pg",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("a", "do a", routes=[]),
+                _agent_with_prompt("b", "do b", routes=[]),
+                _agent_with_prompt(
+                    "consumer",
+                    "{{ pg.outputs.a.val }}",
+                    input=["pg.errors"],
+                ),
+            ],
+            parallel=[
+                ParallelGroup(name="pg", agents=["a", "b"], routes=[RouteDef(to="consumer")]),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any(
+            "pg.outputs" in w and "does not declare 'pg.outputs'" in w and "explicit" in w
+            for w in warnings
+        )
+
+    def test_declared_outputs_does_not_suppress_errors_warning(self) -> None:
+        """Symmetric: ``input: ["pg.outputs"]`` must not suppress an
+        undeclared-errors warning when the template references ``pg.errors``.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="pg",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("a", "do a", routes=[]),
+                _agent_with_prompt("b", "do b", routes=[]),
+                _agent_with_prompt(
+                    "consumer",
+                    "{% if pg.errors %}fail{% endif %}",
+                    input=["pg.outputs"],
+                ),
+            ],
+            parallel=[
+                ParallelGroup(name="pg", agents=["a", "b"], routes=[RouteDef(to="consumer")]),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert any(
+            "pg.errors" in w and "does not declare 'pg.errors'" in w and "explicit" in w
+            for w in warnings
+        )
+
+    def test_declared_errors_field_does_not_warn_about_outputs_field(self) -> None:
+        """Regression: declaring ``pg.errors.a.foo`` must NOT make the
+        validator emit a warning that says ``only declares pg.outputs.a.foo``.
+        The errors-namespace declaration is unrelated to the outputs ref.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="pg",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("a", "do a", routes=[]),
+                _agent_with_prompt("b", "do b", routes=[]),
+                _agent_with_prompt(
+                    "consumer",
+                    "{{ pg.outputs.a.bar }}",
+                    input=["pg.errors.a.foo"],
+                ),
+            ],
+            parallel=[
+                ParallelGroup(name="pg", agents=["a", "b"], routes=[RouteDef(to="consumer")]),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        # Should emit the "undeclared outputs" warning, NOT the misleading
+        # "only declares pg.outputs.a.foo" message.
+        assert not any("only declares pg.outputs.a.foo" in w for w in warnings)
+        assert any("pg.outputs" in w and "does not declare 'pg.outputs'" in w for w in warnings)
+
+    # ---------------------------------------------------------------------
+    # Other edge cases flagged by review
+    # ---------------------------------------------------------------------
+
+    def test_optional_input_with_question_mark_treated_as_declared(self) -> None:
+        """Optional inputs (``a.output.foo?``) still count as declarations
+        for explicit-mode warning purposes — the ``?`` only affects runtime
+        missing-required behavior, not the validation contract.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "{{ producer.output.foo }}",
+                    input=["producer.output.foo?"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        assert not any("explicit context mode" in w for w in warnings)
+
+    def test_mixed_bare_and_specific_field_extraction(self) -> None:
+        """``{{ a.output }} {{ a.output.foo }}`` extracts BOTH the bare
+        whole-output ref and the specific-field ref, so a config declaring
+        only one specific field still warns about the bare reference.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "make it", routes=[RouteDef(to="writer")]),
+                _agent_with_prompt(
+                    "writer",
+                    "{{ producer.output.foo }} {{ producer.output }}",
+                    input=["producer.output.foo"],
+                ),
+            ],
+        )
+        warnings = validate_workflow_config(config)
+        # Should warn about the whole-output ref but not the specific one.
+        assert any(
+            "the whole 'producer.output'" in w and "only declares specific fields" in w
+            for w in warnings
+        )
+
+    def test_malformed_template_with_duplicate_block_does_not_hard_fail(self) -> None:
+        """Templates that pass ``parse()`` but raise during
+        ``meta.find_undeclared_variables`` (e.g. duplicate ``{% block %}``
+        names) must not break validation — render-time will surface the
+        precise error.
+        """
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="writer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt(
+                    "writer",
+                    "{% block a %}1{% endblock %}{% block a %}2{% endblock %}",
+                ),
+            ],
+        )
+        # Should not raise.
+        validate_workflow_config(config)
+
 
 class TestOutputTemplateValidation:
     """Tests for unknown references in workflow `output:` templates."""
@@ -1169,9 +1902,9 @@ class TestInputMappingTemplateCollection:
         # Simulates: when this PR merges with main's AgentDef.input_mapping,
         # a stale agent reference inside an input_mapping expression is caught
         # by _extract_template_refs the same as any other template field.
-        agent_refs, input_refs = _extract_template_refs("{{ old_agent.output.findings }}")
-        assert "old_agent" in agent_refs
-        assert not input_refs
+        refs = _extract_template_refs("{{ old_agent.output.findings }}")
+        assert "old_agent" in refs.agent_refs
+        assert not refs.workflow_inputs
 
 
 class TestSubWorkflowRefValidation:


### PR DESCRIPTION
Closes #105.

PR #125 added explicit-mode warnings for undeclared `workflow.input` / `agent.output` references. While building on top of it, I confirmed (by running real workflows that pass validation and crash at runtime) two follow-up gaps that still produce the exact `TemplateError: 'dict object' has no attribute 'X'` symptom from #105.

## Gap A — Field-level precision

When an agent declares `input: [a.output.foo]`, the engine (`engine/context.py:_add_agent_input`) copies *only* the `foo` field into the agent's ctx. A prompt that then references `{{ a.output.bar }}` fails at runtime — same `'dict object' has no attribute 'bar'` error the issue body quotes. The validator previously tracked declared agents as a flat `set[str]` of names, so this slipped through.

Fix: track declared fields per root as `dict[str, set[str | None]]` (where `None` in the set means "whole-output declared, any field allowed"), and emit a warning naming the missing field when a template references a field not in the declared set. Same logic applies to static parallel groups (`pg.outputs.member.field` — the engine field-slices on `len ≥ 3`). For-each groups are **intentionally skipped** because the engine copies whole members regardless of `.field` suffix (`elif is_for_each_dict or len(remaining_parts) == 2`), so field-precision warnings would be false positives there.

## Gap B — Script/sub-workflow `agent.output` exclusion was too broad

`agent.type not in ("script", "workflow")` previously suppressed *both* `workflow.input` and `agent.output` warnings. But the engine's `_LOCAL_RENDER_AGENT_TYPES` carve-out only populates `workflow.input` for these types — `agent.output` references still raise `KeyError` in `_add_explicit_input` if undeclared.

Fix: split the gate. Keep the script/workflow/human_gate exclusion for `workflow.input` warnings only; for `agent.output` warnings, only exclude `human_gate` (whose prompts render in accumulate mode).

## Other improvements

- **`_extract_template_refs` returns a typed `TemplateRefs` NamedTuple** carrying field detail (`agent_output_fields`, `group_member_fields`, `group_error_refs`) alongside the existing flat `agent_refs` set.
- **AST walker filters inner-link Getattr nodes** — for `{{ a.output.bar }}`, only the outermost Getattr (attrs=`["output", "bar"]`) is processed. The inner Getattr (attrs=`["output"]`) is the `.node` of the outer, so emitting it separately would falsely register a whole-output reference and suppress the field-precision warning.
- **AST walker detects method-call Getattr nodes** (those that are the callee of a `Call`). `{% for k,v in a.output.items() %}` now registers as a whole-output ref rather than a field ref to `items` — eliminates a class of false positives.
- **`human_gate` agents added to the explicit-mode exclusion list** — fixes a pre-existing false-positive warning. Gate prompts render via `context.get_for_template()` which forces `mode='accumulate'`, so explicit-mode declarations are not required.
- **Documented limitations** in `_extract_template_refs`: bracket access (`a.output["x"]`) and dynamic field access (`a.output[var]`) are intentionally not detected.

## Example output

Issue #105's exact example:
```
⚠ agent 'intake' prompt references 'workflow.input.prompt' but agent 'intake'
  does not declare 'workflow.input.prompt' in its input: list (explicit context mode)
```

Gap A (new):
```
⚠ agent 'b' args[0] references 'a.output.bar' but agent 'b' only declares
  a.output.foo in its input: list (explicit context mode)
```

Gap B (newly caught):
```
⚠ agent 'scripty' args[0] references 'a.output' but agent 'scripty' does not
  declare 'a.output' in its input: list (explicit context mode)
```

## Testing

- **14 new tests** across `TestExtractTemplateRefs`, `TestExplicitModeWarnings` (script/sub-workflow `agent.output`, sub-workflow `workflow.input` carve-out regression, human_gate false-positive regression), and a new `TestExplicitModeFieldPrecision` class (field precision, whole-output declarations, method-call filter, static parallel precision, for-each precision skip, sub-workflow `input_mapping` field precision).
- Existing tests updated for the new NamedTuple return shape.
- **2640 tests pass**, 15 skipped (full repo suite, `-m "not performance"`).
- `make lint` ✅
- `make typecheck`: only the pre-existing `dialog_evaluator.py` diagnostic (verified by stashing and re-running on `main`).
- All `examples/*.yaml` continue to validate without unexpected warnings.

## Decisions that may need a closer look

- **Severity**: kept as warning per #105's framing, even for field-mismatch cases where runtime failure is essentially certain. Rationale: consistency, and templates can still legitimately use guards/defaults.
- **TemplateRefs is a typed NamedTuple, not a `dataclass`** — chosen for slightly cleaner tuple-style unpacking in tests and zero runtime overhead. No behavior difference.
- **Dict-method filter is belt-and-suspenders** — the primary defense is the Call-node filter (handles `a.output.items()`); `_DICT_METHOD_NAMES` covers the rarer case of referencing a method without calling it (`{{ a.output.items }}` as a value).

Suggested commit on merge: `feat(validate): warn on undeclared agent.output refs and field-level mismatches in explicit mode (#NNN)`