### PR TITLE
fix: gate dashboard URL prints behind is_verbose() for --silent compliance

### DIFF
--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -987,8 +987,9 @@ def replay(
             raise typer.Exit(1) from exc
 
         await dashboard.start()
-        console.print(f"\n[bold green]▶ Replay dashboard:[/] {dashboard.url}\n")
-        console.print("[dim]Press Ctrl+C to exit[/dim]\n")
+        if is_verbose():
+            console.print(f"\n[bold green]▶ Replay dashboard:[/] {dashboard.url}\n")
+            console.print("[dim]Press Ctrl+C to exit[/dim]\n")
 
         try:
             await asyncio.Event().wait()

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -1169,8 +1169,9 @@ async def run_workflow_async(
 
         try:
             await dashboard.start()
-            # Print URL to stderr regardless of --silent/--quiet
-            _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
+            from conductor.cli.app import is_verbose
+            if is_verbose():
+                _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
         except Exception as e:
             _verbose_console.print(
                 f"[bold yellow]Warning:[/bold yellow] "
@@ -1682,7 +1683,9 @@ async def resume_workflow_async(
 
             try:
                 await dashboard.start()
-                _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
+                from conductor.cli.app import is_verbose
+                if is_verbose():
+                    _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
             except Exception as e:
                 _verbose_console.print(
                     f"[bold yellow]Warning:[/bold yellow] "


### PR DESCRIPTION
## Summary

Fixes #209. Three locations still printed the dashboard URL to stderr even when --silent was set, violating the "No progress output. Only JSON result on stdout." contract.

## Changes

1. **src/conductor/cli/app.py (replay command, lines 990-991)** — Gated the "Replay dashboard:" and "Press Ctrl+C to exit" prints behind is_verbose().
2. **src/conductor/cli/run.py (run --web, line 1173)** — Gated the dashboard URL print behind a lazy is_verbose() import, removing the `# Print URL to stderr regardless of --silent/--quiet` comment since that behavior was the bug.
3. **src/conductor/cli/run.py (resume --web, line 1685)** — Same gate as #2.

All three match the pattern established in the existing verbose_log() helper and the #201/#203 fix for --web-bg mode.

## Verification

Before this fix:
```
conductor --silent run examples/simple-qa.yaml --web 2>&1 | grep Dashboard
# Output: Dashboard: http://127.0.0.1:XXXXX (leaked even with --silent)
```

After this fix:
```
conductor --silent run examples/simple-qa.yaml --web 2>&1 | grep Dashboard
# No output (silent mode respected)
```

Dashboard failure warnings (Exception handler in run.py) are left ungated since they communicate actual errors that users should see regardless of verbosity mode.