### PR TITLE
fix(cli): gate remaining dashboard URL prints behind is_verbose() for --silent compliance

### DIFF
--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -991,7 +991,8 @@ def replay(
             raise typer.Exit(1) from exc
 
         await dashboard.start()
-        console.print(f"\n[bold green]▶ Replay dashboard:[/] {dashboard.url}\n")
+        if is_verbose():
+            console.print(f"\n[bold green]▶ Replay dashboard:[/] {dashboard.url}\n")
         console.print("[dim]Press Ctrl+C to exit[/dim]\n")
 
         try:

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -1171,6 +1171,7 @@ async def run_workflow_async(
         try:
             await dashboard.start()
             from conductor.cli.app import is_verbose
+
             if is_verbose():
                 _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
         except Exception as e:
@@ -1318,6 +1319,7 @@ async def run_workflow_async(
                     await dashboard.wait_for_clients_disconnect()
                 else:
                     from conductor.cli.app import is_verbose
+
                     if is_verbose():
                         _verbose_console.print(
                             f"\n[bold green]Workflow complete.[/bold green] "
@@ -1833,6 +1835,7 @@ async def resume_workflow_async(
                 try:
                     await dashboard.start()
                     from conductor.cli.app import is_verbose
+
                     if is_verbose():
                         _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
                 except Exception as e:
@@ -1885,6 +1888,7 @@ async def resume_workflow_async(
                     await dashboard.wait_for_clients_disconnect()
                 else:
                     from conductor.cli.app import is_verbose
+
                     if is_verbose():
                         _verbose_console.print(
                             f"\n[bold green]Workflow complete.[/bold green] "

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -1170,8 +1170,9 @@ async def run_workflow_async(
 
         try:
             await dashboard.start()
-            # Print URL to stderr regardless of --silent/--quiet
-            _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
+            from conductor.cli.app import is_verbose
+            if is_verbose():
+                _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
         except Exception as e:
             _verbose_console.print(
                 f"[bold yellow]Warning:[/bold yellow] "
@@ -1316,11 +1317,13 @@ async def run_workflow_async(
                 if is_bg:
                     await dashboard.wait_for_clients_disconnect()
                 else:
-                    _verbose_console.print(
-                        f"\n[bold green]Workflow complete.[/bold green] "
-                        f"Dashboard still running at {dashboard.url} — "
-                        f"press [bold]Ctrl+C[/bold] to exit."
-                    )
+                    from conductor.cli.app import is_verbose
+                    if is_verbose():
+                        _verbose_console.print(
+                            f"\n[bold green]Workflow complete.[/bold green] "
+                            f"Dashboard still running at {dashboard.url} — "
+                            f"press [bold]Ctrl+C[/bold] to exit."
+                        )
                     with contextlib.suppress(asyncio.CancelledError):
                         await asyncio.Event().wait()
 
@@ -1829,7 +1832,9 @@ async def resume_workflow_async(
 
                 try:
                     await dashboard.start()
-                    _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
+                    from conductor.cli.app import is_verbose
+                    if is_verbose():
+                        _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
                 except Exception as e:
                     _verbose_console.print(
                         f"[bold yellow]Warning:[/bold yellow] "
@@ -1879,11 +1884,13 @@ async def resume_workflow_async(
                 if is_bg:
                     await dashboard.wait_for_clients_disconnect()
                 else:
-                    _verbose_console.print(
-                        f"\n[bold green]Workflow complete.[/bold green] "
-                        f"Dashboard still running at {dashboard.url} — "
-                        f"press [bold]Ctrl+C[/bold] to exit."
-                    )
+                    from conductor.cli.app import is_verbose
+                    if is_verbose():
+                        _verbose_console.print(
+                            f"\n[bold green]Workflow complete.[/bold green] "
+                            f"Dashboard still running at {dashboard.url} — "
+                            f"press [bold]Ctrl+C[/bold] to exit."
+                        )
                     with contextlib.suppress(asyncio.CancelledError):
                         await asyncio.Event().wait()
 


### PR DESCRIPTION
## Description

Follow-up to PR #203 (merged, by @sjh9714). PR #203 fixed the web-bg startup dashboard URL leak in `src/conductor/cli/app.py`, but the `--silent` flag is supposed to suppress ALL dashboard URL output, not just the startup print.

## Remaining fixes

This PR gates the remaining dashboard URL prints behind `is_verbose()`:

1. **`src/conductor/cli/run.py` — `run_workflow_async` function (line 1174)**: The `--silent` flag should suppress this dashboard URL print during foreground --web runs, not just web-bg mode (#203's scope).

2. **`src/conductor/cli/run.py` — `resume` function (line 1832)**: Same issue in the resume code path — dashboard URL printed regardless of --silent.

3. **`src/conductor/cli/app.py` — `_run_replay` function (line 994)**: Replay dashboard URL leaked even in --silent mode.

4. **`src/conductor/cli/run.py` — "Workflow complete. Dashboard still running at..." shutdown messages (lines 1321, 1884)**: Both the `run` and `resume` functions printed the dashboard URL during shutdown regardless of --silent mode.

## Testing

Existing tests from #203 should continue to pass. The fix follows the same pattern as #203: lazy-import `is_verbose()` from `app.py` and gate the print call.

Co-authored-by: sjh9714 <sjh9714@users.noreply.github.com>