### PR TITLE
feat: Phase 1 of typed on_error routing (#227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ See the [`examples/`](./examples/) directory for complete workflows:
 | [parallel-research.yaml](./examples/parallel-research.yaml) | Static parallel execution |
 | [design-review.yaml](./examples/design-review.yaml) | Human gate with loop pattern |
 | [script-step.yaml](./examples/script-step.yaml) | Script step with exit_code routing |
+| [error-routing.yaml](./examples/error-routing.yaml) | Typed script failures with deterministic error routes |
 | [set-step.yaml](./examples/set-step.yaml) | Set step deriving named values + boolean-routed branching |
 | [wait-step.yaml](./examples/wait-step.yaml) | Wait step + script for a polling loop-back pattern |
 | [wait-smoke.yaml](./examples/wait-smoke.yaml) | Minimal wait-only smoke test (no provider required) |

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -146,6 +146,8 @@ agents:
     routes:                         # Optional: Routing logic
       - to: next_agent              # Agent name or $end
         when: "{{ condition }}"     # Optional: Route condition
+      - to: recovery_agent          # Script steps only in Phase 1
+        on_error: external.git.drift
 ```
 
 ### Retry Policy
@@ -441,7 +443,74 @@ routes:
   - to: $end
 ```
 
-**Restrictions** — script steps cannot have `prompt`, `model`, `provider`, `tools`, `system_prompt`, `options`, or `validator`. Script steps also cannot be used inside `parallel` groups or `for_each` groups.
+**Typed script failures** — scripts may intentionally publish a language-neutral
+error envelope through the path in `CONDUCTOR_ERROR_OUT`:
+
+```json
+{
+  "kind": "external.git.drift",
+  "message": "remote changed while preparing the update",
+  "details": {"branch": "main"}
+}
+```
+
+`CONDUCTOR_ERROR_OUT` is a file path, not JSON stored in an environment variable.
+Conductor creates a private temporary directory for each script process, injects
+the path only into that subprocess, reads the file after the process exits, and
+then removes the directory. The script may use any language capable of writing
+UTF-8 JSON; no Conductor helper library is required or shipped.
+
+The file is intentionally out-of-band because script stdout already carries the
+step's output contract. File presence means the script intended to raise a typed
+failure, regardless of its exit code. A missing file means no typed failure:
+ordinary nonzero exits, `exit_code` conditions, stdout parsing, and existing
+routes retain their previous behavior.
+
+When a typed envelope is present, error routing takes precedence over validating
+the script's success `output:` schema, so handlers can inspect partial stdout and
+stderr that do not satisfy the success contract.
+
+Malformed JSON, invalid UTF-8, an invalid envelope, or a read failure becomes the
+engine-owned `internal.script_error_transport` envelope. This fail-safe behavior
+prevents an intended typed failure from silently becoming success.
+Scripts cannot publish kinds under the engine-owned `internal.`, `provider.`,
+`subworkflow.`, or `retry.` namespaces; attempts are treated as invalid
+transport envelopes.
+
+```yaml
+agents:
+  - name: fetch
+    type: script
+    command: python
+    args: ["scripts/fetch.py"]
+    raises:                         # Optional documentation/load-time validation
+      - external.git.drift
+    routes:
+      - to: continue_pipeline       # Success bucket
+      - to: recover_drift           # Exact error-kind match
+        on_error: external.git.drift
+      - to: diagnose_unknown        # Catch-all; must be the last error route
+        on_error: true
+```
+
+`raises:` is optional documentation and validation metadata. When present,
+specific `on_error` kinds must be declared (engine-owned kinds such as
+`internal.script_error_transport` are exempt). It does not opt a script into
+error synthesis, does not rewrite undeclared runtime kinds, and does not limit
+`on_error: true`; the catch-all receives the original runtime kind.
+
+Error handlers can inspect both the script's partial output and its envelope:
+
+```yaml
+prompt: |
+  {{ fetch.error.kind }}: {{ fetch.error.message }}
+  stderr: {{ fetch.output.stderr }}
+```
+
+In `context.mode: explicit`, declare `fetch.error` (or a nested field such as
+`fetch.error.kind`) in the handler's `input:` list, just as for `fetch.output`.
+
+**Restrictions** — script steps cannot have `prompt`, `model`, `provider`, `tools`, `system_prompt`, `options`, `validator`, or `retry`. Script steps also cannot be used inside `parallel` groups or `for_each` groups. `CONDUCTOR_ERROR_OUT` is engine-owned and overrides a value with the same name in `env:`.
 
 **Environment variable note** — values in `env` are passed as-is to the subprocess (they are not rendered as Jinja2 templates). Use `${VAR}` syntax in the workflow YAML loader if you need environment variable substitution in env values.
 
@@ -988,6 +1057,59 @@ Structure:
 
 Routes define workflow control flow. Routes are evaluated in order, and the first matching route is taken.
 
+Routes are separated into success and typed-error buckets. A route without
+`on_error` is considered only after successful execution. A route with
+`on_error` is considered only when a script publishes a typed envelope. Within
+the selected bucket, declaration order and `when:` behavior are unchanged.
+
+`on_error` accepts an exact kind, a list of exact kinds, or `true` as a catch-all:
+
+```yaml
+routes:
+  - to: continue_pipeline
+  - to: recover
+    on_error:
+      - external.git.drift
+      - external.git.fetch_failed
+    when: "{{ output.exit_code == 0 and error.details.branch == 'main' }}"
+  - to: diagnose
+    on_error: true
+```
+
+For error-route conditions, both `output` and `error` are in scope. A script
+with error routes must also define at least one success route, and a catch-all
+error route must be last among error routes. Phase 1 supports `on_error` and
+`raises` only on top-level `type: script` steps; provider agents, workflow
+steps, terminate steps, parallel groups, and for-each groups are rejected at
+validation rather than accepted as handlers that never run.
+
+Jinja2 conditions use `error.kind`, `error.message`, and `error.details`.
+Arithmetic-style conditions use the router's flattened names such as
+`error_kind` and `error_message`.
+
+### Error precedence and checkpoints
+
+- **Retry before routing:** existing provider-agent `retry:` behavior completes
+  inside the provider before the workflow engine observes a failure. Provider
+  failures are not routable in Phase 1. Script steps cannot configure `retry`,
+  so typed script failures are never retried implicitly.
+- **Explicit terminate:** `type: terminate, status: failed` remains a terminal
+  control-flow signal. It is not converted to an error envelope, does not run
+  `on_error` routes, and does not create a failure checkpoint.
+- **Sub-workflow terminate:** a child's failed terminate remains
+  `SubworkflowTerminatedError` at the parent seam. `type: workflow` cannot use
+  `on_error` in Phase 1, so existing parent hook and checkpoint behavior is
+  unchanged.
+- **Routed failure:** the failing script's output and envelope are committed to
+  context before its handler runs. The routed failure is handled control flow,
+  so it creates no failure checkpoint. If the handler later fails, the normal
+  failure checkpoint points at the handler and includes the earlier envelope.
+- **Unhandled failure:** if no error route matches, Conductor raises
+  `UnhandledNodeError` before committing the failing step's output/error or
+  execution count. The normal failure checkpoint points at the script so
+  `conductor resume` re-runs it. Any periodic boundary checkpoint taken before
+  the script remains valid.
+
 ### Basic Route
 
 ```yaml
@@ -1236,6 +1358,9 @@ How it works:
   the run reaches a terminal, non-resumable outcome** (clean completion or an
   explicit `status: failed` terminate). On an unexpected failure they are kept
   alongside the on-failure checkpoint.
+- A typed script failure that is successfully routed is not a workflow failure,
+  so it does not create an on-failure checkpoint. An unhandled typed failure
+  follows the normal failure path and checkpoints the failing script for replay.
 - If a periodic save itself fails (e.g. the disk fills), the run is not
   interrupted; the failure is surfaced via a `checkpoint_save_failed` event and
   a console warning so you know recovery may be unavailable.

--- a/examples/README.md
+++ b/examples/README.md
@@ -243,6 +243,22 @@ Demonstrates:
 conductor run examples/script-step.yaml
 ```
 
+### error-routing.yaml
+
+Typed script failures using the language-neutral `CONDUCTOR_ERROR_OUT` file
+contract. Demonstrates:
+
+- Exact-kind and catch-all `on_error` routes
+- Optional documentation-only `raises:`
+- Handler access to both `step.error` and partial `step.output`
+- Backward-compatible success behavior without helper libraries
+
+```bash
+conductor run examples/error-routing.yaml --input failure=none
+conductor run examples/error-routing.yaml --input failure=drift
+conductor run examples/error-routing.yaml --input failure=unexpected
+```
+
 ### script-stdin.yaml
 
 Hand a structured payload to a script step via **stdin** instead of

--- a/examples/error-routing.yaml
+++ b/examples/error-routing.yaml
@@ -1,0 +1,82 @@
+# Typed Script Error Routing
+#
+# Usage:
+#   conductor run examples/error-routing.yaml --input failure=none
+#   conductor run examples/error-routing.yaml --input failure=drift
+#   conductor run examples/error-routing.yaml --input failure=unexpected
+
+workflow:
+  name: typed-script-error-routing
+  description: Typed script failures with exact and catch-all error routes
+  version: "1.0.0"
+  entry_point: check_remote
+
+  input:
+    failure:
+      type: string
+      required: false
+      default: none
+
+agents:
+  - name: check_remote
+    type: script
+    command: python
+    args:
+      - -c
+      - |
+        import json
+        import os
+        import sys
+
+        failure = sys.argv[1]
+        if failure != "none":
+            kind = (
+                "external.git.drift"
+                if failure == "drift"
+                else "external.git.unexpected"
+            )
+            envelope = {
+                "kind": kind,
+                "message": f"simulated {failure} failure",
+                "details": {"branch": "main"},
+            }
+            with open(os.environ["CONDUCTOR_ERROR_OUT"], "w", encoding="utf-8") as stream:
+                json.dump(envelope, stream)
+
+        print(json.dumps({"checked": True, "failure": failure}))
+      - "{{ workflow.input.failure }}"
+    raises:
+      - external.git.drift
+    routes:
+      - to: success
+      - to: recover_drift
+        on_error: external.git.drift
+      - to: recover_unexpected
+        on_error: true
+
+  - name: success
+    type: set
+    value: "remote is current"
+    output_type: string
+    routes:
+      - to: $end
+
+  - name: recover_drift
+    type: set
+    value: "recovering {{ check_remote.error.kind }} on {{ check_remote.error.details.branch }}"
+    output_type: string
+    routes:
+      - to: $end
+
+  - name: recover_unexpected
+    type: set
+    value: "caught undeclared kind {{ check_remote.error.kind }}"
+    output_type: string
+    routes:
+      - to: $end
+
+output:
+  result: >-
+    {% if success is defined %}{{ success.output }}
+    {% elif recover_drift is defined %}{{ recover_drift.output }}
+    {% else %}{{ recover_unexpected.output }}{% endif %}

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -20,6 +20,7 @@ from pydantic import (
 )
 
 from conductor.duration import parse_duration
+from conductor.error_kinds import is_reserved_error_kind, validate_error_kind
 from conductor.file_string import FileString
 from conductor.providers.context_tier import ContextTier
 from conductor.providers.reasoning import ReasoningEffort
@@ -123,6 +124,9 @@ class RouteDef(BaseModel):
     output: dict[str, str] | None = None
     """Optional output transformation (template expressions)."""
 
+    on_error: bool | str | list[str] | None = None
+    """Select typed failures for this route; omitted routes handle success."""
+
     @field_validator("to")
     @classmethod
     def validate_target(cls, v: str) -> str:
@@ -130,6 +134,24 @@ class RouteDef(BaseModel):
         if not v:
             raise ValueError("Route target cannot be empty")
         return v
+
+    @field_validator("on_error", mode="before")
+    @classmethod
+    def validate_on_error(cls, value: Any) -> bool | str | list[str] | None:
+        """Validate exact, list, and catch-all typed failure selectors."""
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            if not value:
+                raise ValueError("on_error: false is invalid; omit on_error for success routes")
+            return True
+        if isinstance(value, str):
+            return validate_error_kind(value)
+        if isinstance(value, list):
+            if not value:
+                raise ValueError("on_error kind list cannot be empty")
+            return [validate_error_kind(kind) for kind in value]
+        raise ValueError("on_error must be true, an error kind, or a list of error kinds")
 
 
 class ParallelGroup(BaseModel):
@@ -750,6 +772,9 @@ class AgentDef(BaseModel):
     routes: list[RouteDef] = Field(default_factory=list)
     """Routing rules evaluated in order after execution."""
 
+    raises: list[str] | None = None
+    """Optional documentation and load-time validation for script error kinds."""
+
     options: list[GateOption] | None = None
     """Options for human_gate type agents."""
 
@@ -1117,6 +1142,25 @@ class AgentDef(BaseModel):
         if isinstance(value, FileString):
             return value
         return handler(value)
+
+    @field_validator("raises")
+    @classmethod
+    def validate_raises(cls, value: list[str] | None) -> list[str] | None:
+        """Validate optional author-owned error-kind declarations."""
+        if value is None:
+            return None
+        if not value:
+            raise ValueError("raises cannot be empty; omit the field instead")
+
+        validated: list[str] = []
+        for kind in value:
+            validate_error_kind(kind)
+            if is_reserved_error_kind(kind):
+                raise ValueError(f"raises kind '{kind}' uses an engine-owned namespace")
+            if kind in validated:
+                raise ValueError(f"raises kind '{kind}' is declared more than once")
+            validated.append(kind)
+        return validated
 
     @model_validator(mode="after")
     def validate_agent_type(self) -> AgentDef:

--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import jinja2
 from jinja2 import Environment, meta, nodes
 
+from conductor.error_kinds import is_reserved_error_kind
 from conductor.exceptions import ConfigurationError
 from conductor.providers.capabilities import ProviderCapabilities, get_capabilities
 from conductor.templating import is_jinja_template
@@ -67,8 +68,8 @@ _JINJA_ENV.tests = _TolerantNameMap(_JINJA_ENV.tests)
 _BUILTIN_NAMES = frozenset({"workflow", "context", "item", "_index", "_key", "loop"})
 
 # Attribute names that mark a Getattr chain as an "output reference":
-#   agent.output.field, group.outputs.member, group.errors.member
-_OUTPUT_ATTRS = frozenset({"output", "outputs", "errors"})
+#   agent.output.field, agent.error.kind, group.outputs.member, group.errors.member
+_OUTPUT_ATTRS = frozenset({"output", "error", "outputs", "errors"})
 
 # Attribute names that look like fields on an output but are actually built-in
 # dict methods. We avoid emitting field-precision warnings for these because
@@ -84,14 +85,14 @@ _DICT_METHOD_NAMES = frozenset({"items", "keys", "values", "get"})
 _MAX_ENUMERATED_PATHS = 100
 
 # Pattern for input references:
-# - agent.output[.field[.subfield...]]
+# - agent.output|error[.field[.subfield...]]
 # - parallel_group.outputs|errors[.agent[.field]]  (parallel depth unchanged)
 # - workflow.input.param
 # - agent.field[.subfield...]  (shorthand; excludes workflow.*)
 # All with optional ? suffix
 INPUT_REF_PATTERN = re.compile(
     r"^(?:"
-    r"(?P<agent>[a-zA-Z_][a-zA-Z0-9_]*)\.output(?:\.(?P<field>[a-zA-Z_][a-zA-Z0-9_]*)(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)?|"
+    r"(?P<agent>[a-zA-Z_][a-zA-Z0-9_]*)\.(?P<agent_kind>output|error)(?:\.(?P<field>[a-zA-Z_][a-zA-Z0-9_]*)(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)?|"
     r"(?P<parallel>[a-zA-Z_][a-zA-Z0-9_]*)\.(?P<pg_kind>outputs|errors)(?:\.(?P<pg_agent>[a-zA-Z_][a-zA-Z0-9_]*)(?:\.(?P<pg_field>[a-zA-Z_][a-zA-Z0-9_]*))?)?|"
     r"workflow\.input\.(?P<input>[a-zA-Z_][a-zA-Z0-9_]*)|"
     r"(?!workflow\b)(?![a-zA-Z_][a-zA-Z0-9_]*\.(?:outputs|errors)(?:\.|$))"
@@ -150,6 +151,7 @@ def validate_workflow_config(
         # Validate route targets - allow routing to agents and parallel groups
         agent_errors = _validate_agent_routes(agent.name, agent.routes, all_names)
         errors.extend(agent_errors)
+        errors.extend(_validate_error_routes(agent.name, agent.type, agent.routes, agent.raises))
 
         # Validate human_gate has options
         if agent.type == "human_gate":
@@ -204,9 +206,28 @@ def validate_workflow_config(
     if config.parallel:
         parallel_errors = _validate_parallel_groups(config)
         errors.extend(parallel_errors)
+        for group in config.parallel:
+            if any(route.on_error is not None for route in group.routes):
+                errors.append(
+                    f"Parallel group '{group.name}' uses on_error routes, "
+                    "which are not supported in Phase 1"
+                )
 
     # Validate for_each groups: reject step types that can't be used inline
     for for_each_group in config.for_each:
+        if any(route.on_error is not None for route in for_each_group.routes):
+            errors.append(
+                f"For-each group '{for_each_group.name}' uses on_error routes, "
+                "which are not supported in Phase 1"
+            )
+        errors.extend(
+            _validate_error_routes(
+                f"{for_each_group.name}.agent",
+                for_each_group.agent.type,
+                for_each_group.agent.routes,
+                for_each_group.agent.raises,
+            )
+        )
         if for_each_group.agent.type == "script":
             errors.append(
                 f"For-each group '{for_each_group.name}' uses a script step as its "
@@ -295,6 +316,55 @@ def _validate_agent_routes(
                 f"{', '.join(sorted(valid_targets))}"
             )
 
+    return errors
+
+
+def _validate_error_routes(
+    agent_name: str,
+    agent_type: str | None,
+    routes: list,
+    raises: list[str] | None,
+) -> list[str]:
+    """Validate the Phase 1 typed-error routing surface."""
+    error_routes = [route for route in routes if route.on_error is not None]
+    errors: list[str] = []
+    if raises is not None and agent_type != "script":
+        errors.append(
+            f"Agent '{agent_name}' declares raises, but Phase 1 supports "
+            "typed error declarations only for script steps"
+        )
+    if not error_routes:
+        return errors
+
+    if agent_type != "script":
+        errors.append(
+            f"Agent '{agent_name}' uses on_error routes, but Phase 1 supports "
+            "typed error routing only for script steps"
+        )
+    if not any(route.on_error is None for route in routes):
+        errors.append(
+            f"Agent '{agent_name}' has on_error routes but no success route. "
+            "Add a route without on_error for successful execution."
+        )
+    for index, route in enumerate(error_routes[:-1]):
+        if route.on_error is True:
+            errors.append(
+                f"Agent '{agent_name}' catch-all on_error route must be last "
+                f"among error routes (error route index {index})"
+            )
+    if raises is not None:
+        declared = set(raises)
+        for route in error_routes:
+            selector = route.on_error
+            kinds = [selector] if isinstance(selector, str) else selector
+            if not isinstance(kinds, list):
+                continue
+            for kind in kinds:
+                if kind not in declared and not is_reserved_error_kind(kind):
+                    errors.append(
+                        f"Agent '{agent_name}' routes error kind '{kind}', "
+                        "but it is not declared in raises"
+                    )
     return errors
 
 
@@ -689,7 +759,7 @@ class TemplateRefs(NamedTuple):
     (enables explicit-mode field-precision warnings).
 
     Attributes:
-        agent_refs: Root names referenced via ``<name>.output``,
+        agent_refs: Root names referenced via ``<name>.output``, ``<name>.error``,
             ``<name>.outputs``, or ``<name>.errors`` (deduped). Used for
             unknown-agent checks and undeclared-agent warnings.
         workflow_inputs: Names referenced via ``workflow.input.<name>``.
@@ -700,6 +770,8 @@ class TemplateRefs(NamedTuple):
             ``{{ a.output }}`` from ``{{ a.output.foo }}`` for field-precision
             analysis. Absence from this dict means no ``<name>.output*`` ref
             was seen (only ``.outputs`` / ``.errors`` perhaps).
+        agent_error_fields: Maps each agent name to fields referenced through
+            ``<name>.error``. ``None`` means the whole envelope was referenced.
         group_member_fields: Maps each ``(group, member)`` pair to the set of
             fields referenced via ``<group>.outputs.<member>.<field>``.
             ``None`` in the set indicates a bare
@@ -716,6 +788,7 @@ class TemplateRefs(NamedTuple):
     agent_refs: set[str]
     workflow_inputs: set[str]
     agent_output_fields: dict[str, set[str | None]]
+    agent_error_fields: dict[str, set[str | None]]
     group_member_fields: dict[tuple[str, str | None], set[str | None]]
     group_error_refs: set[str]
 
@@ -767,6 +840,7 @@ def _extract_template_refs(template: str) -> TemplateRefs:
         agent_refs=set(),
         workflow_inputs=set(),
         agent_output_fields={},
+        agent_error_fields={},
         group_member_fields={},
         group_error_refs=set(),
     )
@@ -811,6 +885,7 @@ def _extract_template_refs(template: str) -> TemplateRefs:
     group_error_refs: set[str] = set()
     # Output / outputs chains, accumulated as the structured maps directly.
     agent_output_fields: dict[str, set[str | None]] = {}
+    agent_error_fields: dict[str, set[str | None]] = {}
     group_member_fields: dict[tuple[str, str | None], set[str | None]] = {}
     agent_refs: set[str] = set()
 
@@ -874,6 +949,9 @@ def _extract_template_refs(template: str) -> TemplateRefs:
             # checks compare declared first-level fields.
             field: str | None = attrs[1] if len(attrs) >= 2 else None
             agent_output_fields.setdefault(root, set()).add(field)
+        elif kind == "error":
+            field = attrs[1] if len(attrs) >= 2 else None
+            agent_error_fields.setdefault(root, set()).add(field)
         else:  # kind == "outputs"
             # attrs is ["outputs"] or ["outputs", "<member>", ...]
             if len(attrs) == 1:
@@ -888,6 +966,7 @@ def _extract_template_refs(template: str) -> TemplateRefs:
         agent_refs=agent_refs,
         workflow_inputs=workflow_inputs,
         agent_output_fields=agent_output_fields,
+        agent_error_fields=agent_error_fields,
         group_member_fields=group_member_fields,
         group_error_refs=group_error_refs,
     )
@@ -1280,6 +1359,11 @@ def _validate_template_references(
     parallel_names = {pg.name for pg in config.parallel}
     for_each_names = {fe.name for fe in config.for_each}
     all_names = agent_names | parallel_names | for_each_names
+    typed_error_sources = {
+        agent.name
+        for agent in config.agents
+        if agent.type == "script" and any(route.on_error is not None for route in agent.routes)
+    }
     workflow_input_names = set(config.workflow.input.keys())
     is_explicit = config.workflow.context.mode == "explicit"
 
@@ -1310,6 +1394,7 @@ def _validate_template_references(
         #     fail at runtime.
         declared_workflow_inputs: set[str] = set()
         declared_agent_output_fields: dict[str, set[str | None]] = {}
+        declared_agent_error_fields: dict[str, set[str | None]] = {}
         # Per (group, member) — only populated for ``.outputs`` declarations.
         # Member is ``None`` for the bare-group form ``g.outputs``.
         declared_group_output_member_fields: dict[tuple[str, str | None], set[str | None]] = {}
@@ -1334,7 +1419,12 @@ def _validate_template_references(
                 # name. Nested paths intentionally degrade to first-level
                 # advisory precision.
                 field = match.group("field") if match.group("agent") else match.group("sh_field")
-                declared_agent_output_fields.setdefault(ref_agent, set()).add(field)
+                if match.group("agent_kind") == "error" and ref_agent in typed_error_sources:
+                    declared_agent_error_fields.setdefault(ref_agent, set()).add(field)
+                elif match.group("agent_kind") == "error":
+                    declared_agent_output_fields.setdefault(ref_agent, set()).add("error")
+                else:
+                    declared_agent_output_fields.setdefault(ref_agent, set()).add(field)
             ref_parallel = match.group("parallel")
             if ref_parallel:
                 pg_kind = match.group("pg_kind")
@@ -1416,6 +1506,47 @@ def _validate_template_references(
                             f"{source} references '{ref_root}.output.{ref_field}' but "
                             f"agent '{agent.name}' only declares "
                             f"{declared_list} "
+                            f"in its input: list (explicit context mode)"
+                        )
+
+            # --- Agent-error references (``a.error[.field]``) ---
+            for ref_root, ref_fields in refs.agent_error_fields.items():
+                if ref_root not in valid_names:
+                    errors.append(
+                        f"{source} references unknown agent '{ref_root}'. "
+                        f"Available: {', '.join(sorted(valid_names))}"
+                    )
+                    continue
+                if agent_output_warning_allowed and ref_root not in declared_agent_error_fields:
+                    warnings.append(
+                        f"{source} references '{ref_root}.error' but "
+                        f"agent '{agent.name}' does not declare '{ref_root}.error' "
+                        f"in its input: list (explicit context mode)"
+                    )
+                    continue
+                if not agent_output_warning_allowed:
+                    continue
+                declared_fields = declared_agent_error_fields[ref_root]
+                if None in declared_fields:
+                    continue
+                declared_field_names = sorted(f for f in declared_fields if f)
+                declared_list = ", ".join(f"{ref_root}.error.{f}" for f in declared_field_names)
+                for ref_field in ref_fields:
+                    if ref_field is None:
+                        warnings.append(
+                            f"{source} references the whole '{ref_root}.error' "
+                            f"object but agent '{agent.name}' only declares "
+                            f"specific fields ({', '.join(declared_field_names)}) "
+                            f"in its input: list. Declare '{ref_root}.error' (without "
+                            f"a field) to access the whole envelope (explicit context mode)"
+                        )
+                        continue
+                    if ref_field in _DICT_METHOD_NAMES:
+                        continue
+                    if ref_field not in declared_fields:
+                        warnings.append(
+                            f"{source} references '{ref_root}.error.{ref_field}' but "
+                            f"agent '{agent.name}' only declares {declared_list} "
                             f"in its input: list (explicit context mode)"
                         )
 

--- a/src/conductor/engine/context.py
+++ b/src/conductor/engine/context.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from conductor.error_envelope import ErrorEnvelope
     from conductor.providers.base import AgentProvider
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,9 @@ class WorkflowContext:
     agent_outputs: dict[str, dict[str, Any]] = field(default_factory=dict)
     """Outputs from executed agents, keyed by agent name."""
 
+    step_errors: dict[str, ErrorEnvelope] = field(default_factory=dict)
+    """Handled typed failures, keyed by the step that raised them."""
+
     current_iteration: int = 0
     """Current execution iteration count."""
 
@@ -162,8 +166,13 @@ class WorkflowContext:
                 store a scalar, list, or any JSON-safe value directly.
         """
         self.agent_outputs[agent_name] = output
+        self.step_errors.pop(agent_name, None)
         self.execution_history.append(agent_name)
         self.current_iteration += 1
+
+    def store_error(self, agent_name: str, error: ErrorEnvelope) -> None:
+        """Store a handled typed failure without recording another execution."""
+        self.step_errors[agent_name] = error
 
     def build_for_agent(
         self,
@@ -247,6 +256,8 @@ class WorkflowContext:
                     else:
                         # Regular agents wrap output in {"output": ...}
                         ctx[agent] = {"output": output}
+                        if agent in self.step_errors:
+                            ctx[agent]["error"] = self.step_errors[agent].to_dict()
 
             elif mode == "last_only" and self.execution_history:
                 # Only the most recent agent's output
@@ -264,6 +275,8 @@ class WorkflowContext:
                     ctx[last_agent] = last_output
                 else:
                     ctx[last_agent] = {"output": last_output}
+                    if last_agent in self.step_errors:
+                        ctx[last_agent]["error"] = self.step_errors[last_agent].to_dict()
 
         return ctx
 
@@ -326,6 +339,10 @@ class WorkflowContext:
             if entity_name in self.agent_outputs:
                 agent_output = self.agent_outputs[entity_name]
 
+                if parts[1] == "error" and entity_name in self.step_errors:
+                    self._add_agent_error_input(ctx, entity_name, parts[1:], is_optional)
+                    return
+
                 # Check if this is a parallel group (has 'outputs' and 'errors' keys)
                 is_parallel_group = (
                     isinstance(agent_output, dict)
@@ -339,8 +356,49 @@ class WorkflowContext:
                 else:
                     # Handle regular agent references
                     self._add_agent_input(ctx, entity_name, parts[1:], is_optional)
+            elif entity_name in self.step_errors:
+                self._add_agent_error_input(ctx, entity_name, parts[1:], is_optional)
             elif not is_optional:
                 raise KeyError(f"Missing required agent output: {entity_name}")
+
+    def _add_agent_error_input(
+        self,
+        ctx: dict[str, Any],
+        agent_name: str,
+        remaining_parts: list[str],
+        is_optional: bool,
+    ) -> None:
+        """Add an explicit ``agent.error`` reference to context."""
+        if not remaining_parts or remaining_parts[0] != "error":
+            if not is_optional:
+                raise KeyError(f"Missing required agent output: {agent_name}")
+            return
+
+        error = self.step_errors.get(agent_name)
+        if error is None:
+            if not is_optional:
+                raise KeyError(f"Missing typed error from agent '{agent_name}'")
+            return
+
+        value: Any = error.to_dict()
+        path = remaining_parts[1:]
+        for key in path:
+            if isinstance(value, dict) and key in value:
+                value = value[key]
+                continue
+            if not is_optional:
+                raise KeyError(f"Missing error field '{'.'.join(path)}' from agent '{agent_name}'")
+            return
+
+        ctx.setdefault(agent_name, {"output": None})
+        if not path:
+            ctx[agent_name]["error"] = error.to_dict()
+            return
+
+        target = ctx[agent_name].setdefault("error", {})
+        for key in path[:-1]:
+            target = target.setdefault(key, {})
+        target[path[-1]] = copy.deepcopy(value)
 
     def _add_agent_input(
         self, ctx: dict[str, Any], agent_name: str, remaining_parts: list[str], is_optional: bool
@@ -560,6 +618,7 @@ class WorkflowContext:
         return {
             "workflow_inputs": copy.deepcopy(self.workflow_inputs),
             "agent_outputs": copy.deepcopy(self.agent_outputs),
+            "step_errors": {name: error.to_dict() for name, error in self.step_errors.items()},
             "current_iteration": self.current_iteration,
             "execution_history": list(self.execution_history),
             "user_guidance": list(self.user_guidance),
@@ -580,6 +639,12 @@ class WorkflowContext:
         ctx = cls()
         ctx.workflow_inputs = copy.deepcopy(data.get("workflow_inputs", {}))
         ctx.agent_outputs = copy.deepcopy(data.get("agent_outputs", {}))
+        from conductor.error_envelope import ErrorEnvelope
+
+        ctx.step_errors = {
+            name: ErrorEnvelope.from_dict(value)
+            for name, value in data.get("step_errors", {}).items()
+        }
         ctx.current_iteration = data.get("current_iteration", 0)
         ctx.execution_history = list(data.get("execution_history", []))
         ctx.user_guidance = list(data.get("user_guidance", []))
@@ -683,6 +748,7 @@ class WorkflowContext:
 
             if agent_name in self.agent_outputs:
                 del self.agent_outputs[agent_name]
+                self.step_errors.pop(agent_name, None)
 
         return self.estimate_context_tokens()
 
@@ -815,6 +881,7 @@ class WorkflowContext:
                         )
                     summary_parts.append(summary.strip())
                     del self.agent_outputs[agent_name]
+                    self.step_errors.pop(agent_name, None)
 
             # Store summary as a special context entry
             if summary_parts:

--- a/src/conductor/engine/router.py
+++ b/src/conductor/engine/router.py
@@ -14,6 +14,7 @@ from conductor.executor.template import TemplateRenderer
 
 if TYPE_CHECKING:
     from conductor.config.schema import RouteDef
+    from conductor.error_envelope import ErrorEnvelope
 
 
 @dataclass
@@ -64,6 +65,8 @@ class Router:
         routes: list[RouteDef],
         current_output: dict[str, Any],
         context: dict[str, Any],
+        *,
+        error: ErrorEnvelope | None = None,
     ) -> RouteResult:
         """Evaluate routes and return the first matching target.
 
@@ -82,12 +85,20 @@ class Router:
             ValueError: If no routes match (shouldn't happen with proper config).
         """
         # Add current output to context for condition evaluation
-        eval_context = {
+        eval_context: dict[str, Any] = {
             **context,
             "output": current_output,
         }
+        if error is not None:
+            eval_context["error"] = error.to_dict()
 
         for route in routes:
+            if error is None:
+                if route.on_error is not None:
+                    continue
+            elif not self._matches_error(route, error.kind):
+                continue
+
             if route.when is None:
                 # No condition = always matches
                 return RouteResult(
@@ -109,6 +120,18 @@ class Router:
             "No matching route found. Ensure at least one route has no 'when' clause "
             "or add a catch-all route at the end."
         )
+
+    @staticmethod
+    def _matches_error(route: RouteDef, kind: str) -> bool:
+        """Return whether an error route selects the supplied kind."""
+        selector = route.on_error
+        if selector is True:
+            return True
+        if isinstance(selector, str):
+            return selector == kind
+        if isinstance(selector, list):
+            return kind in selector
+        return False
 
     def _evaluate_condition(self, when: str, context: dict[str, Any]) -> bool:
         """Evaluate a 'when' condition.

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -25,6 +25,7 @@ from conductor.engine.limits import LimitEnforcer
 from conductor.engine.pricing import ModelPricing
 from conductor.engine.router import Router, RouteResult
 from conductor.engine.usage import UsageTracker, WorkflowUsage
+from conductor.error_envelope import ErrorEnvelope
 from conductor.events import WorkflowEvent, WorkflowEventEmitter
 from conductor.exceptions import (
     AgentTimeoutError,
@@ -34,6 +35,7 @@ from conductor.exceptions import (
     InterruptError,
     MaxIterationsError,
     SubworkflowTerminatedError,
+    UnhandledNodeError,
     ValidationError,
     WorkflowTerminated,
 )
@@ -3364,7 +3366,7 @@ class WorkflowEngine:
                             # into strict JSON-object mode with zero declared
                             # fields. See `_validate_script_output_schema` for
                             # the validation rules and wrapping rationale.
-                            if agent.output is not None:
+                            if agent.output is not None and script_output.error is None:
                                 try:
                                     self._validate_script_output_schema(
                                         agent,
@@ -3387,24 +3389,55 @@ class WorkflowEngine:
                                     )
                                     raise
 
-                            self._emit(
-                                "script_completed",
-                                {
-                                    "agent_name": agent.name,
-                                    "elapsed": _script_elapsed,
-                                    "stdout": script_output.stdout,
-                                    "stderr": script_output.stderr,
-                                    "exit_code": script_output.exit_code,
-                                    "stdin_bytes": script_output.stdin_bytes,
-                                },
-                            )
+                            route_result: RouteResult | None = None
+                            if script_output.error is not None:
+                                self._emit(
+                                    "script_failed",
+                                    {
+                                        "agent_name": agent.name,
+                                        "elapsed": _script_elapsed,
+                                        "error_type": "TypedScriptError",
+                                        "message": script_output.error.message,
+                                        "error": script_output.error.to_dict(),
+                                        "stdout": script_output.stdout,
+                                        "stderr": script_output.stderr,
+                                        "exit_code": script_output.exit_code,
+                                    },
+                                )
+                                try:
+                                    route_result = self._evaluate_routes(
+                                        agent,
+                                        output_content,
+                                        error=script_output.error,
+                                    )
+                                except ValueError as exc:
+                                    raise UnhandledNodeError(
+                                        agent_name=agent.name,
+                                        error=script_output.error,
+                                        output=output_content,
+                                    ) from exc
+                            else:
+                                self._emit(
+                                    "script_completed",
+                                    {
+                                        "agent_name": agent.name,
+                                        "elapsed": _script_elapsed,
+                                        "stdout": script_output.stdout,
+                                        "stderr": script_output.stderr,
+                                        "exit_code": script_output.exit_code,
+                                        "stdin_bytes": script_output.stdin_bytes,
+                                    },
+                                )
 
                             self.context.store(agent.name, output_content)
+                            if script_output.error is not None:
+                                self.context.store_error(agent.name, script_output.error)
                             self.limits.record_execution(agent.name)
                             self.limits.check_timeout()
                             self._check_budget()
 
-                            route_result = self._evaluate_routes(agent, output_content)
+                            if route_result is None:
+                                route_result = self._evaluate_routes(agent, output_content)
 
                             self._emit(
                                 "route_taken",
@@ -5558,6 +5591,7 @@ class WorkflowEngine:
         Args:
             agent: The current agent definition.
             output: The agent's output content.
+            error: Typed failure envelope, when evaluating the error bucket.
 
         Returns:
             The name of the next agent or "$end".
@@ -5565,7 +5599,13 @@ class WorkflowEngine:
         result = self._evaluate_routes(agent, output)
         return result.target
 
-    def _evaluate_routes(self, agent: AgentDef, output: dict[str, Any]) -> RouteResult:
+    def _evaluate_routes(
+        self,
+        agent: AgentDef,
+        output: dict[str, Any],
+        *,
+        error: ErrorEnvelope | None = None,
+    ) -> RouteResult:
         """Evaluate routes using the Router.
 
         Uses the Router to evaluate routing rules and determine the next agent.
@@ -5579,13 +5619,15 @@ class WorkflowEngine:
             RouteResult with target and optional output transform.
         """
         if not agent.routes:
+            if error is not None:
+                raise ValueError("No error routes are defined")
             # No routes defined - default to $end
             return RouteResult(target="$end")
 
         # Build context for condition evaluation
         eval_context = self.context.get_for_template()
 
-        return self.router.evaluate(agent.routes, output, eval_context)
+        return self.router.evaluate(agent.routes, output, eval_context, error=error)
 
     def _evaluate_parallel_routes(
         self, parallel_group: ParallelGroup, output: dict[str, Any]

--- a/src/conductor/error_envelope.py
+++ b/src/conductor/error_envelope.py
@@ -1,0 +1,80 @@
+"""Typed workflow failure envelopes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from conductor.error_kinds import is_reserved_error_kind, validate_error_kind
+
+
+class ErrorEnvelopeValidationError(ValueError):
+    """Raised when a script publishes an invalid error envelope."""
+
+
+@dataclass(frozen=True)
+class ErrorEnvelope:
+    """Engine-owned representation of a routable workflow failure."""
+
+    kind: str
+    message: str
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-compatible envelope shape."""
+        return {
+            "kind": self.kind,
+            "message": self.message,
+            "details": self.details,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        value: Any,
+        *,
+        allow_reserved: bool = True,
+    ) -> ErrorEnvelope:
+        """Validate a wire value and return a typed envelope."""
+        if not isinstance(value, dict):
+            raise ErrorEnvelopeValidationError("error envelope must be a JSON object")
+
+        kind = value.get("kind")
+        if not isinstance(kind, str):
+            raise ErrorEnvelopeValidationError(
+                "error envelope kind must be a dotted lowercase identifier"
+            )
+        try:
+            validate_error_kind(kind)
+        except ValueError as exc:
+            raise ErrorEnvelopeValidationError(str(exc)) from exc
+        if not allow_reserved and is_reserved_error_kind(kind):
+            raise ErrorEnvelopeValidationError(
+                f"error kind '{kind}' uses an engine-owned namespace"
+            )
+
+        message = value.get("message")
+        if not isinstance(message, str) or not message:
+            raise ErrorEnvelopeValidationError("error envelope message must be a non-empty string")
+
+        details = value.get("details", {})
+        if not isinstance(details, dict):
+            raise ErrorEnvelopeValidationError("error envelope details must be a JSON object")
+
+        return cls(kind=kind, message=message, details=details)
+
+
+def make_script_transport_error(
+    *,
+    agent_name: str,
+    error: Exception,
+) -> ErrorEnvelope:
+    """Create a routable failure when the script error channel is malformed."""
+    return ErrorEnvelope(
+        kind="internal.script_error_transport",
+        message=f"Script '{agent_name}' published an invalid error envelope",
+        details={
+            "error_type": type(error).__name__,
+            "error": str(error),
+        },
+    )

--- a/src/conductor/error_kinds.py
+++ b/src/conductor/error_kinds.py
@@ -1,0 +1,23 @@
+"""Shared validation for typed workflow error kinds."""
+
+from __future__ import annotations
+
+import re
+
+KIND_PATTERN = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+RESERVED_KIND_PREFIXES = ("internal.", "provider.", "subworkflow.", "retry.")
+
+
+def validate_error_kind(kind: str) -> str:
+    """Validate and return a dotted lowercase error kind."""
+    if not KIND_PATTERN.fullmatch(kind):
+        raise ValueError(
+            f"error kind '{kind}' must be a dotted lowercase identifier "
+            "(for example, 'external.git.fetch_failed')"
+        )
+    return kind
+
+
+def is_reserved_error_kind(kind: str) -> bool:
+    """Return whether an error kind belongs to an engine-owned namespace."""
+    return kind.startswith(RESERVED_KIND_PREFIXES)

--- a/src/conductor/exceptions.py
+++ b/src/conductor/exceptions.py
@@ -7,7 +7,10 @@ to help users resolve issues.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from conductor.error_envelope import ErrorEnvelope
 
 
 class ConductorError(Exception):
@@ -329,6 +332,28 @@ class ExecutionError(ConductorError):
         """
         self.agent_name = agent_name
         super().__init__(message, suggestion, file_path, line_number)
+
+
+class UnhandledNodeError(ExecutionError):
+    """Raised when a typed node failure has no matching error route."""
+
+    def __init__(
+        self,
+        *,
+        agent_name: str,
+        error: ErrorEnvelope,
+        output: dict[str, Any],
+    ) -> None:
+        """Initialize an unhandled typed failure."""
+        self.error = error
+        self.output = output
+        super().__init__(
+            f"Step '{agent_name}' raised unhandled error '{error.kind}': {error.message}",
+            agent_name=agent_name,
+            suggestion=(
+                f"Add an on_error route for '{error.kind}' or a catch-all on_error: true route"
+            ),
+        )
 
 
 class MaxIterationsError(ExecutionError):

--- a/src/conductor/executor/script.py
+++ b/src/conductor/executor/script.py
@@ -7,12 +7,20 @@ as workflow steps, capturing stdout/stderr and exit codes.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import shutil
 import sys
+import tempfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from conductor.error_envelope import (
+    ErrorEnvelope,
+    ErrorEnvelopeValidationError,
+    make_script_transport_error,
+)
 from conductor.exceptions import ExecutionError
 from conductor.executor.template import TemplateRenderer
 
@@ -26,6 +34,18 @@ def _verbose_log(message: str, style: str = "dim") -> None:
     from conductor.cli.run import verbose_log
 
     verbose_log(message, style)
+
+
+def _read_error_envelope(error_path: Path, agent_name: str) -> ErrorEnvelope | None:
+    """Read the optional script error channel without dropping transport failures."""
+    if not error_path.exists():
+        return None
+
+    try:
+        raw = json.loads(error_path.read_text(encoding="utf-8"))
+        return ErrorEnvelope.from_dict(raw, allow_reserved=False)
+    except (OSError, UnicodeError, json.JSONDecodeError, ErrorEnvelopeValidationError) as exc:
+        return make_script_transport_error(agent_name=agent_name, error=exc)
 
 
 if TYPE_CHECKING:
@@ -49,6 +69,7 @@ class ScriptOutput:
     stderr: str
     exit_code: int
     stdin_bytes: int | None = None
+    error: ErrorEnvelope | None = None
 
 
 class ScriptExecutor:
@@ -131,92 +152,99 @@ class ScriptExecutor:
                     ),
                 ) from exc
 
-        # Build environment (merge os.environ + agent.env)
-        # Note: ${VAR:-default} patterns in agent.env are already resolved
-        # by the config loader during YAML parsing.
-        # Always set PYTHONUTF8=1 so child Python processes use UTF-8 encoding
-        # instead of the system default (cp1252 on Windows), preventing garbled
-        # Unicode characters in script output.
-        base_env = {**os.environ, "PYTHONUTF8": "1"}
-        env = {**base_env, **agent.env} if agent.env else base_env
+        with tempfile.TemporaryDirectory(prefix="conductor-error-") as error_dir:
+            error_path = Path(error_dir) / "error.json"
 
-        # Resolve bare command names and absolute paths against PATH so that a
-        # bare name (e.g. "python") finds the executable the shell would, and a
-        # path missing an extension resolves correctly. Resolution uses the
-        # subprocess's own ``PATH`` (``env`` may override it via ``agent.env``),
-        # so the resolved binary matches the one the child would have executed.
-        # Relative paths containing a separator are left untouched so they keep
-        # resolving against ``working_dir``. Resolution is non-destructive: when
-        # ``which`` cannot resolve the command we fall back to the rendered value
-        # and let the FileNotFoundError handler below produce a clear error.
-        has_separator = os.sep in rendered_command or (
-            os.altsep is not None and os.altsep in rendered_command
-        )
-        if os.path.isabs(rendered_command) or not has_separator:
-            rendered_command = (
-                shutil.which(rendered_command, path=env.get("PATH")) or rendered_command
+            # Build environment (merge os.environ + agent.env)
+            # Note: ${VAR:-default} patterns in agent.env are already resolved
+            # by the config loader during YAML parsing.
+            # Always set PYTHONUTF8=1 so child Python processes use UTF-8 encoding
+            # instead of the system default (cp1252 on Windows), preventing garbled
+            # Unicode characters in script output.
+            base_env = {**os.environ, "PYTHONUTF8": "1"}
+            env = {**base_env, **agent.env} if agent.env else base_env
+            env["CONDUCTOR_ERROR_OUT"] = str(error_path)
+
+            # Resolve bare command names and absolute paths against PATH so that a
+            # bare name (e.g. "python") finds the executable the shell would, and a
+            # path missing an extension resolves correctly. Resolution uses the
+            # subprocess's own ``PATH`` (``env`` may override it via ``agent.env``),
+            # so the resolved binary matches the one the child would have executed.
+            # Relative paths containing a separator are left untouched so they keep
+            # resolving against ``working_dir``. Resolution is non-destructive: when
+            # ``which`` cannot resolve the command we fall back to the rendered value
+            # and let the FileNotFoundError handler below produce a clear error.
+            has_separator = os.sep in rendered_command or (
+                os.altsep is not None and os.altsep in rendered_command
             )
-
-        _verbose_log(f"  Script: {rendered_command} {' '.join(rendered_args)}")
-        if stdin_payload is not None:
-            _verbose_log(f"  Script stdin: {len(stdin_payload)} bytes")
-
-        # Create subprocess
-        try:
-            process = await asyncio.create_subprocess_exec(
-                rendered_command,
-                *rendered_args,
-                stdin=asyncio.subprocess.PIPE if stdin_payload is not None else None,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=rendered_working_dir,
-                env=env,
-            )
-        except FileNotFoundError as exc:
-            hint = ""
-            if sys.platform == "win32":
-                hint = (
-                    " Hint: on Windows, include the file extension (e.g. .exe) "
-                    "or use an absolute path."
+            if os.path.isabs(rendered_command) or not has_separator:
+                rendered_command = (
+                    shutil.which(rendered_command, path=env.get("PATH")) or rendered_command
                 )
-            raise ExecutionError(
-                f"Script '{agent.name}': command not found: '{rendered_command}'"
-                f" (working_dir={rendered_working_dir or 'cwd'}){hint}",
-                agent_name=agent.name,
-                suggestion=f"Ensure '{rendered_command}' is installed and on PATH",
-            ) from exc
-        except OSError as e:
-            raise ExecutionError(
-                f"Script '{agent.name}' failed to start: {e}",
-                agent_name=agent.name,
-            ) from e
 
-        # Wait with optional per-script timeout
-        timeout = agent.timeout
-        try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                process.communicate(input=stdin_payload), timeout=timeout
+            _verbose_log(f"  Script: {rendered_command} {' '.join(rendered_args)}")
+            if stdin_payload is not None:
+                _verbose_log(f"  Script stdin: {len(stdin_payload)} bytes")
+
+            # Create subprocess
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    rendered_command,
+                    *rendered_args,
+                    stdin=asyncio.subprocess.PIPE if stdin_payload is not None else None,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=rendered_working_dir,
+                    env=env,
+                )
+            except FileNotFoundError as exc:
+                hint = ""
+                if sys.platform == "win32":
+                    hint = (
+                        " Hint: on Windows, include the file extension (e.g. .exe) "
+                        "or use an absolute path."
+                    )
+                raise ExecutionError(
+                    f"Script '{agent.name}': command not found: '{rendered_command}'"
+                    f" (working_dir={rendered_working_dir or 'cwd'}){hint}",
+                    agent_name=agent.name,
+                    suggestion=f"Ensure '{rendered_command}' is installed and on PATH",
+                ) from exc
+            except OSError as e:
+                raise ExecutionError(
+                    f"Script '{agent.name}' failed to start: {e}",
+                    agent_name=agent.name,
+                ) from e
+
+            # Wait with optional per-script timeout
+            timeout = agent.timeout
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    process.communicate(input=stdin_payload), timeout=timeout
+                )
+            except TimeoutError:
+                process.kill()
+                await process.wait()
+                raise ExecutionError(
+                    f"Script '{agent.name}' timed out after {timeout}s",
+                    agent_name=agent.name,
+                ) from None
+
+            error = _read_error_envelope(error_path, agent.name)
+
+            stdout_text = stdout_bytes.decode("utf-8", errors="replace")
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+
+            if stderr_text:
+                _verbose_log(f"  Script stderr: {stderr_text.strip()}")
+
+            # IMPORTANT: process.returncode is guaranteed non-None after communicate().
+            # Do NOT use `process.returncode or 0` — 0 is falsy in Python.
+            assert process.returncode is not None
+            return ScriptOutput(
+                stdout=stdout_text,
+                stderr=stderr_text,
+                exit_code=process.returncode,
+                stdin_bytes=len(stdin_payload) if stdin_payload is not None else None,
+                error=error,
             )
-        except TimeoutError:
-            process.kill()
-            await process.wait()
-            raise ExecutionError(
-                f"Script '{agent.name}' timed out after {timeout}s",
-                agent_name=agent.name,
-            ) from None
-
-        stdout_text = stdout_bytes.decode("utf-8", errors="replace")
-        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
-
-        if stderr_text:
-            _verbose_log(f"  Script stderr: {stderr_text.strip()}")
-
-        # IMPORTANT: process.returncode is guaranteed non-None after communicate().
-        # Do NOT use `process.returncode or 0` — 0 is falsy in Python.
-        assert process.returncode is not None
-        return ScriptOutput(
-            stdout=stdout_text,
-            stderr=stderr_text,
-            exit_code=process.returncode,
-            stdin_bytes=len(stdin_payload) if stdin_payload is not None else None,
-        )

--- a/src/conductor/web/server.py
+++ b/src/conductor/web/server.py
@@ -633,9 +633,11 @@ class WebDashboard:
 
         execution_history = list(getattr(context, "execution_history", []) or [])
         agent_outputs = getattr(context, "agent_outputs", {}) or {}
+        step_errors = getattr(context, "step_errors", {}) or {}
+        last_execution_index = {name: index for index, name in enumerate(execution_history)}
 
         count = 0
-        for name in execution_history:
+        for index, name in enumerate(execution_history):
             output = agent_outputs.get(name, {})
             if name in parallel_groups:
                 started_type, started_data, completed_type, completed_data = self._synth_parallel(
@@ -647,7 +649,12 @@ class WebDashboard:
                 )
             else:
                 started_type, started_data, completed_type, completed_data = (
-                    self._synth_agent_or_script(name, agent_defs.get(name), output)
+                    self._synth_agent_or_script(
+                        name,
+                        agent_defs.get(name),
+                        output,
+                        step_errors.get(name) if last_execution_index[name] == index else None,
+                    )
                 )
 
             self._event_history.append(
@@ -726,7 +733,7 @@ class WebDashboard:
 
     @staticmethod
     def _synth_agent_or_script(
-        name: str, agent_def: Any, output: Any
+        name: str, agent_def: Any, output: Any, error: Any = None
     ) -> tuple[str, dict[str, Any], str, dict[str, Any]]:
         """Build synthetic (started, completed) event payloads for an agent/script/wait."""
         agent_type = getattr(agent_def, "type", None) or "agent"
@@ -746,6 +753,16 @@ class WebDashboard:
                 "exit_code": output_dict.get("exit_code", 0),
                 "synthetic": True,
             }
+            if error is not None:
+                error_dict = error.to_dict() if hasattr(error, "to_dict") else error
+                completed_data.update(
+                    {
+                        "error_type": "TypedScriptError",
+                        "message": error_dict.get("message", ""),
+                        "error": error_dict,
+                    }
+                )
+                return "script_started", started_data, "script_failed", completed_data
             return "script_started", started_data, "script_completed", completed_data
 
         if agent_type == "wait":

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -137,6 +137,22 @@ class TestRouteDef:
         route = RouteDef(to="$end")
         assert route.to == "$end"
 
+    def test_error_route_accepts_specific_and_catch_all_kinds(self) -> None:
+        """Error routes declare exact kinds, kind lists, or a catch-all."""
+        exact = RouteDef(to="recover", on_error="external.git.drift")
+        several = RouteDef(
+            to="recover",
+            on_error=["external.git.drift", "external.git.fetch_failed"],
+        )
+        catch_all = RouteDef(to="halt", on_error=True)
+
+        assert exact.on_error == "external.git.drift"
+        assert several.on_error == [
+            "external.git.drift",
+            "external.git.fetch_failed",
+        ]
+        assert catch_all.on_error is True
+
     def test_empty_target_raises(self) -> None:
         """Test that empty route target raises ValidationError."""
         with pytest.raises(ValidationError):
@@ -311,6 +327,17 @@ class TestAgentDef:
         assert agent.type is None
         assert agent.routes == []
         assert agent.input == []
+
+    def test_script_may_document_raised_error_kinds(self) -> None:
+        """The optional raises declaration is documentation and validation metadata."""
+        agent = AgentDef(
+            name="script",
+            type="script",
+            command="echo",
+            raises=["external.git.drift"],
+        )
+
+        assert agent.raises == ["external.git.drift"]
 
     def test_agent_with_all_fields(self) -> None:
         """Test agent with all fields populated."""

--- a/tests/test_config/test_validator.py
+++ b/tests/test_config/test_validator.py
@@ -41,6 +41,107 @@ class TestValidateWorkflowConfig:
         warnings = validate_workflow_config(config)
         assert isinstance(warnings, list)
 
+    def test_script_with_error_routes_requires_success_route(self) -> None:
+        """A successful script must have a deterministic success path."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="test", entry_point="script"),
+            agents=[
+                AgentDef(
+                    name="script",
+                    type="script",
+                    command="echo",
+                    routes=[RouteDef(to="$end", on_error=True)],
+                )
+            ],
+        )
+
+        with pytest.raises(ConfigurationError, match="no success route"):
+            validate_workflow_config(config)
+
+    def test_raises_validates_specific_error_routes_when_present(self) -> None:
+        """A raises declaration catches misspelled specific route kinds."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="test", entry_point="script"),
+            agents=[
+                AgentDef(
+                    name="script",
+                    type="script",
+                    command="echo",
+                    raises=["external.git.drift"],
+                    routes=[
+                        RouteDef(to="$end"),
+                        RouteDef(to="$end", on_error="external.git.fetch_failed"),
+                    ],
+                )
+            ],
+        )
+
+        with pytest.raises(ConfigurationError, match="not declared in raises"):
+            validate_workflow_config(config)
+
+    def test_error_routes_are_rejected_on_non_script_steps(self) -> None:
+        """Phase 1 cannot accept error handlers that the engine will never run."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="test", entry_point="agent"),
+            agents=[
+                AgentDef(
+                    name="agent",
+                    prompt="work",
+                    routes=[
+                        RouteDef(to="$end"),
+                        RouteDef(to="$end", on_error=True),
+                    ],
+                )
+            ],
+        )
+
+        with pytest.raises(ConfigurationError, match="only for script steps"):
+            validate_workflow_config(config)
+
+    def test_error_routes_are_rejected_on_parallel_groups(self) -> None:
+        """Group error routing stays out of the Phase 1 execution surface."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="test", entry_point="group"),
+            agents=[
+                AgentDef(name="one", prompt="one"),
+                AgentDef(name="two", prompt="two"),
+            ],
+            parallel=[
+                ParallelGroup(
+                    name="group",
+                    agents=["one", "two"],
+                    routes=[
+                        RouteDef(to="$end"),
+                        RouteDef(to="$end", on_error=True),
+                    ],
+                )
+            ],
+        )
+
+        with pytest.raises(ConfigurationError, match="Parallel group 'group'.*on_error"):
+            validate_workflow_config(config)
+
+    def test_error_catch_all_must_be_last(self) -> None:
+        """A catch-all cannot shadow a later specific error route."""
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="test", entry_point="script"),
+            agents=[
+                AgentDef(
+                    name="script",
+                    type="script",
+                    command="echo",
+                    routes=[
+                        RouteDef(to="$end"),
+                        RouteDef(to="$end", on_error=True),
+                        RouteDef(to="$end", on_error="external.git.drift"),
+                    ],
+                )
+            ],
+        )
+
+        with pytest.raises(ConfigurationError, match="catch-all on_error route must be last"):
+            validate_workflow_config(config)
+
     def test_valid_multi_agent_config(self) -> None:
         """Test validation of a valid multi-agent config."""
         config = WorkflowConfig(
@@ -1167,6 +1268,81 @@ class TestExplicitModeWarnings:
         )
         warnings = validate_workflow_config(config)
         assert any("research.output" in w and "explicit" in w and "writer" in w for w in warnings)
+
+    def test_undeclared_agent_error_ref_in_explicit_mode_warns(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="checker",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                AgentDef(
+                    name="checker",
+                    type="script",
+                    command="check",
+                    routes=[
+                        RouteDef(to="$end"),
+                        RouteDef(to="recovery", on_error=True),
+                    ],
+                ),
+                _agent_with_prompt("recovery", "Handle {{ checker.error.kind }}"),
+            ],
+        )
+
+        warnings = validate_workflow_config(config)
+
+        assert any("checker.error" in w and "explicit" in w and "recovery" in w for w in warnings)
+
+    def test_declared_agent_error_ref_in_explicit_mode_has_no_warning(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="checker",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                AgentDef(
+                    name="checker",
+                    type="script",
+                    command="check",
+                    routes=[
+                        RouteDef(to="$end"),
+                        RouteDef(to="recovery", on_error=True),
+                    ],
+                ),
+                _agent_with_prompt(
+                    "recovery",
+                    "Handle {{ checker.error.kind }}",
+                    input=["checker.error.kind"],
+                ),
+            ],
+        )
+
+        warnings = validate_workflow_config(config)
+
+        assert not any("checker.error" in w and "explicit context mode" in w for w in warnings)
+
+    def test_legacy_error_field_shorthand_remains_an_output_declaration(self) -> None:
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="t",
+                entry_point="producer",
+                context=ContextConfig(mode="explicit"),
+            ),
+            agents=[
+                _agent_with_prompt("producer", "Produce", routes=[RouteDef(to="consumer")]),
+                _agent_with_prompt(
+                    "consumer",
+                    "Handle {{ producer.output.error }}",
+                    input=["producer.error"],
+                ),
+            ],
+        )
+
+        warnings = validate_workflow_config(config)
+
+        assert not any("producer.output.error" in w and "explicit" in w for w in warnings)
 
     def test_undeclared_workflow_input_ref_in_explicit_mode_warns(self) -> None:
         config = WorkflowConfig(

--- a/tests/test_engine/test_context.py
+++ b/tests/test_engine/test_context.py
@@ -17,6 +17,7 @@ from conductor.engine.context import (
     estimate_dict_tokens,
     estimate_tokens,
 )
+from conductor.error_envelope import ErrorEnvelope
 
 
 class TestWorkflowContextBasic:
@@ -70,6 +71,60 @@ class TestWorkflowContextBasic:
         assert ctx.agent_outputs["agent1"]["result"] == "first"
         assert ctx.agent_outputs["agent2"]["result"] == "second"
         assert ctx.agent_outputs["agent3"]["result"] == "third"
+
+    def test_typed_error_is_available_in_explicit_context_and_checkpoint_round_trip(
+        self,
+    ) -> None:
+        """Handled failures survive explicit projection and serialization."""
+        ctx = WorkflowContext()
+        error = ErrorEnvelope(
+            kind="external.git.drift",
+            message="remote changed",
+            details={"branch": "main"},
+        )
+        ctx.store("checker", {"stdout": "partial"})
+        ctx.store_error("checker", error)
+
+        restored = WorkflowContext.from_dict(ctx.to_dict())
+        explicit = restored.build_for_agent(
+            "recovery",
+            ["checker.output", "checker.error"],
+            mode="explicit",
+        )
+
+        assert explicit["checker"]["output"] == {"stdout": "partial"}
+        assert explicit["checker"]["error"] == error.to_dict()
+
+    def test_new_output_clears_previous_typed_error(self) -> None:
+        """A later successful execution cannot expose a stale handled failure."""
+        ctx = WorkflowContext()
+        ctx.store("checker", {"stdout": "partial"})
+        ctx.store_error(
+            "checker",
+            ErrorEnvelope(
+                kind="external.git.drift",
+                message="remote changed",
+                details={},
+            ),
+        )
+
+        ctx.store("checker", {"stdout": "current"})
+
+        assert "checker" not in ctx.step_errors
+        assert ctx.get_for_template()["checker"] == {"output": {"stdout": "current"}}
+
+    def test_error_shorthand_still_projects_legacy_output_field(self) -> None:
+        """Typed errors do not steal the existing agent.field shorthand."""
+        ctx = WorkflowContext()
+        ctx.store("producer", {"error": {"code": "legacy"}})
+
+        explicit = ctx.build_for_agent(
+            "consumer",
+            ["producer.error"],
+            mode="explicit",
+        )
+
+        assert explicit["producer"]["output"] == {"error": {"code": "legacy"}}
 
     def test_get_latest_output(self) -> None:
         """Test getting the latest output."""

--- a/tests/test_engine/test_context_serialization.py
+++ b/tests/test_engine/test_context_serialization.py
@@ -32,6 +32,7 @@ class TestWorkflowContextToDict:
         assert d == {
             "workflow_inputs": {},
             "agent_outputs": {},
+            "step_errors": {},
             "current_iteration": 0,
             "execution_history": [],
             "user_guidance": [],

--- a/tests/test_engine/test_router.py
+++ b/tests/test_engine/test_router.py
@@ -14,6 +14,7 @@ import pytest
 
 from conductor.config.schema import RouteDef
 from conductor.engine.router import Router, RouteResult
+from conductor.error_envelope import ErrorEnvelope
 
 
 class TestRouteResult:
@@ -276,6 +277,54 @@ class TestRouterFallthrough:
 
         result = router.evaluate(routes, {"special": False, "other": True}, {})
         assert result.target == "default"
+
+
+class TestRouterErrorRoutes:
+    """Tests for deterministic success/error route buckets."""
+
+    def test_error_route_matches_kind_with_output_and_error_context(self) -> None:
+        """Error conditions can inspect partial output and the typed envelope."""
+        router = Router()
+        routes = [
+            RouteDef(to="success"),
+            RouteDef(
+                to="recover",
+                on_error="external.git.drift",
+                when=("{{ output.exit_code == 0 and error.details.branch == 'main' }}"),
+            ),
+            RouteDef(to="fallback", on_error=True),
+        ]
+        error = ErrorEnvelope(
+            kind="external.git.drift",
+            message="remote changed",
+            details={"branch": "main"},
+        )
+
+        result = router.evaluate(routes, {"exit_code": 0}, {}, error=error)
+
+        assert result.target == "recover"
+
+    def test_arithmetic_error_route_receives_flattened_error_context(self) -> None:
+        """Simple expressions can inspect the same typed envelope."""
+        router = Router()
+        routes = [
+            RouteDef(to="success"),
+            RouteDef(
+                to="recover",
+                on_error="external.git.drift",
+                when="error_kind == 'external.git.drift' and exit_code == 0",
+            ),
+            RouteDef(to="fallback", on_error=True),
+        ]
+        error = ErrorEnvelope(
+            kind="external.git.drift",
+            message="remote changed",
+            details={"branch": "main"},
+        )
+
+        result = router.evaluate(routes, {"exit_code": 0}, {}, error=error)
+
+        assert result.target == "recover"
 
 
 class TestRouterOutputTransform:

--- a/tests/test_engine/test_script_workflow.py
+++ b/tests/test_engine/test_script_workflow.py
@@ -16,6 +16,7 @@ Tests cover:
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,9 +32,15 @@ from conductor.config.schema import (
     WorkflowConfig,
     WorkflowDef,
 )
+from conductor.engine.checkpoint import CheckpointManager
 from conductor.engine.workflow import WorkflowEngine
 from conductor.events import WorkflowEvent, WorkflowEventEmitter
-from conductor.exceptions import ConfigurationError, ValidationError
+from conductor.exceptions import (
+    ConfigurationError,
+    ExecutionError,
+    UnhandledNodeError,
+    ValidationError,
+)
 from conductor.providers.copilot import CopilotProvider
 
 
@@ -253,6 +260,213 @@ class TestScriptRouting:
         result = await engine.run({})
 
         assert result["path"] == "ran success_handler"
+
+    @pytest.mark.asyncio
+    async def test_typed_script_failure_routes_with_error_context(self) -> None:
+        """A typed failure selects error routes and is visible to its handler."""
+        script = (
+            "import json, os; "
+            "open(os.environ['CONDUCTOR_ERROR_OUT'], 'w', encoding='utf-8').write("
+            "json.dumps({'kind': 'external.git.drift', "
+            "'message': 'remote changed', 'details': {'branch': 'main'}})); "
+            "print('partial')"
+        )
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="typed-script-route",
+                entry_point="checker",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="checker",
+                    type="script",
+                    command=sys.executable,
+                    args=["-c", script],
+                    output={"result": OutputField(type="string")},
+                    routes=[
+                        RouteDef(to="success_handler"),
+                        RouteDef(to="recovery", on_error="external.git.drift"),
+                    ],
+                ),
+                AgentDef(
+                    name="success_handler",
+                    prompt="Unexpected success",
+                    routes=[RouteDef(to="$end")],
+                ),
+                AgentDef(
+                    name="recovery",
+                    prompt=(
+                        "Recover {{ checker.error.kind }}: "
+                        "{{ checker.error.message }} / {{ checker.output.stdout }}"
+                    ),
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"path": "{{ recovery.output.result }}"},
+        )
+        received_prompts: list[str] = []
+
+        def mock_handler(agent, prompt, context):
+            received_prompts.append(prompt)
+            return {"result": f"ran {agent.name}"}
+
+        engine = WorkflowEngine(config, CopilotProvider(mock_handler=mock_handler))
+
+        result = await engine.run({})
+
+        assert result["path"] == "ran recovery"
+        assert [prompt.strip() for prompt in received_prompts] == [
+            "Recover external.git.drift: remote changed / partial"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unhandled_typed_failure_checkpoints_before_state_commit(
+        self, tmp_path: Path
+    ) -> None:
+        """An unhandled failure checkpoints the failing step for replay."""
+        script = (
+            "import json, os; "
+            "open(os.environ['CONDUCTOR_ERROR_OUT'], 'w', encoding='utf-8').write("
+            "json.dumps({'kind': 'external.git.drift', "
+            "'message': 'remote changed', 'details': {}}))"
+        )
+        workflow_path = tmp_path / "workflow.yaml"
+        workflow_path.write_text("workflow: {}", encoding="utf-8")
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="typed-script-unhandled",
+                entry_point="checker",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="checker",
+                    type="script",
+                    command=sys.executable,
+                    args=["-c", script],
+                )
+            ],
+        )
+        provider = MagicMock()
+        provider.get_session_ids.return_value = {}
+        engine = WorkflowEngine(config, provider, workflow_path=workflow_path)
+
+        with pytest.raises(UnhandledNodeError) as raised:
+            await engine.run({})
+
+        assert raised.value.error.kind == "external.git.drift"
+        assert "checker" not in engine.context.agent_outputs
+        assert engine.limits.current_iteration == 0
+        assert engine._last_checkpoint_path is not None
+
+    @pytest.mark.asyncio
+    async def test_handler_failure_checkpoint_includes_routed_error_context(
+        self, tmp_path: Path
+    ) -> None:
+        """A later handler failure checkpoints the handler and prior envelope."""
+        script = (
+            "import json, os; "
+            "open(os.environ['CONDUCTOR_ERROR_OUT'], 'w', encoding='utf-8').write("
+            "json.dumps({'kind': 'external.git.drift', "
+            "'message': 'remote changed', 'details': {'branch': 'main'}})); "
+            "print('partial')"
+        )
+        workflow_path = tmp_path / "workflow.yaml"
+        workflow_path.write_text("workflow: {}", encoding="utf-8")
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="typed-script-handler-failure",
+                entry_point="checker",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="checker",
+                    type="script",
+                    command=sys.executable,
+                    args=["-c", script],
+                    routes=[
+                        RouteDef(to="$end"),
+                        RouteDef(to="recovery", on_error="external.git.drift"),
+                    ],
+                ),
+                AgentDef(
+                    name="recovery",
+                    type="script",
+                    command="definitely-not-a-real-conductor-command",
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+        )
+        provider = MagicMock()
+        provider.get_session_ids.return_value = {}
+        engine = WorkflowEngine(config, provider, workflow_path=workflow_path)
+
+        with pytest.raises(ExecutionError, match="command not found"):
+            await engine.run({})
+
+        assert engine._last_checkpoint_path is not None
+        checkpoint = CheckpointManager.load_checkpoint(engine._last_checkpoint_path)
+        assert checkpoint.current_agent == "recovery"
+        assert checkpoint.context["agent_outputs"]["checker"]["stdout"].strip() == "partial"
+        assert checkpoint.context["step_errors"]["checker"] == {
+            "kind": "external.git.drift",
+            "message": "remote changed",
+            "details": {"branch": "main"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_catch_all_preserves_kind_not_declared_in_raises(self) -> None:
+        """Raises is documentation-only; catch-all routes retain the runtime kind."""
+        script = (
+            "import json, os; "
+            "open(os.environ['CONDUCTOR_ERROR_OUT'], 'w', encoding='utf-8').write("
+            "json.dumps({'kind': 'external.git.unexpected', "
+            "'message': 'unexpected', 'details': {}}))"
+        )
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="typed-script-catch-all",
+                entry_point="checker",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="checker",
+                    type="script",
+                    command=sys.executable,
+                    args=["-c", script],
+                    raises=["external.git.drift"],
+                    routes=[
+                        RouteDef(to="$end"),
+                        RouteDef(to="recovery", on_error=True),
+                    ],
+                ),
+                AgentDef(
+                    name="recovery",
+                    prompt="{{ checker.error.kind }}",
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"kind": "{{ recovery.output.result }}"},
+        )
+        engine = WorkflowEngine(
+            config,
+            CopilotProvider(mock_handler=lambda agent, prompt, context: {"result": prompt}),
+        )
+
+        result = await engine.run({})
+
+        assert result["kind"] == "external.git.unexpected"
 
 
 class TestScriptLimits:

--- a/tests/test_executor/test_script.py
+++ b/tests/test_executor/test_script.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from conductor.config.schema import AgentDef
+from conductor.error_envelope import ErrorEnvelope
 from conductor.exceptions import ExecutionError, TemplateError
 from conductor.executor.script import ScriptExecutor, ScriptOutput
 
@@ -104,6 +105,118 @@ class TestScriptExecutorBasic:
         output = await executor.execute(agent, {})
         assert "out" in output.stdout
         assert "err" in output.stderr
+
+    @pytest.mark.asyncio
+    async def test_typed_error_file_is_returned_without_changing_process_output(
+        self, executor: ScriptExecutor
+    ) -> None:
+        """A script can publish a typed failure through the engine-owned file."""
+        envelope = {
+            "kind": "external.git.drift",
+            "message": "remote changed",
+            "details": {"branch": "main"},
+        }
+        script = (
+            "import json, os; "
+            "open(os.environ['CONDUCTOR_ERROR_OUT'], 'w', encoding='utf-8').write("
+            f"json.dumps({envelope!r})); "
+            "print('partial output')"
+        )
+        agent = AgentDef(
+            name="typed_failure",
+            type="script",
+            command=sys.executable,
+            args=["-c", script],
+        )
+
+        output = await executor.execute(agent, {})
+
+        assert output.stdout.strip() == "partial output"
+        assert output.exit_code == 0
+        assert output.error == ErrorEnvelope(
+            kind="external.git.drift",
+            message="remote changed",
+            details={"branch": "main"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_error_file_becomes_transport_failure(
+        self, executor: ScriptExecutor
+    ) -> None:
+        """A malformed file cannot silently turn an intended failure into success."""
+        script = (
+            "import os; "
+            "open(os.environ['CONDUCTOR_ERROR_OUT'], 'w', encoding='utf-8').write('{broken')"
+        )
+        agent = AgentDef(
+            name="invalid_typed_failure",
+            type="script",
+            command=sys.executable,
+            args=["-c", script],
+        )
+
+        output = await executor.execute(agent, {})
+
+        assert output.exit_code == 0
+        assert output.error is not None
+        assert output.error.kind == "internal.script_error_transport"
+        assert output.error.details["error_type"] == "JSONDecodeError"
+
+    @pytest.mark.asyncio
+    async def test_script_cannot_publish_engine_owned_error_kind(
+        self, executor: ScriptExecutor
+    ) -> None:
+        """The untrusted script channel cannot impersonate engine failures."""
+        envelope = {
+            "kind": "internal.script_error_transport",
+            "message": "forged",
+            "details": {},
+        }
+        script = (
+            "import json, os; "
+            "open(os.environ['CONDUCTOR_ERROR_OUT'], 'w', encoding='utf-8').write("
+            f"json.dumps({envelope!r}))"
+        )
+        agent = AgentDef(
+            name="forged_engine_failure",
+            type="script",
+            command=sys.executable,
+            args=["-c", script],
+        )
+
+        output = await executor.execute(agent, {})
+
+        assert output.error is not None
+        assert output.error.kind == "internal.script_error_transport"
+        assert output.error.message == (
+            "Script 'forged_engine_failure' published an invalid error envelope"
+        )
+        assert "engine-owned namespace" in output.error.details["error"]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_error_file_becomes_transport_failure(
+        self, executor: ScriptExecutor
+    ) -> None:
+        """An engine-owned file read failure cannot erase a typed failure."""
+        script = (
+            "import os; open(os.environ['CONDUCTOR_ERROR_OUT'], 'w', encoding='utf-8').write('{}')"
+        )
+        agent = AgentDef(
+            name="unreadable_typed_failure",
+            type="script",
+            command=sys.executable,
+            args=["-c", script],
+        )
+
+        with (
+            patch("conductor.executor.script._verbose_log"),
+            patch("pathlib.Path.read_text", side_effect=OSError("access denied")),
+        ):
+            output = await executor.execute(agent, {})
+
+        assert output.error is not None
+        assert output.error.kind == "internal.script_error_transport"
+        assert output.error.details["error_type"] == "OSError"
 
 
 class TestScriptExecutorTimeout:

--- a/tests/test_web/test_server.py
+++ b/tests/test_web/test_server.py
@@ -1173,6 +1173,63 @@ class TestReplaySyntheticFromContext:
         assert types == ["script_started", "script_completed"]
         assert dashboard._event_history[1]["data"]["stdout"] == "hi"
 
+    def test_emits_script_failed_for_handled_typed_error(self) -> None:
+        from conductor.engine.context import WorkflowContext
+        from conductor.error_envelope import ErrorEnvelope
+
+        emitter, dashboard = _make_dashboard()
+        ctx = WorkflowContext()
+        ctx.store("s", {"stdout": "partial", "stderr": "", "exit_code": 0})
+        ctx.store_error(
+            "s",
+            ErrorEnvelope(
+                kind="external.git.drift",
+                message="remote changed",
+                details={"branch": "main"},
+            ),
+        )
+
+        count = dashboard.replay_synthetic_from_context(ctx, self._build_config())
+
+        assert count == 2
+        types = [ev["type"] for ev in dashboard._event_history]
+        assert types == ["script_started", "script_failed"]
+        failed = dashboard._event_history[1]["data"]
+        assert failed["error"] == {
+            "kind": "external.git.drift",
+            "message": "remote changed",
+            "details": {"branch": "main"},
+        }
+        assert failed["stdout"] == "partial"
+        assert failed["synthetic"] is True
+
+    def test_repeated_script_marks_only_latest_execution_with_current_error(self) -> None:
+        from conductor.engine.context import WorkflowContext
+        from conductor.error_envelope import ErrorEnvelope
+
+        emitter, dashboard = _make_dashboard()
+        ctx = WorkflowContext()
+        ctx.store("s", {"stdout": "first", "stderr": "", "exit_code": 0})
+        ctx.store("s", {"stdout": "second", "stderr": "", "exit_code": 0})
+        ctx.store_error(
+            "s",
+            ErrorEnvelope(
+                kind="external.git.drift",
+                message="remote changed",
+                details={},
+            ),
+        )
+
+        dashboard.replay_synthetic_from_context(ctx, self._build_config())
+
+        types = [ev["type"] for ev in dashboard._event_history]
+        assert types == [
+            "script_started",
+            "script_completed",
+            "script_started",
+            "script_failed",
+        ]
+
     def test_emits_wait_events_for_wait_type(self) -> None:
         """Wait steps replay via _synth_agent_or_script's wait branch
         (issue #218). The synthetic event pair must use the


### PR DESCRIPTION
Rebased onto current `main` (`148b80e`) and narrowed to the smallest coherent Phase 1 from RFC #227: **typed script failures with deterministic error routing**.

## Phase 1 scope

- Language-neutral `CONDUCTOR_ERROR_OUT` file transport for `type: script`.
- One engine-owned envelope: `{kind, message, details}`.
- `on_error` selectors: exact kind, list of kinds, or `true` catch-all.
- Separate success and error route buckets; declaration order and `when:` behavior remain unchanged within each bucket.
- Handler context exposes both `<step>.output` and `<step>.error`.
- Optional `raises:` as documentation/load-time validation only.
- Engine-owned namespaces (`internal.`, `provider.`, `subworkflow.`, `retry.`) cannot be published or declared by scripts.
- Checkpoint serialization and dashboard fallback replay preserve handled error state.

## Compatibility and deliberate exclusions

- Ordinary nonzero script exits remain ordinary script output; existing `exit_code` routes are unchanged.
- A missing error file means no typed failure. File presence is authoritative regardless of exit code.
- Malformed, unreadable, or reserved-kind envelopes become `internal.script_error_transport` rather than silently succeeding.
- No agent-output discriminator, provider-error routing, sub-workflow/group propagation, route retry actions, `errors.jsonl`, new CLI exit code, or bundled language helpers in Phase 1.
- `on_error`/`raises` are rejected outside top-level script steps so unsupported handlers cannot silently never run.

## Resolved precedence

1. Provider retries remain provider-owned and complete before the engine observes a failure; provider failures are not routable in Phase 1.
2. Script typed failure routing takes precedence over validating the success `output:` schema, allowing handlers to inspect partial stdout/stderr.
3. Failed explicit `terminate` remains terminal, unroutable, and non-checkpointed.
4. `SubworkflowTerminatedError` retains existing parent behavior; workflow steps cannot use `on_error` in Phase 1.
5. A routed failure commits output + envelope and creates no failure checkpoint. If the handler later fails, the checkpoint points at the handler and contains the prior envelope.
6. An unmatched typed failure, including a script with no routes, raises `UnhandledNodeError` before committing that execution; the checkpoint points at the script for replay.

## `raises:` decision

`raises:` remains useful as optional author-facing documentation and lint. It does not opt into synthesis, rewrite undeclared runtime kinds, or constrain `on_error: true`; catch-all handlers receive the original runtime kind.

## Validation

- 731 focused tests passed across schema, validator, executor, router, context, workflow, checkpoint behavior, and web replay.
- Full test collection succeeds and a cold provider-factory import succeeds.
- Ruff lint/format and changed-source `ty` checks pass.
- `examples/error-routing.yaml` validates and all success/exact/catch-all paths run successfully.
- One unrelated Windows CRLF assertion was deselected after confirming it fails identically on clean `origin/main`.

The branch history was intentionally replaced with one rebased commit so the PR no longer carries the obsolete broad implementation.