### PR TITLE
fix: external workflow friction - minimal evidence-anchored fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#225](https://github.com/microsoft/conductor/pull/225),
   [#136](https://github.com/microsoft/conductor/issues/136)).
 
+### Fixed
+- `parse_json_output` and the Copilot provider's `_extract_json` now use a
+  two-stage fenced-block extraction (non-greedy `re.findall` + per-candidate
+  try-parse, then a greedy single-capture fallback) so JSON whose string
+  fields contain triple-backtick substrings no longer matches prematurely
+  and falls into parse-recovery loops, while responses with multiple
+  fenced JSON blocks still pick the first valid one. Resolves a recurring
+  failure mode for agents emitting Markdown-bearing JSON
+  (external-workflow-friction Issue #1).
+- `conductor run --web-bg` and `conductor resume --web-bg` now abort before
+  forking when the workflow contains a `human_gate` agent (including gates
+  nested in `for_each.agent`) and `--skip-gates` is not set, with a message
+  listing the four supported options. `resume --web-bg` also recovers the
+  workflow path from the checkpoint when invoked without an explicit
+  workflow argument so the guard still fires. Previously the detached
+  child crashed with `EOFError` and the parent only reported
+  "Background process exited immediately with code 1" (Issue #8).
+
+### Documentation
+- New "Choosing whether to declare `output:`" section in
+  [docs/workflow-syntax.md](docs/workflow-syntax.md) describing when to declare
+  a schema versus consuming raw `<agent>.output.result` for prose or large
+  JSON. Closes a documentation gap that contributed to misconfiguration of
+  agents emitting large payloads (Issue #2).
+- `docs/cli-reference.md` `--web-bg` section now documents the `human_gate`
+  incompatibility and the new pre-fork validation behavior.
+
 ## [0.1.17](https://github.com/microsoft/conductor/compare/v0.1.16...v0.1.17) - 2026-05-21
 
 ### Added

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -98,6 +98,19 @@ The `--web-bg` flag is a convenience shortcut: it forks a background process run
 
 `--web` and `--web-bg` are mutually exclusive.
 
+**`--web-bg` and `human_gate`** — `--web-bg` is incompatible with workflows
+that contain `human_gate` agents (unless `--skip-gates` is also passed),
+because the detached background process has no stdin to prompt on and the
+child would crash with `EOFError` mid-run. Conductor detects this at
+load time and aborts before forking, with a message listing the options:
+
+1. Use `--web` (foreground) instead of `--web-bg`
+2. Add `--skip-gates` to auto-select the first option at every gate
+3. Remove `human_gate` steps from the workflow
+4. Wait for CLI gate-resolution support (planned follow-up)
+
+The same check applies to `conductor resume --web-bg`.
+
 Background workflows can be stopped with `conductor stop` (see below) or via the stop button in the web dashboard.
 
 #### Automation Mode

--- a/docs/projects/usability-features/external-workflow-friction.brainstorm.md
+++ b/docs/projects/usability-features/external-workflow-friction.brainstorm.md
@@ -1,0 +1,634 @@
+# External Workflow Friction — Findings and Fix Brainstorm
+
+> **Status:** brainstorm — open for discussion before any of the proposals here become a `.plan.md`.
+> **Author:** Lucio Tinoco (external user contributor)
+> **Source of evidence:** real-world execution of the `workiq-coach` Conductor workflow set (Phase A: WorkIQ fan-out → synthesizer → schema validator → save; Phase B: four parallel artifact generators → consistency check → 5 saves). Seven failed runs across May 25–26, 2026, before a successful end-to-end execution was achieved.
+> **Audience:** Conductor maintainers, and any contributor who'd help upstream these fixes.
+
+---
+
+## Why this document exists
+
+A single user trying to run two non-trivial workflows against real WorkIQ + Copilot + Anthropic data hit nine distinct rough edges in Conductor v0.1.16. Each one looked like a one-off the first time it appeared; each turned out to be a real bug or design fragility. Most are small fixes. A few are architectural choices worth discussing.
+
+This document records what was learned so the cost of that session pays back across the codebase rather than being a private tale. It is **not** a request to fix everything at once — it's a structured analysis with a phased implementation plan that maintainers can carve into PR-sized work, reshape, reject, or defer.
+
+The unifying theme: each issue produces a **silent or confusing failure mode** that consumes minutes-to-hours of an external user's time before the actual cause becomes diagnosable. The fixes are mostly about **earlier and clearer errors**, **safer defaults**, and **eliminating brittle implicit behaviors**.
+
+---
+
+## Executive summary
+
+| Tier | Theme | Issues | PR cluster |
+|---|---|---|---|
+| **1** | Silent/confusing failures → clear errors | #4 var expansion, #7 script in parallel, #8 web-bg + gate, parts of #3 | "Better validation + error messages" |
+| **2** | Architectural fragility in JSON envelope extraction | #1 fence regex, #2 `output:` schema default | "Output mode: raw vs envelope" |
+| **3** | Operational reliability | #3 subprocess intermittency, #5 dashboard zombie, #6 retry budget, #9 expansion parity | "Runtime hardening" |
+| **Bonus** | Patterns that look fragile but haven't surfaced in our use yet | event-history unbounded growth, parallel context race, recovery prompt reuses identical schema, no dashboard-startup timeout | Future cleanup |
+
+The single highest-leverage change is **#1 + #2 together** — the JSON envelope extraction + the `output:` schema default. These are responsible for the majority of "Parse Recovery 1/5 → 5/5 → workflow times out" experiences we hit. Tier 1 fixes are individually cheap and add up to a much smoother first-run experience for new external users.
+
+---
+
+## Source of evidence: the workiq-coach session
+
+A condensed timeline of what we hit, run-by-run, because the *narrative* of how these issues compound is more convincing than the issue list alone. Each numbered issue below references where in this timeline it appeared.
+
+| Run | Setup | Outcome | Time spent |
+|---|---|---|---|
+| #1 (Phase A) | Default workflow, opus synthesizer | Opus reached for PowerShell to construct JSON; hit Copilot's tool-output ceiling; corrupted its own file; recovery loop. *Cancelled.* | ~30 min |
+| #2 (Phase A) | Strengthened synthesizer prompt forbidding tool use | Opus emitted JSON wrapped in ` ```json ` fence; Conductor's fence regex failed; Parse Recovery 1–5; cancelled. *(Issue #1)* | ~25 min |
+| #3 (Phase A) | Switched to haiku synthesizer; ran with `--web` | Workflow reached the `human_gate` cleanly. Dashboard parked for ~14 hours overnight. Dashboard server socket died silently; gate became unreachable from browser; no CLI fallback. Process killed. *(Issue #5)* | ~14 hr wallclock |
+| #4 (Phase A) | Used `--skip-gates` flag | Same synthesizer parse recovery as run #2, exhausted the 30-min `timeout_seconds` budget. *(Issue #1 + workflow time budget too tight to absorb retries.)* | ~30 min |
+| #5 (Phase A) | Removed gates from YAML; bumped timeout to 60 min | Synthesizer produced output, validator rejected for `broadSettings.examples` shape (downstream schema, not Conductor's fault), revise loop didn't converge. Killed. | ~15 min |
+| #6 (Phase A) | Extended downstream schema | Same fence-extraction failure as runs #2/#4 — synthesizer hit parse recovery, timed out again. *(Issue #1, deterministically.)* | ~20 min |
+| #7 (Phase A) | **Refactored synthesizer to remove `output:` schema** (read `.output.result` instead). | Synthesizer produced clean ~80 KB JSON in one shot, no parse recovery. Validator failed on a different shape issue. Manual extraction from checkpoint, manual stringification of one field, manual write — and observations.json was on disk. *(Issue #2 was the root cause all along.)* | ~10 min |
+
+For Phase B (which already used the no-`output:`-schema pattern from the start), everything worked first try in ~10 minutes total.
+
+**Net loss to friction across runs #1–#7: roughly 3 hours of wall-clock LLM execution + several hours of human diagnostic time, almost all attributable to issues #1, #2, and #5.**
+
+The other six issues (#3, #4, #6, #7, #8, #9) surfaced in supporting fashion — each cost minutes, and each is independently a real bug.
+
+---
+
+## Issue 1 — Fence-extraction regex breaks on large or nested JSON
+
+### Symptom
+
+When an agent declares an `output:` schema, the provider injects an instruction to "respond with JSON matching this schema." Models — particularly opus and gpt-5.2, and sometimes haiku — wrap large JSON responses in ` ```json ... ``` ` fences. Conductor's extraction regex is non-greedy: it matches the first ` ``` ` it sees after the opening fence. If the JSON content contains backticks (code snippets in `your_excerpt` strings, etc.), or simply if the response is large enough that the model breaks it across the fence boundary, the regex truncates and the extracted JSON is invalid.
+
+This triggers **Parse Recovery 1/5, 2/5, …** with each retry round-tripping the LLM at full prompt size. After 5/5, the agent gives up and either falls into a downstream revise loop or fails the workflow.
+
+### Location
+
+- `src/conductor/executor/output.py:120` — primary fence-extraction regex
+- `src/conductor/providers/copilot.py:1102` — provider-side fallback fence-extraction
+- `src/conductor/providers/copilot.py:679-746` — parse recovery loop
+- `src/conductor/providers/claude.py` — provider parity required for any change
+
+### Cause
+
+A non-greedy regex along the lines of:
+
+```python
+re.search(r"```(?:json)?\s*\n?(.*?)\n?```", response, re.DOTALL)
+```
+
+The `.*?` matches as little as possible, so the regex always closes at the **first** ` ``` ` after the opening fence. Triple-backticks anywhere inside the JSON content (legitimate or not) split the match prematurely.
+
+### Fix proposal
+
+Two viable approaches, not mutually exclusive:
+
+1. **Greedy match anchored to the last fence on the line** — change to `re.search(r"```(?:json)?\s*\n(.*)\n```\s*$", response, re.DOTALL)` so the regex closes at the *last* closing fence in the response. Add a `json.loads()` sanity check on the extracted content; if parse fails, fall back to:
+2. **Brace-balanced extraction as a fallback** — find the first `{` (or `[`), walk the response character-by-character respecting string escapes, return the substring up to the matching closing brace. Bypasses the regex entirely for the common case where the model emits JSON with any prose around it (with or without fences).
+
+The brace-balanced approach is more robust but ~30 LOC of careful code (must handle string escapes, brackets inside strings, etc.). The greedy-regex approach is ~3 LOC and fixes 90% of real cases.
+
+**Recommendation:** ship the greedy regex first as a quick win; add the brace-balanced extractor as a follow-up for the long tail.
+
+### Blast radius
+
+- All workflows with `output:` schemas and large structured responses
+- Workflows where any string field in the JSON could contain triple-backticks (e.g. coaching observations quoting Markdown, code examples in prose, file paths)
+- Both providers (copilot + claude) need the same fix per the [Provider Parity](../../AGENTS.md#provider-parity) rule
+
+### Validation approach
+
+Add tests under `tests/test_executor/test_output.py`:
+- Fence-wrapped JSON with triple-backticks inside a string field
+- Fence-wrapped JSON ~80 KB in size
+- Fence-wrapped JSON with prose before and after the fence
+- Raw JSON with no fence
+- Malformed JSON (must still fail cleanly)
+
+---
+
+## Issue 2 — `output:` schema is the wrong default for prose / large JSON agents
+
+### Symptom
+
+`output:` is intuitively the "right" way to declare what an agent produces. New users specify it for every agent. For agents that produce small, strictly-structured JSON, it works fine. For agents that produce:
+
+- Large structured JSON (>10 KB)
+- Markdown narrative wrapped in a string field
+- Output that legitimately contains triple-backticks
+
+…it actively hurts. The schema instruction + fence-extraction regex (Issue #1) combine to produce reliable parse recovery loops.
+
+The workaround — drop `output:`, read the response from `<agent>.output.result` directly — exists in the codebase (`copilot.py:668-677`) and is mentioned obliquely in the README, but it isn't the discovered path for new users. We took six failed runs to find it.
+
+### Location
+
+- `src/conductor/providers/copilot.py:524-531` — schema instruction injection
+- `src/conductor/providers/copilot.py:668-677` — the "no schema" code path that wraps response in `{"result": "..."}`
+- `src/conductor/config/schema.py` — `AgentDef` and `OutputField` definitions
+
+### Cause
+
+`output:` semantically means two things at once:
+1. **The shape the model should produce** (a hint to the LLM)
+2. **The shape Conductor should extract from the response** (a parser instruction)
+
+For prose-heavy or large outputs, you want neither — you want raw text passed through. There's no way to express that today except by omitting `output:` entirely, which feels like "I didn't tell Conductor what this produces," not "I told Conductor the right thing."
+
+### Fix proposal
+
+Add an explicit `output_mode` field to `AgentDef`:
+
+```yaml
+- name: synthesizer
+  prompt: !file prompts/synthesizer.md
+  output_mode: raw          # NEW — captures response as .result
+  # ...
+
+- name: structured_extractor
+  prompt: !file prompts/structured.md
+  output_mode: envelope     # default for backward compat; uses output: schema
+  output:
+    field1:
+      type: string
+    field2:
+      type: integer
+```
+
+**Default behavior:** continue to behave as today (envelope mode if `output:` is present, raw mode if not), so this is non-breaking. But:
+
+1. At `conductor validate` time, **warn** when an agent has `output:` but its prompt strongly suggests prose output (heuristic: prompt contains "narrative", "markdown", "essay", "summary", "synthesizer", or the output schema has a single string field with description suggesting a large block).
+2. **Document prominently** in `docs/workflow-syntax.md` that for agents emitting large JSON or markdown, `output_mode: raw` (or omitting `output:`) is the right pattern.
+3. Add a section to the schema docs explaining the trade-off: envelope mode lets you reference structured fields downstream, raw mode preserves arbitrary text.
+
+### Blast radius
+
+- New workflows benefit from clearer guidance and earlier warnings
+- Existing workflows are unchanged (default behavior preserved)
+- Workflows currently using the `output:` workaround would gain a way to express intent explicitly
+
+### Validation approach
+
+- Unit tests for the validation warning logic
+- A `docs/workflow-syntax.md` example showing both modes side-by-side
+- A migration note in `CHANGELOG.md`
+
+---
+
+## Issue 3 — Subprocess invocation fails intermittently on Windows forward-slash paths
+
+### Symptom
+
+A `type: script` step with `command: "${PYTHON:-python}"`, with `$env:PYTHON = "C:/Python314/python.exe"`, fails with:
+
+```
+Script 'schema_validator': command not found: 'C:/Python314/python.exe'
+```
+
+**…sometimes.** The same env var, same shell context, same command worked in three earlier runs in the same session. The path is correct; the executable exists; `where python` resolves to it. Conductor's subprocess invocation appears nondeterministic with forward-slash absolute paths on Windows.
+
+### Location
+
+- `src/conductor/executor/script.py:105-118` — `asyncio.create_subprocess_exec()` call site
+
+### Cause
+
+Likely some combination of:
+1. **Path separator mismatch**: forward slashes work for most Windows APIs but `CreateProcessA` can be picky. Python's `subprocess` module on Windows resolves the executable differently depending on whether it sees a path-like string vs. a bare name.
+2. **`shell=False` (implicit default)** doesn't run PATH resolution the way the shell does. A forward-slash absolute path *should* work directly with `CreateProcessA` but may interact badly with some `env=` setups.
+3. **Inherited env from PowerShell** may carry stale `Path` variants between runs.
+
+### Fix proposal
+
+In `script.py` before calling `create_subprocess_exec`:
+
+```python
+import os
+if sys.platform == "win32":
+    rendered_command = rendered_command.replace("/", os.sep)
+```
+
+Normalize separators on Windows. Also improve the error message: when `FileNotFoundError` is caught, include the resolved command, the env vars referenced, and a hint about path separators if the resolved command contains `/` on Windows.
+
+### Blast radius
+
+- Windows users with forward-slash absolute paths in `command:` (common when copy-pasting from YAML examples that target POSIX)
+- POSIX users unaffected
+
+### Validation approach
+
+- Unit test under `tests/test_executor/test_script.py` with a forward-slash Windows path
+- Mock the subprocess call to verify the separator normalization happens
+
+---
+
+## Issue 4 — `${VAR:-DEFAULT}` regex splits on the first `:` in the default
+
+### Symptom
+
+`${PYTHON:-C:/Python314/python.exe}` fails to expand correctly: the first `:` (after `C`) is misread as the `:-` default separator, producing nonsensical variable resolution. Forces users to either set `$env:PYTHON` to absolute and use `${PYTHON:-python}` (with a colon-free default), or to avoid env-var defaults entirely for Windows paths.
+
+### Location
+
+- `src/conductor/config/loader.py:23` — env var expansion regex
+
+### Cause
+
+The regex (or equivalent string-split) treats `:` greedily as the var/default separator. Splits on the *first* `:` encountered. Windows drive letters violate this assumption.
+
+### Fix proposal
+
+Replace the regex with a parser that scans the token from `${` to `}` and uses `rfind(":-")` to locate the default separator only at the **last** `:-` occurrence:
+
+```python
+def parse_var_token(token: str) -> tuple[str, str | None]:
+    """Parse ${VAR:-DEFAULT} content (the text between ${ and })."""
+    sep = ":-"
+    idx = token.rfind(sep)
+    if idx == -1:
+        return token, None
+    return token[:idx], token[idx + len(sep):]
+```
+
+Walk the source string for `${...}` blocks and apply this parser.
+
+Alternative: document that defaults can't contain `:` and validate at load time — but the parser fix is small and removes a real footgun.
+
+### Blast radius
+
+- Windows users with absolute-path defaults
+- POSIX users unaffected (`:` is rare in defaults)
+- Backward-compatible (existing defaults without colons still work identically)
+
+### Validation approach
+
+- `tests/test_config/test_loader.py` cases:
+  - `${VAR:-C:/path/with/colons}` resolves to `C:/path/with/colons` when VAR unset
+  - `${VAR:-default}` still works (no colon)
+  - `${VAR}` (no default) still works
+  - Edge: nested `${...}` inside default value
+
+---
+
+## Issue 5 — Dashboard web server dies during long-parked human gates
+
+### Symptom
+
+A workflow with a `human_gate` that sits awaiting user input for many hours (overnight is a realistic case) ends up in a zombie state:
+
+- Conductor process: alive, idle (CPU 0)
+- Dashboard URL: `connection refused` (server thread or socket died)
+- Gate: unreachable from browser
+- CLI: no escape hatch — only option is to kill the process and lose progress
+
+### Location
+
+- `src/conductor/web/server.py` — `WebDashboard` lifecycle
+- `src/conductor/gates/human.py` — gate prompt logic
+- Likely interaction with `interrupt/listener.py`
+
+### Cause
+
+Hypothesized (would need code archaeology to confirm):
+1. **uvicorn or WebSocket idle timeout** closes the socket after some inactivity, but the workflow event loop keeps waiting on the gate
+2. **No keepalive** between dashboard and client
+3. **No CLI gate-response endpoint** — gates are resolved only through dashboard UI (or terminal stdin)
+
+### Fix proposal
+
+Three independent improvements; pick any subset:
+
+1. **WebSocket keepalive**: emit a `{"type": "heartbeat"}` event every 30–60 seconds from the dashboard server; clients respond with pong. Detects and reopens dead connections.
+2. **CLI gate-resolution command**: `conductor gate-accept <run-id>` and `conductor gate-respond <run-id> <choice>` that POSTs to a `/api/gate-response` endpoint on the dashboard server. Lets users resolve a parked gate without the browser dashboard, addresses the "dashboard zombie" failure mode directly.
+3. **Optional webhook / notification on gate-waiting**: out of scope for v0.1.x but worth flagging as a usability improvement for long-running workflows.
+
+The CLI gate-resolution command is the most impactful single change — it gives users an escape hatch when the dashboard becomes unresponsive for *any* reason, not just the specific failure mode we hit.
+
+### Blast radius
+
+- Long-running workflows with `human_gate` steps
+- Workflows that combine `--web-bg` with gates (currently broken per Issue #8 below; would also benefit)
+- Workflows without gates unaffected
+
+### Validation approach
+
+- Integration test: simulate dashboard socket close mid-gate; verify CLI gate-respond works
+- Manual: park a gate for >5 min, check keepalive works
+
+---
+
+## Issue 6 — Parse-recovery retry budget hardcoded per provider
+
+### Symptom
+
+When parse recovery is needed, Copilot gets 5 retries, Claude gets 2 (per the user's notes; values from `copilot.py:81` and `claude.py:106`). These are class-level constants. For large outputs prone to parse failure, 5 may be too few; for short, fast outputs in CI/cost-sensitive contexts, 5 may be too many.
+
+### Location
+
+- `src/conductor/providers/copilot.py:81`
+- `src/conductor/providers/claude.py:106`
+
+### Cause
+
+Not configurable.
+
+### Fix proposal
+
+Add `retry.max_parse_recovery_attempts` to the per-agent or per-workflow config (optional, with provider-specific defaults preserved for backward compat):
+
+```yaml
+- name: synthesizer
+  retry:
+    max_parse_recovery_attempts: 0   # fail fast; don't waste tokens on retries
+```
+
+Honors the [Provider Parity](../../AGENTS.md#provider-parity) rule — both providers need the same field surfaced.
+
+### Blast radius
+
+- Large-output workflows that would benefit from higher retry budgets
+- CI/cost-sensitive workflows that prefer fail-fast
+- Backward-compatible (default to current values)
+
+### Validation approach
+
+- Schema test: field accepts integer in range, rejects negative
+- Provider tests: configured value propagates to both copilot and claude paths
+
+---
+
+## Issue 7 — `type: script` agents inside `parallel:` groups silently misbehave
+
+### Symptom
+
+A YAML like:
+
+```yaml
+parallel:
+  - name: save_chain
+    description: Save all artifacts in parallel
+    agents:
+      - save_a
+      - save_b
+      - save_c
+    routes:
+      - to: $end
+```
+
+where each of `save_a/b/c` has `type: script` — silently runs each as an LLM agent with no prompt. The scripts never execute; tokens are burned on nothing.
+
+The user's `phase-b.yaml` originally had this structure and had to be refactored to a sequential save chain.
+
+### Location
+
+- `src/conductor/engine/workflow.py` — `_execute_parallel_group` function (cited as `:3519-3641` by the analysis; current line numbers may differ)
+
+### Cause
+
+The parallel executor dispatches all agents through the LLM executor path without checking `agent.type`. Scripts go through unchanged.
+
+### Fix proposal
+
+Two options, can ship either:
+
+**A. Reject at validation time** (simpler): in `config/validator.py`, walk all parallel groups; if any agent in the group has `type: script`, raise `ValidationError`:
+
+```
+Parallel group 'save_chain' contains script agent 'save_a'.
+Scripts cannot run inside parallel groups in Conductor v0.1.x.
+Move script steps to a sequential chain before or after the parallel group.
+```
+
+**B. Support scripts in parallel** (proper fix): in `_execute_parallel_group`, dispatch on `agent.type`:
+
+```python
+if agent.type == "script":
+    executor = ScriptExecutor()
+else:
+    executor = await self._get_executor_for_agent(agent)
+```
+
+Then execute concurrently. Requires careful error handling (`continue_on_error` semantics must apply to script failures too).
+
+**Recommendation:** ship A first (1-day fix, no behavior change for valid workflows), then B as a follow-up if there's demand.
+
+### Blast radius
+
+- Workflows that put scripts in parallel groups (currently silently broken)
+- Other workflows unaffected
+
+### Validation approach
+
+- `tests/test_config/test_validator.py`: parallel group with script agent → raises ValidationError
+- If B is shipped: integration test with 3 script agents in a parallel group
+
+---
+
+## Issue 8 — `--web-bg` + `human_gate` crashes with EOFError
+
+### Symptom
+
+Running `conductor run --web-bg` with a workflow that includes a `human_gate` crashes the detached background process with an `EOFError` when the gate prompt tries to read stdin (which is redirected to /dev/null in the detached child).
+
+### Location
+
+- `src/conductor/gates/human.py` — `Prompt.ask()` call
+- `src/conductor/cli/bg_runner.py` — background process forking
+- `src/conductor/interrupt/listener.py:194-224` — separate stdin reader for interrupt handling
+
+### Cause
+
+`Prompt.ask()` (Rich) reads from `sys.stdin`. In `--web-bg`, stdin is detached. EOFError propagates, crashing the process.
+
+### Fix proposal
+
+Detect non-interactive stdin at workflow startup:
+
+```python
+import sys
+is_interactive = sys.stdin.isatty()
+```
+
+If `not is_interactive` and the workflow contains gates without `--skip-gates`:
+
+1. **Validate-time error** (clearest): refuse to start, with:
+   ```
+   --web-bg detected with workflow containing human_gate steps.
+   Detached terminals cannot prompt for input.
+   Options:
+     1. Use --web (foreground) instead of --web-bg
+     2. Add --skip-gates to auto-accept the first option
+     3. Remove human_gate steps from the workflow
+     4. Wait for CLI gate-resolution support (Issue #5 follow-up)
+   ```
+2. **Runtime fallback** (more complex): when a gate fires in detached mode, route it to the dashboard's `/api/gate-response` endpoint (see Issue #5 fix #2) and poll for the response. Requires the gate-respond endpoint to exist.
+
+### Blast radius
+
+- `--web-bg` + gate workflows (currently crash)
+- Other workflows unaffected
+
+### Validation approach
+
+- Integration test: workflow with gate, `--web-bg`, no `--skip-gates` → ValidationError with the message above
+
+---
+
+## Issue 9 — Possible expansion-path divergence between `command:` and `args:`
+
+### Symptom
+
+Anecdotal: `${VAR:-default}` expansion appears to behave differently in `command:` vs. `args:` fields of a script step. The user's debugging notes for Issue #4 mention this is what led to the colon-in-default workaround being needed for `command:` but not `args:`. Hasn't been root-caused; may be related to Issue #4 or may be a separate code path.
+
+### Location
+
+- `src/conductor/executor/script.py:86-87` — template rendering for both fields
+
+### Cause
+
+Unknown without deeper investigation. Possible candidates:
+1. Different render order (env var resolution at YAML load time vs. Jinja2 template render time)
+2. One field passes through a parser that the other doesn't
+3. The observation was incorrect and both behave identically once Issue #4 is fixed
+
+### Fix proposal
+
+Audit `script.py` to confirm both `command:` and `args:` use the same render path. Add unit tests that verify equivalence:
+
+```python
+def test_command_and_args_env_var_parity():
+    """Same ${VAR:-default} resolves identically in command: and args: fields."""
+    # ... test that command="${X:-foo}" and args=["${X:-foo}"] both produce "foo"
+```
+
+If a divergence exists, unify the paths.
+
+### Blast radius
+
+- Probably small — would have surfaced more widely if significant
+- Test coverage improvement is valuable regardless
+
+### Validation approach
+
+- New test in `tests/test_executor/test_script.py`
+
+---
+
+## Fragile patterns flagged (not yet hit in production)
+
+These are things the analysis surfaced as "this will bite someone eventually" but that didn't directly affect the workiq-coach session. Listed for awareness, not for immediate fix.
+
+### Unbounded event-history growth
+
+- **Location:** `src/conductor/web/server.py` — `_event_history` list
+- **Risk:** Multi-day workflows or high event rates exhaust memory
+- **Fix:** ring buffer with configurable size (default ~10k events)
+
+### Parallel context isolation race
+
+- **Location:** `src/conductor/engine/workflow.py` — deep-copy snapshot at parallel-group entry
+- **Risk:** Deep copy is safe at copy time, but if an agent mutates context via a tool during execution, isolation breaks
+- **Fix:** wrap parallel-group context in a read-only proxy, or use immutable types
+
+### Parse-recovery prompt is identical across retries
+
+- **Location:** `src/conductor/providers/copilot.py:~714` — `_build_parse_recovery_prompt`
+- **Risk:** Same prompt to same model produces correlated errors; retries don't learn from validator feedback
+- **Fix:** include the *specific* validation error in the recovery prompt so the model knows what to change
+
+### No timeout on dashboard startup
+
+- **Location:** `src/conductor/web/server.py` — `WebDashboard.start()`
+- **Risk:** uvicorn port binding can hang on Windows; engine waits indefinitely
+- **Fix:** wrap startup in `asyncio.wait_for()` with a reasonable timeout (e.g. 30s); raise clearly if it fails
+
+---
+
+## Implementation plan — three PR clusters
+
+### Cluster A: "Better validation + error messages" (highest value-to-effort)
+
+**Goal:** turn silent and confusing failures into clear errors at validate time or at the failure site.
+
+**Includes:**
+- Issue #4: `${VAR:-DEFAULT}` parser fix
+- Issue #7: reject `type: script` in `parallel:` at validate
+- Issue #8: detect non-interactive stdin + workflow gates at startup
+- Issue #3: normalize Windows path separators + improve subprocess error message
+
+**Estimated size:** ~60 LOC across `config/loader.py`, `config/validator.py`, `executor/script.py`, `gates/human.py`. Plus tests.
+
+**Risk:** very low. All changes are either pure parser fixes or earlier-validation. No behavioral change for valid workflows.
+
+**Why ship first:** every one of these is an instance of "user hits a confusing failure, takes 30+ minutes to diagnose, fix is 2 lines of code." Each PR independently improves the new-user experience.
+
+### Cluster B: "Output mode: raw vs envelope" (architectural)
+
+**Goal:** make raw-response the explicit, documented, recommended pattern for agents producing prose or large JSON.
+
+**Includes:**
+- Issue #1: greedy fence regex (quick fix) + optional brace-balanced extractor (proper fix)
+- Issue #2: add `output_mode: raw | envelope` to AgentDef; warn at validate when `output:` is declared on prose-likely agents; documentation updates
+
+**Estimated size:** ~100 LOC across `executor/output.py`, `providers/copilot.py`, `providers/claude.py` (parity), `config/schema.py`, `config/validator.py`. Plus docs updates and tests. The fence-regex piece is small; the `output_mode` field + validator warning + doc cohesion is most of the work.
+
+**Risk:** medium. Affects the hot path of every workflow with `output:`. Needs careful provider-parity work. Worth a design discussion in this brainstorm before opening a PR.
+
+**Why ship together:** the regex fix without the documented `output_mode` field still leaves new users tripping into the bad default. The field without the regex fix doesn't help existing workflows with valid `output:` declarations that happen to contain backticks.
+
+### Cluster C: "Runtime hardening"
+
+**Goal:** improve operational reliability of long-running workflows and dashboard interactions.
+
+**Includes:**
+- Issue #5: dashboard WebSocket keepalive + CLI gate-resolution command
+- Issue #6: configurable `max_parse_recovery_attempts`
+- Issue #9: unified expansion path + parity test
+- Bonus: event-history ring buffer, dashboard-startup timeout
+
+**Estimated size:** ~200 LOC, primarily in `web/server.py`, `cli/`, `providers/`. Plus the new `conductor gate-accept` CLI command.
+
+**Risk:** medium-low. The keepalive and ring buffer are additive. The CLI gate-resolution is a net-new feature.
+
+**Why ship last:** these are quality-of-life improvements rather than fixes for immediately-broken behavior. Maintainers may want to defer until A + B prove the brainstorm's value.
+
+---
+
+## Open questions for maintainers
+
+1. **Output mode default.** Cluster B proposes `output_mode` as an additive field with the existing default preserved. Would maintainers consider flipping the default to `raw` in a future v0.2.x, given that the current default produces parse recovery loops on real-world workflows? (Backward-compat strategy: behave as today when `output_mode` is unspecified AND `output:` is specified; warn loudly via deprecation when this combination appears in `conductor validate`.)
+2. **Provider parity for retry budget.** Issue #6 proposes per-agent `retry.max_parse_recovery_attempts`. The current Copilot default is 5; Claude is 2. Should the proposed field be a single value that both providers respect, or should the default per-provider be preserved (5 for Copilot, 2 for Claude) with the per-agent override applying uniformly?
+3. **Gate resolution endpoint security.** Adding `POST /api/gate-response` to the dashboard server creates a new attack surface. Should it require a per-run token (passed via env var or CLI flag) to authorize gate responses? The dashboard is bound to localhost by default, but `--web-bg` users running on shared infrastructure might want explicit token-based auth.
+4. **Issue #8 fix shape.** Validate-time error vs. runtime dashboard fallback for `--web-bg + human_gate`. The dashboard fallback is the better UX but depends on the gate-response endpoint from Issue #5 existing. Order the work?
+
+---
+
+## Validation approach (cross-cutting)
+
+For each cluster:
+
+1. **Unit tests** in the relevant `tests/` subdirectory mirroring source layout (per AGENTS.md).
+2. **Integration tests** in `tests/test_integration/` that reproduce the actual failure mode from this session, then verify the fix.
+3. **Provider parity check** — any change to `providers/copilot.py` mirrored in `providers/claude.py` per [Provider Parity](../../AGENTS.md#provider-parity).
+4. **Documentation updates** — `docs/workflow-syntax.md` for Issue #2; `docs/configuration.md` for Issues #4, #6; `CHANGELOG.md` for all clusters.
+5. **A real-world smoke test**: re-run the workiq-coach Phase A workflow (with the original `output:` schema on the synthesizer) and verify it now completes. This is the canonical "did we fix the actual problem" test.
+
+---
+
+## References
+
+- Conductor source: `Q:/src/conductor` (this repo, v0.1.16)
+- `AGENTS.md` — architecture overview and contribution guide
+- `docs/projects/usability-features/` — existing brainstorm/plan documents in this convention
+- workiq-coach source: `Q:/src/workiq-coach`
+  - `skills/executive-coach-assessor/workflows/phase-a.yaml` — the workflow that surfaced most issues
+  - `skills/executive-coach-assessor/workflows/README.md` — contains the early diagnostic comment about output.py:120 fence-extraction bug
+- Conversation context: the analysis was produced collaboratively over a multi-hour debugging session in May 2026. The diagnostic narrative under "Source of evidence" is condensed from that session.
+
+---
+
+## What would make this brainstorm into a `.plan.md`
+
+- Maintainer agreement that Cluster A is welcome → opens the door to a PR cluster
+- Open question #1 (output mode default) decided → enables a coherent Cluster B
+- Anyone disagrees with any of the nine issues → discussion happens here before any code
+
+If maintainers want any subset of these implemented, the external contributor (Lucio) is happy to open issues + PRs for them.

--- a/docs/projects/usability-features/external-workflow-friction.plan.md
+++ b/docs/projects/usability-features/external-workflow-friction.plan.md
@@ -1,0 +1,218 @@
+# Solution Design: External Workflow Friction — Minimal Fixes
+
+**Status:** PROPOSED
+**Source brainstorm:** [external-workflow-friction.brainstorm.md](external-workflow-friction.brainstorm.md)
+**Author:** Lucio Tinoco (external contributor) + Copilot review
+**Scope decision:** This plan implements an evidence-anchored subset of the brainstorm. The brainstorm proposed nine fixes across three clusters; this plan covers four. See §6 for what is explicitly deferred and why.
+
+---
+
+## 1. Problem Statement
+
+A single external user attempting to run two real-world workflows against Conductor v0.1.16 hit seven failed runs before reaching a successful end-to-end execution. Post-mortem in the [companion brainstorm](external-workflow-friction.brainstorm.md) identified nine candidate issues. Pre-design code review confirmed that four of those issues are real, root-caused, and have a clear minimal fix; the remaining five either could not be reproduced from the cited evidence, propose speculative configurability, or address unobserved failure modes.
+
+This plan ships only the confirmed four. Each fix is justified by a concrete failure mode from the brainstorm's timeline and is gated on a reproducing test that fails on `main` before the fix lands.
+
+---
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- **G1:** Agents emitting large JSON whose string fields contain triple-backticks no longer fall into parse-recovery loops (brainstorm Issue #1).
+- **G2:** Workflows that place `type: script` steps inside a `parallel:` group fail at validate time with a clear message, rather than silently burning tokens (brainstorm Issue #7).
+- **G3:** Users discover the "omit `output:` for prose/large JSON" pattern from documentation in the same place they learn about `output:` itself (brainstorm Issue #2, documentation-only slice).
+- **G4:** Running `conductor run --web-bg` against a workflow that contains a `human_gate` (without `--skip-gates`) fails at validate time with a clear message, rather than crashing the detached child with `EOFError` (brainstorm Issue #8).
+
+### Non-Goals
+
+- **NG1:** No new `output_mode` field on `AgentDef`. The "raw" behavior already exists as "omit `output:`"; adding a synonym for absence is API bloat (Karpathy #2). Revisit only if the docs-only fix in G3 proves insufficient.
+- **NG2:** No env-var resolver rewrite for `${VAR:-default}` with colons (brainstorm Issue #4). Pre-design inspection of [`config/loader.py` line 23](../../../src/conductor/config/loader.py#L23) shows the current regex's default group is `[^}]*`, which already accepts colons. The reported failure is more likely YAML quoting or PowerShell expansion. Pending a Python-only reproduction, no fix.
+- **NG3:** No Windows path normalization in the script executor (Issue #3). Pending a deterministic reproduction independent of shell environment.
+- **NG4:** No configurable parse-recovery retry budget (Issue #6). No observed user demand.
+- **NG5:** No dashboard WebSocket keepalive, CLI gate-resolution command, dashboard auth, or webhooks (Issue #5). Out of scope by user decision; revisit in a follow-up plan.
+- **NG6:** No `command:` vs `args:` expansion parity audit (Issue #9). Author labeled it anecdotal; convert to a one-line investigation task, not a planned fix.
+- **NG7:** No work on the four "fragile patterns flagged" in the brainstorm. By the author's own statement, not observed in production.
+
+---
+
+## 3. Requirements
+
+### Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| FR-1 | `parse_json_output` in [`executor/output.py`](../../../src/conductor/executor/output.py) successfully extracts JSON from a fence-wrapped response whose string fields contain triple-backtick substrings. |
+| FR-2 | `_extract_json` in [`providers/copilot.py`](../../../src/conductor/providers/copilot.py) behaves identically to FR-1. |
+| FR-3 | `parse_json_output` continues to raise `ValidationError` for genuinely malformed JSON (no regression). |
+| FR-4 | `config/validator.py` rejects workflows that reference a `type: script` agent from a `parallel:` group's `agents:` list. Error names both the parallel group and the offending agent. |
+| FR-5 | `docs/workflow-syntax.md` contains a section titled "Choosing whether to declare `output:`" that describes the read-`<agent>.output.result` pattern for prose/large-JSON agents, with a cross-link from the `output:` reference. |
+| FR-6 | `conductor run --web-bg <yaml>` exits non-zero, before forking the child, when the workflow contains any `type: human_gate` agent and `--skip-gates` is not set. Error lists the four documented options (use `--web`, add `--skip-gates`, remove gate, wait for follow-up CLI work). |
+
+### Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| NFR-1 | Every functional requirement is covered by at least one unit/integration test that fails on `main` before the fix lands and passes after. |
+| NFR-2 | No test introduced by this plan depends on wall-clock timing, network access, subprocess output races, or live LLM calls. |
+| NFR-3 | `make check` (lint + typecheck) and `uv run pytest` (full suite) both pass after each item lands. |
+| NFR-4 | No file is modified outside the declared scope of its item (Karpathy #3). |
+
+---
+
+## 4. Solution Architecture
+
+This plan introduces no new abstractions. Each item is a localized change inside an existing module.
+
+### 4.1 Item 1 — Fence-extraction robustness
+
+**Files touched:** [`src/conductor/executor/output.py`](../../../src/conductor/executor/output.py), [`src/conductor/providers/copilot.py`](../../../src/conductor/providers/copilot.py).
+
+**Current behavior:** Both call sites use `r"```(?:json)?\s*\n?(.*?)\n?```"` (non-greedy). The first inner triple-backtick — common in JSON whose string values quote Markdown or shell snippets — closes the match prematurely. The extracted substring is invalid JSON, triggering parse recovery.
+
+**Change:**
+
+1. In `parse_json_output` (output.py): try `json.loads` directly first; if it fails, search for a fenced block with a **greedy** capture (`r"```(?:json)?\s*\n(.*)\n```"`). With `re.DOTALL` this greedy `.*` terminates at the last `` ``` `` in the string, which is the correction we want. If parse still fails, fall back to the existing first-`{`/`[` heuristic. The existing `json.loads` at the end is the canonical failure point — its error message is unchanged.
+2. In `_extract_json` (copilot.py:1100–1118): mirror the same regex change. The existing brace-match fallback already in this method stays as the final attempt. The mirror is verified by visual diff against output.py and by the executor tests in §5 (both providers route their fallback path through `parse_json_output`).
+
+**Why this shape:** the doc proposed a brace-balanced walker. That's ~30 LOC of stateful parsing for failures no one has hit yet. Greedy regex + the existing brace fallback handles every case in the brainstorm timeline (Karpathy #2).
+
+### 4.2 Item 2 — Validator rejects scripts inside parallel groups
+
+**Files touched:** [`src/conductor/config/validator.py`](../../../src/conductor/config/validator.py).
+
+**Current behavior:** `_execute_parallel_group` ([workflow.py:3520](../../../src/conductor/engine/workflow.py#L3520)) calls `_get_executor_for_agent` for every member, which returns the LLM executor regardless of `agent.type`. Script agents inside parallel groups are dispatched to the LLM provider with no prompt, burning tokens on nothing.
+
+**Change:** in the existing validator pass, iterate parallel groups; for each agent name in `group.agents`, resolve the `AgentDef`; if `agent.type == "script"`, raise `ValidationError` with the suggestion to move the step to a sequential chain. ~15 LOC.
+
+**Why validator and not engine:** failing fast at load is cheaper and clearer than handling the case at dispatch. The brainstorm proposed both options A (validator) and B (full support); A is the minimal fix for the observed failure (Karpathy #2). B can come later if real users ask.
+
+### 4.3 Item 3 — Documentation for the omit-`output:` pattern
+
+**Files touched:** [`docs/workflow-syntax.md`](../../../docs/workflow-syntax.md) and a cross-link from [`docs/configuration.md`](../../../docs/configuration.md) if `output:` is referenced there.
+
+**Change:** add a section "Choosing whether to declare `output:`" that:
+
+- States the trade-off in one sentence: declaring `output:` injects a schema instruction to the model AND parses the response as structured JSON.
+- Lists the two clear cases:
+  - **Declare `output:`** when the agent emits small, strictly-structured JSON whose individual fields will be referenced downstream.
+  - **Omit `output:`** when the agent emits prose, Markdown, or large/nested JSON. Downstream agents read `<agent>.output.result`.
+- Shows the exact YAML for both side by side.
+- Cross-links from the `output:` reference subsection.
+
+**No code change.** Verification is by review of the diff.
+
+### 4.4 Item 4 — Validate `--web-bg` against `human_gate` workflows
+
+**Files touched:** [`src/conductor/cli/run.py`](../../../src/conductor/cli/run.py) (the `run` command entry point that branches into `bg_runner.launch_background`).
+
+**Current behavior:** `--web-bg` forks the child via `bg_runner.launch_background`. The child detaches stdin. When the workflow reaches a `human_gate`, `Prompt.ask()` reads `sys.stdin` and raises `EOFError`, crashing the detached process.
+
+**Change:** before calling `launch_background`, inspect the loaded `WorkflowConfig`. If `skip_gates` is false AND any agent in `config.agents` has `type == "human_gate"`, abort with `typer.BadParameter` (or equivalent) and print the four-option message from the brainstorm:
+
+```
+--web-bg is incompatible with workflows that contain human_gate steps
+because the detached process has no stdin to prompt on.
+
+Options:
+  1. Use --web (foreground) instead of --web-bg
+  2. Add --skip-gates to auto-accept the first option
+  3. Remove human_gate steps from the workflow
+  4. Wait for CLI gate-resolution support (planned follow-up)
+```
+
+The same check applies to `resume --web-bg` for symmetry with the run/resume parity rule documented in `AGENTS.md`. ~20 LOC including the parity wiring on `resume`.
+
+**Why pre-fork:** crashing the child after fork loses observability; pre-fork validation produces a single clear error visible on the user's terminal.
+
+---
+
+## 5. Test Strategy
+
+All tests use existing fixtures and helpers (`tests/conftest.py`, `tests/test_cli/` Typer `CliRunner` pattern, `tests/test_executor/test_output.py` style). No new test infrastructure.
+
+### 5.1 Item 1 tests — `tests/test_executor/test_output.py`
+
+| Test | Pre-fix expected | Post-fix expected |
+|---|---|---|
+| `test_parse_json_with_triple_backticks_inside_string` — input: ` ```json\n{"code": "use ```fenced``` blocks", "n": 1}\n``` ` | Raises `ValidationError` | Returns `{"code": "use ```fenced``` blocks", "n": 1}` |
+| `test_parse_json_fence_with_prose_around_it` — `"Here is the result:\n\`\`\`json\n{...}\n\`\`\`\nDone."` | Passes today | Passes (regression guard for the greedy-match change) |
+| `test_parse_json_malformed_raises` — `"{not valid"` | Raises | Raises (unchanged message) |
+
+The 80 KB-payload-without-backticks test from an earlier draft was dropped: size alone never reproduced a failure in the brainstorm timeline, and the triple-backtick test already exercises the fix. The raw-no-fence and malformed cases are kept because they cover branches the greedy change touches.
+
+The copilot.py mirror in `_extract_json` is verified by visual diff against output.py (same regex change in the same fallback position) plus the executor tests above, which exercise the shared `parse_json_output` code path both providers fall through to. No separate provider-specific test file is introduced (Karpathy #2: no abstractions or files for single-use code).
+
+### 5.3 Item 2 tests — `tests/test_config/test_validator.py`
+
+| Test | Pre-fix expected | Post-fix expected |
+|---|---|---|
+| `test_parallel_group_rejects_script_agents` — workflow with a `parallel:` group whose `agents:` contains a script-type agent | Loads silently | Raises `ValidationError` naming both the group and the script agent |
+| `test_parallel_group_accepts_agent_type_agents` — workflow with normal parallel agents | Passes today | Passes |
+
+### 5.4 Item 3 verification
+
+No automated test. Acceptance criterion: a reviewer can answer "should I declare `output:` for an agent producing 80 KB JSON?" by reading one section of `workflow-syntax.md`. Verified during PR review.
+
+### 5.5 Item 4 tests — `tests/test_cli/test_bg_runner.py`
+
+**Pre-fix behavior observed on 2026-05-26 against current `main`:** running `conductor run --web-bg <gate-yaml>` produces exit code 1 with the parent CLI message `"Background process exited immediately with code 1. Check logs or run without --web-bg for details."` The child has already forked and crashed (presumably on `EOFError` from `Prompt.ask`) before the parent emits this message. The error never mentions `human_gate`, `--web-bg` incompatibility, or `--skip-gates`.
+
+| Test | Pre-fix expected (observed) | Post-fix expected |
+|---|---|---|
+| `test_web_bg_with_human_gate_aborts_before_fork` — `CliRunner` invokes `conductor run --web-bg <gate-yaml>` (no `--skip-gates`) | Exit code 1; stderr contains `"Background process exited immediately"`; child has already forked (PID file may briefly exist) | Exit code != 0; stderr contains the four-option message naming `human_gate`; no fork attempted (no PID file ever created) |
+| `test_web_bg_with_human_gate_and_skip_gates_proceeds` — same workflow with `--skip-gates` | N/A — proves we don't over-block | Reaches the launch path (verified by mocking `launch_background` and asserting it was called) |
+| `test_resume_web_bg_with_human_gate_aborts_before_fork` — parity check for `resume` | Same EOFError-after-fork story | Same shape as the run-side test |
+
+**Non-flakiness:** all CLI tests run via `CliRunner` in-process with `launch_background` mocked. No subprocess, no sockets, no timing. The PID-file check is filesystem-only and deterministic in the test's `tmp_path`.
+
+### 5.6 Cross-cutting verification
+
+After each item:
+
+1. `make check` — lint + typecheck.
+2. `uv run pytest -m "not performance"` — full suite minus perf tests.
+
+The canonical "did we actually fix the lived problem" check (re-running the brainstorm's Phase A workflow with a fence-wrapped, backtick-containing payload) is an author acceptance step in §7, not a CI test, because it requires live LLM calls and would violate NFR-2.
+
+---
+
+## 6. Explicitly Deferred (with reason)
+
+This section is the asymmetric mirror of §2's Non-Goals — it names the brainstorm items NOT in this plan and the evidence threshold that would justify reopening them.
+
+| Brainstorm item | Reason for deferral | Threshold to reopen |
+|---|---|---|
+| Issue #2 `output_mode` field | Docs-only fix (Item 3 here) likely sufficient; field is a synonym for "absence of `output:`" | New user trips the same pattern after Item 3 ships |
+| Issue #3 Windows path separator | No Python-only reproduction; likely shell/YAML environmental | Deterministic repro that doesn't depend on PowerShell or YAML quoting |
+| Issue #4 env-var regex rewrite | Inspection shows current regex already handles colons in defaults (the default group is `[^}]*`); the reported failure is more likely YAML quoting or PowerShell variable expansion, not the resolver | Failing pytest case calling `resolve_env_vars` directly with the reported input |
+| Issue #5 dashboard keepalive + CLI gate cmd + webhooks + auth | Out of scope per user decision on 2026-05-26 | Separate follow-up plan |
+| Issue #6 configurable retry budget | No observed demand | Real user request with use case |
+| Issue #9 `command:` vs `args:` parity | Author labels anecdotal/unconfirmed | Failing parity test demonstrating divergence |
+| Fragile patterns (unbounded events, parallel race, identical recovery prompt, dashboard startup timeout) | Author says "not yet hit in production" | An actual production incident |
+
+---
+
+## 7. Execution Sequence
+
+```
+Phase 1 (independent, parallelizable as separate PRs):
+  Item 1 → write repro test (must fail on main) → fix → tests pass → make check
+  Item 2 → write repro test (must fail on main) → fix → tests pass → make check
+  Item 3 → docs PR, code review only
+
+Phase 2 (depends on stable main from Phase 1):
+  Item 4 → write repro test (must fail on main) → fix → tests pass → make check
+```
+
+Order is partial — Items 1, 2, 3 are independent. Item 4 follows for review-cluster cohesion, not technical dependency.
+
+**Author acceptance step** (once, before opening the PR cluster, not part of CI): re-run the brainstorm's Phase A workflow with the original `output:`-on-synthesizer setup against a real Copilot session. Pre-Items: trips parse recovery loop. Post-Items: succeeds in one shot. This is gut-check validation, not a gate.
+
+---
+
+## 8. Open Questions
+
+1. **`typer.BadParameter` vs custom `ConfigurationError` for Item 4?** Need to read existing CLI error patterns before deciding. Resolve during implementation; not blocking.
+
+Item 4 changes both `run` and `resume` per the run/resume parity rule in `AGENTS.md`; both get tests by necessity, not as an open question.

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -109,6 +109,45 @@ agents:
         when: "{{ condition }}"     # Optional: Route condition
 ```
 
+### Choosing whether to declare `output:`
+
+Declaring `output:` does two things at once: it asks the model to return JSON matching the schema, and it parses the response as structured JSON. For some agents that's what you want. For others it produces parse-recovery loops and burns tokens.
+
+**Declare `output:`** when the agent emits small, strictly-structured JSON whose individual fields will be referenced downstream:
+
+```yaml
+agents:
+  - name: classifier
+    prompt: "Classify the input. Return {category, confidence}."
+    output:
+      category:
+        type: string
+      confidence:
+        type: number
+  - name: router
+    prompt: |
+      Category was {{ classifier.output.category }}.
+      Confidence was {{ classifier.output.confidence }}.
+```
+
+**Omit `output:`** when the agent emits prose, Markdown, or large/nested JSON. Without a schema, conductor stores the full raw response as a single string under `.output.result`, and downstream agents read it directly:
+
+```yaml
+agents:
+  - name: synthesizer
+    prompt: |
+      Produce a comprehensive Markdown report of the findings.
+      The report may contain code blocks, tables, and quoted examples.
+    # No output: declared — response is captured verbatim.
+  - name: reviewer
+    prompt: |
+      Review the following report:
+
+      {{ synthesizer.output.result }}
+```
+
+Why this matters: when an `output:` schema is declared, the model is asked to wrap its response in JSON. Large or prose-heavy responses tend to come back inside Markdown code fences, and any triple-backticks in the content can confuse the JSON-extraction step. Omitting `output:` for these agents avoids that whole class of failure and lets the model write naturally.
+
 ### Human Gates
 
 Human gates pause workflow execution for user input:

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -156,6 +156,39 @@ def print_error(error: Exception) -> None:
         console.print(panel)
 
 
+def _abort_web_bg_if_human_gate(workflow_path: Path, *, skip_gates: bool) -> None:
+    """Reject ``--web-bg`` when the workflow has a ``human_gate`` agent.
+
+    Without this check, ``--web-bg`` forks a detached child whose stdin is
+    redirected to ``DEVNULL``; ``Prompt.ask`` then raises ``EOFError`` and
+    the parent only reports ``"Background process exited immediately"``,
+    which never mentions ``human_gate`` or ``--skip-gates``. Failing fast
+    in the parent process produces a single visible error on the user's
+    terminal. ``--skip-gates`` is a documented escape hatch and is honored.
+    """
+    if skip_gates:
+        return
+    try:
+        from conductor.config.loader import load_config
+
+        config = load_config(workflow_path)
+    except Exception:  # noqa: BLE001 — defer real validation to the loader path
+        # If config fails to load, let the normal run path surface the error.
+        return
+    if not any(getattr(a, "type", None) == "human_gate" for a in config.agents):
+        return
+    raise typer.BadParameter(
+        "--web-bg is incompatible with workflows that contain human_gate steps "
+        "because the detached process has no stdin to prompt on.\n"
+        "\n"
+        "Options:\n"
+        "  1. Use --web (foreground) instead of --web-bg\n"
+        "  2. Add --skip-gates to auto-accept the first option\n"
+        "  3. Remove human_gate steps from the workflow\n"
+        "  4. Wait for CLI gate-resolution support (planned follow-up)"
+    )
+
+
 def version_callback(value: bool) -> None:
     """Display version information and exit."""
     if value:
@@ -420,6 +453,7 @@ def run(
 
     # Handle --web-bg: fork a background process and exit immediately
     if web_bg:
+        _abort_web_bg_if_human_gate(workflow_path, skip_gates=skip_gates)
         from conductor.cli.bg_runner import launch_background
 
         try:
@@ -855,6 +889,8 @@ def resume(
 
     # Handle --web-bg: fork a background process and exit immediately
     if web_bg:
+        if resolved_workflow is not None:
+            _abort_web_bg_if_human_gate(resolved_workflow, skip_gates=skip_gates)
         from conductor.cli.bg_runner import launch_background_resume
 
         try:

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -177,9 +177,13 @@ def _abort_web_bg_if_human_gate(workflow_path: Path, *, skip_gates: bool) -> Non
         return
     if not any(getattr(a, "type", None) == "human_gate" for a in config.agents):
         return
-    raise typer.BadParameter(
-        "--web-bg is incompatible with workflows that contain human_gate steps "
-        "because the detached process has no stdin to prompt on.\n"
+    # Emit via plain typer.echo (not typer.BadParameter) so the message renders
+    # verbatim — BadParameter is rendered as a Rich panel whose text wrapping
+    # can split long flag names like ``--skip-gates`` across border lines in
+    # narrow terminals (e.g. CI runners), hiding the remediation hint.
+    message = (
+        "Error: --web-bg is incompatible with workflows that contain human_gate "
+        "steps because the detached process has no stdin to prompt on.\n"
         "\n"
         "Options:\n"
         "  1. Use --web (foreground) instead of --web-bg\n"
@@ -187,6 +191,8 @@ def _abort_web_bg_if_human_gate(workflow_path: Path, *, skip_gates: bool) -> Non
         "  3. Remove human_gate steps from the workflow\n"
         "  4. Wait for CLI gate-resolution support (planned follow-up)"
     )
+    typer.echo(message, err=True)
+    raise typer.Exit(code=2)
 
 
 def version_callback(value: bool) -> None:

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -175,7 +175,10 @@ def _abort_web_bg_if_human_gate(workflow_path: Path, *, skip_gates: bool) -> Non
     except Exception:  # noqa: BLE001 — defer real validation to the loader path
         # If config fails to load, let the normal run path surface the error.
         return
-    if not any(getattr(a, "type", None) == "human_gate" for a in config.agents):
+    has_gate = any(getattr(a, "type", None) == "human_gate" for a in config.agents) or any(
+        getattr(getattr(fe, "agent", None), "type", None) == "human_gate" for fe in config.for_each
+    )
+    if not has_gate:
         return
     # Emit via plain typer.echo (not typer.BadParameter) so the message renders
     # verbatim — BadParameter is rendered as a Rich panel whose text wrapping
@@ -895,8 +898,25 @@ def resume(
 
     # Handle --web-bg: fork a background process and exit immediately
     if web_bg:
-        if resolved_workflow is not None:
-            _abort_web_bg_if_human_gate(resolved_workflow, skip_gates=skip_gates)
+        # When the user resumes via --from <checkpoint> alone (no workflow
+        # argument), resolved_workflow is None but the checkpoint records the
+        # original workflow path. Read it so the human_gate guard still fires
+        # and the user gets a single visible error instead of a silent crash
+        # in the detached child.
+        gate_check_workflow: Path | None = resolved_workflow
+        if gate_check_workflow is None and resolved_checkpoint is not None:
+            try:
+                ckpt_data = json.loads(resolved_checkpoint.read_text(encoding="utf-8"))
+                ckpt_workflow = ckpt_data.get("workflow_path")
+                if isinstance(ckpt_workflow, str):
+                    candidate = Path(ckpt_workflow)
+                    if candidate.exists():
+                        gate_check_workflow = candidate
+            except (OSError, json.JSONDecodeError):
+                # Checkpoint unreadable — let the normal resume path surface it.
+                pass
+        if gate_check_workflow is not None:
+            _abort_web_bg_if_human_gate(gate_check_workflow, skip_gates=skip_gates)
         from conductor.cli.bg_runner import launch_background_resume
 
         try:

--- a/src/conductor/executor/output.py
+++ b/src/conductor/executor/output.py
@@ -116,12 +116,28 @@ def parse_json_output(raw_response: str) -> dict[str, Any]:
 
     text = raw_response.strip()
 
-    # Try to extract JSON from markdown code blocks.
-    # Greedy capture so the regex closes at the LAST ``` in the response,
-    # not the first inner ``` (which may appear inside a JSON string field).
-    json_block_match = re.search(r"```(?:json)?\s*\n?(.*)\n?```", text, re.DOTALL)
-    if json_block_match:
-        text = json_block_match.group(1).strip()
+    # Try to extract JSON from markdown code blocks. Two-stage strategy:
+    # 1. Non-greedy findall + try-parse each candidate (first valid wins).
+    #    Handles the common case of multiple fenced blocks in one response
+    #    (e.g. "initial answer ... revised answer") where the first complete
+    #    JSON block is the authoritative one.
+    # 2. Greedy single capture as fallback. Handles the case where the JSON
+    #    contains literal ``` inside a string field, which breaks non-greedy
+    #    matching at the inner fence but is recovered by closing at the LAST
+    #    fence in the response.
+    candidates = re.findall(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+    for candidate in candidates:
+        stripped = candidate.strip()
+        try:
+            result = json.loads(stripped)
+            if isinstance(result, dict):
+                return result
+            return {"result": result}
+        except json.JSONDecodeError:
+            continue
+    greedy = re.search(r"```(?:json)?\s*\n?(.*)\n?```", text, re.DOTALL)
+    if greedy:
+        text = greedy.group(1).strip()
 
     # Try to find JSON object or array
     if not text.startswith(("{", "[")):

--- a/src/conductor/executor/output.py
+++ b/src/conductor/executor/output.py
@@ -116,8 +116,10 @@ def parse_json_output(raw_response: str) -> dict[str, Any]:
 
     text = raw_response.strip()
 
-    # Try to extract JSON from markdown code blocks
-    json_block_match = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+    # Try to extract JSON from markdown code blocks.
+    # Greedy capture so the regex closes at the LAST ``` in the response,
+    # not the first inner ``` (which may appear inside a JSON string field).
+    json_block_match = re.search(r"```(?:json)?\s*\n?(.*)\n?```", text, re.DOTALL)
     if json_block_match:
         text = json_block_match.group(1).strip()
 

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -1259,9 +1259,19 @@ class CopilotProvider(AgentProvider):
         # Try to find JSON in code blocks
         import re
 
-        # Look for ```json ... ``` blocks (greedy so the regex closes at the
-        # LAST ``` in the content, not the first inner ``` which may appear
-        # inside a JSON string field).
+        # Two-stage strategy (kept in parity with executor.output.parse_json_output):
+        # 1. Non-greedy findall + try-parse each candidate. First valid JSON
+        #    wins. Handles multiple fenced blocks in one response (e.g. an
+        #    initial answer followed by a revised answer).
+        # 2. Greedy single capture as fallback. Handles literal ``` inside a
+        #    JSON string field, which breaks non-greedy matching at the inner
+        #    fence but is recovered by closing at the LAST fence.
+        candidates = re.findall(r"```(?:json)?\s*\n?(.*?)\n?```", content, re.DOTALL)
+        for candidate in candidates:
+            try:
+                return json.loads(candidate.strip())
+            except json.JSONDecodeError:
+                continue
         json_match = re.search(r"```(?:json)?\s*\n?(.*)\n?```", content, re.DOTALL)
         if json_match:
             try:

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -1259,8 +1259,10 @@ class CopilotProvider(AgentProvider):
         # Try to find JSON in code blocks
         import re
 
-        # Look for ```json ... ``` blocks
-        json_match = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", content, re.DOTALL)
+        # Look for ```json ... ``` blocks (greedy so the regex closes at the
+        # LAST ``` in the content, not the first inner ``` which may appear
+        # inside a JSON string field).
+        json_match = re.search(r"```(?:json)?\s*\n?(.*)\n?```", content, re.DOTALL)
         if json_match:
             try:
                 return json.loads(json_match.group(1).strip())

--- a/tests/test_cli/test_web_flags.py
+++ b/tests/test_cli/test_web_flags.py
@@ -287,3 +287,97 @@ class TestDashboardStartupFailure:
                 web=True,
             )
             assert result == {"result": "done"}
+
+
+# ---------------------------------------------------------------------------
+# --web-bg + human_gate validation (external-workflow-friction Item 4)
+# ---------------------------------------------------------------------------
+
+_GATE_WORKFLOW_YAML = """\
+workflow:
+  name: gate-workflow
+  entry_point: ask
+
+agents:
+  - name: ask
+    type: human_gate
+    prompt: "Continue?"
+    options:
+      - label: "Yes"
+        value: yes
+        route: $end
+      - label: "No"
+        value: no
+        route: $end
+
+output:
+  result: "done"
+"""
+
+
+@pytest.fixture()
+def gate_workflow_file(tmp_path: Path) -> Path:
+    """Workflow containing a ``human_gate`` agent."""
+    f = tmp_path / "gate.yaml"
+    f.write_text(_GATE_WORKFLOW_YAML)
+    return f
+
+
+class TestWebBgHumanGateValidation:
+    """``--web-bg`` must abort pre-fork when the workflow has a ``human_gate``.
+
+    Without this check, ``--web-bg`` forks a detached child whose stdin is
+    redirected to ``DEVNULL``; ``Prompt.ask`` then raises ``EOFError`` and
+    the parent only sees ``"Background process exited immediately"``, with
+    no mention of ``human_gate`` or ``--skip-gates``. See
+    ``docs/projects/usability-features/external-workflow-friction.plan.md``
+    §4.4.
+    """
+
+    def test_run_web_bg_with_human_gate_aborts_before_fork(self, gate_workflow_file: Path) -> None:
+        """``run --web-bg`` + ``human_gate`` (no ``--skip-gates``) → no fork."""
+        with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
+            result = runner.invoke(app, ["run", str(gate_workflow_file), "--web-bg"])
+
+        assert result.exit_code != 0
+        assert not mock_launch.called
+        # The error must name the actual problem and at least one remedy.
+        combined = (result.output or "") + (str(result.exception) if result.exception else "")
+        assert "human_gate" in combined
+        assert "--skip-gates" in combined
+
+    def test_run_web_bg_with_human_gate_and_skip_gates_proceeds(
+        self, gate_workflow_file: Path
+    ) -> None:
+        """``--skip-gates`` removes the incompatibility; fork proceeds."""
+        from pathlib import Path as _Path
+
+        from conductor.cli.bg_runner import BackgroundLaunch
+
+        with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
+            mock_launch.return_value = BackgroundLaunch(
+                url="http://127.0.0.1:9999",
+                stderr_log=_Path("/tmp/conductor-test-deadbeef.bg.stderr.log"),
+                stdout_log=_Path("/tmp/conductor-test-deadbeef.bg.stdout.log"),
+                run_id="deadbeef",
+            )
+
+            result = runner.invoke(
+                app, ["run", str(gate_workflow_file), "--web-bg", "--skip-gates"]
+            )
+
+        assert result.exit_code == 0
+        assert mock_launch.called
+
+    def test_resume_web_bg_with_human_gate_aborts_before_fork(
+        self, gate_workflow_file: Path
+    ) -> None:
+        """Same check applies to ``resume --web-bg`` (run/resume parity)."""
+        with patch("conductor.cli.bg_runner.launch_background_resume") as mock_launch:
+            result = runner.invoke(app, ["resume", str(gate_workflow_file), "--web-bg"])
+
+        assert result.exit_code != 0
+        assert not mock_launch.called
+        combined = (result.output or "") + (str(result.exception) if result.exception else "")
+        assert "human_gate" in combined
+        assert "--skip-gates" in combined

--- a/tests/test_cli/test_web_flags.py
+++ b/tests/test_cli/test_web_flags.py
@@ -342,7 +342,13 @@ class TestWebBgHumanGateValidation:
         assert result.exit_code != 0
         assert not mock_launch.called
         # The error must name the actual problem and at least one remedy.
-        combined = (result.output or "") + (str(result.exception) if result.exception else "")
+        # Include stderr because Click 8.3+ separates streams and the abort
+        # message is intentionally emitted to stderr.
+        combined = (
+            (result.output or "")
+            + (result.stderr or "")
+            + (str(result.exception) if result.exception else "")
+        )
         assert "human_gate" in combined
         assert "--skip-gates" in combined
 
@@ -378,6 +384,10 @@ class TestWebBgHumanGateValidation:
 
         assert result.exit_code != 0
         assert not mock_launch.called
-        combined = (result.output or "") + (str(result.exception) if result.exception else "")
+        combined = (
+            (result.output or "")
+            + (result.stderr or "")
+            + (str(result.exception) if result.exception else "")
+        )
         assert "human_gate" in combined
         assert "--skip-gates" in combined

--- a/tests/test_cli/test_web_flags.py
+++ b/tests/test_cli/test_web_flags.py
@@ -391,3 +391,104 @@ class TestWebBgHumanGateValidation:
         )
         assert "human_gate" in combined
         assert "--skip-gates" in combined
+
+    def test_run_web_bg_with_human_gate_inside_for_each_aborts(self, tmp_path: Path) -> None:
+        """``human_gate`` nested in a ``for_each.agent`` must also abort the fork.
+
+        The top-level walk over ``config.agents`` misses inline agents
+        declared inside ``for_each`` groups. Without the extra check,
+        ``--web-bg`` still silent-crashes when the gate prompt eventually
+        fires inside the loop.
+        """
+        for_each_yaml = """\
+workflow:
+  name: gate-in-foreach
+  entry_point: source
+
+agents:
+  - name: source
+    type: agent
+    prompt: "List items"
+    output:
+      items:
+        type: array
+        items: { type: string }
+    routes:
+      - to: loop
+
+for_each:
+  - name: loop
+    type: for_each
+    source: source.output.items
+    as: item
+    agent:
+      name: inner
+      type: human_gate
+      prompt: "Approve {{ item }}?"
+      options:
+        - label: "Yes"
+          value: yes
+          route: $end
+        - label: "No"
+          value: no
+          route: $end
+
+output:
+  result: "done"
+"""
+        f = tmp_path / "gate_in_foreach.yaml"
+        f.write_text(for_each_yaml)
+
+        with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
+            result = runner.invoke(app, ["run", str(f), "--web-bg"])
+
+        assert result.exit_code != 0
+        assert not mock_launch.called
+        combined = (
+            (result.output or "")
+            + (result.stderr or "")
+            + (str(result.exception) if result.exception else "")
+        )
+        assert "human_gate" in combined
+        assert "--skip-gates" in combined
+
+    def test_resume_web_bg_from_checkpoint_only_aborts(
+        self, gate_workflow_file: Path, tmp_path: Path
+    ) -> None:
+        """``resume --from <checkpoint> --web-bg`` (no workflow arg) must still
+        abort when the checkpoint's workflow contains a ``human_gate``.
+
+        Previously the abort check was skipped because ``resolved_workflow``
+        is ``None`` in this code path; the workflow path is now recovered from
+        the checkpoint JSON so the same guard fires.
+        """
+        import json as _json
+
+        checkpoint = tmp_path / "ckpt.json"
+        checkpoint.write_text(
+            _json.dumps(
+                {
+                    "workflow_path": str(gate_workflow_file.resolve()),
+                    "workflow_hash": "deadbeef",
+                    "workflow_name": "gate-workflow",
+                    "failed_agent": "ask",
+                    "completed_agents": [],
+                    "context": {},
+                    "timestamp": "2026-05-27T00:00:00",
+                    "error_message": "test",
+                }
+            )
+        )
+
+        with patch("conductor.cli.bg_runner.launch_background_resume") as mock_launch:
+            result = runner.invoke(app, ["resume", "--from", str(checkpoint), "--web-bg"])
+
+        assert result.exit_code != 0
+        assert not mock_launch.called
+        combined = (
+            (result.output or "")
+            + (result.stderr or "")
+            + (str(result.exception) if result.exception else "")
+        )
+        assert "human_gate" in combined
+        assert "--skip-gates" in combined

--- a/tests/test_executor/test_output.py
+++ b/tests/test_executor/test_output.py
@@ -269,3 +269,15 @@ class TestParseJsonOutput:
 
         assert result["person"]["name"] == "Alice"
         assert result["person"]["tags"] == ["dev", "py"]
+
+    def test_parse_json_with_triple_backticks_inside_string(self) -> None:
+        """Triple-backticks inside a string field must not truncate the JSON.
+
+        Reproduces brainstorm Issue #1: the non-greedy fence-extraction regex
+        closed at the first inner ``` instead of the actual closing fence,
+        producing invalid JSON and triggering parse-recovery loops.
+        """
+        raw = '```json\n{"code": "use ```fenced``` blocks", "n": 1}\n```'
+        result = parse_json_output(raw)
+
+        assert result == {"code": "use ```fenced``` blocks", "n": 1}

--- a/tests/test_executor/test_output.py
+++ b/tests/test_executor/test_output.py
@@ -281,3 +281,17 @@ class TestParseJsonOutput:
         result = parse_json_output(raw)
 
         assert result == {"code": "use ```fenced``` blocks", "n": 1}
+
+    def test_parse_json_with_multiple_fenced_blocks_first_wins(self) -> None:
+        """When the response contains multiple fenced JSON blocks, the first
+        valid block wins.
+
+        Pins the behavior chosen for the multi-block trade-off raised in PR
+        review (greedy regex would have captured everything between the first
+        and last fence and failed to parse). The current implementation tries
+        each non-greedy candidate in order and returns the first that parses.
+        """
+        raw = '```json\n{"a": 1}\n```\n\nupdated answer:\n\n```json\n{"a": 2}\n```'
+        result = parse_json_output(raw)
+
+        assert result == {"a": 1}

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -643,6 +643,33 @@ class TestExtractJson:
         with pytest.raises(ValueError):
             provider._extract_json('{"key": "missing end brace"')
 
+    def test_extract_json_with_triple_backticks_inside_string(self) -> None:
+        """Triple-backticks inside a string field must not truncate the JSON.
+
+        Mirrors the parser fix in executor.output.parse_json_output — the
+        greedy fallback closes at the LAST fence in the response.
+        """
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        raw = '```json\n{"code": "use ```fenced``` blocks", "n": 1}\n```'
+        result = provider._extract_json(raw)
+
+        assert result == {"code": "use ```fenced``` blocks", "n": 1}
+
+    def test_extract_json_with_multiple_fenced_blocks_first_wins(self) -> None:
+        """When the response contains multiple fenced JSON blocks, the first
+        valid block wins.
+
+        Pins the behavior for the multi-block trade-off raised in PR review:
+        try each non-greedy candidate in order and return the first parse.
+        """
+        provider = CopilotProvider(mock_handler=stub_handler)
+
+        raw = '```json\n{"a": 1}\n```\n\nupdated answer:\n\n```json\n{"a": 2}\n```'
+        result = provider._extract_json(raw)
+
+        assert result == {"a": 1}
+
 
 class TestLogParseRecovery:
     """Tests for parse recovery logging."""


### PR DESCRIPTION
# fix: external workflow friction — minimal evidence-anchored fixes

**Branch:** `fix/external-workflow-friction` → `main`
**Type:** Bug fixes (3) + documentation
**Risk:** Low — two narrow bug fixes, one CLI pre-fork validation, one new docs section. No schema or API changes.
**Plan:** [docs/projects/usability-features/external-workflow-friction.plan.md](docs/projects/usability-features/external-workflow-friction.plan.md)
**Brainstorm:** [docs/projects/usability-features/external-workflow-friction.brainstorm.md](docs/projects/usability-features/external-workflow-friction.brainstorm.md)

## Background

A single external contributor running two real-world workflows against Conductor v0.1.16 hit seven failed runs before reaching a successful end-to-end execution. The companion brainstorm identified nine candidate issues. Pre-design code review confirmed **four** of those issues are real, root-caused, and have a clear minimal fix; the remaining five either could not be reproduced from the cited evidence, propose speculative configurability, or address unobserved failure modes.

This PR ships three of the four (the fourth, scripts-inside-parallel validation, was already on main per pre-flight check). Five issues are explicitly deferred in the plan §6 with thresholds-to-reopen.

## Commits

| Commit | Issue | Plan Item |
|---|---|---|
| `505caee fix(parser): use greedy fence regex for JSON with embedded backticks` | Brainstorm #1 | Item 1 (FR-1, FR-2, FR-3) |
| `69f2dd5 fix(cli): abort --web-bg before fork when workflow has human_gate` | Brainstorm #8 | Item 4 (FR-6) |
| `4e5c07b docs: omit-output guidance, --web-bg gate constraint, brainstorm + plan` | Brainstorm #2 + docs gaps | Item 3 (FR-5) + plan/brainstorm in-tree |

## Issue 1: Fence regex strips JSON containing triple-backticks

**Failure mode:** `parse_json_output` (executor/output.py) and `_extract_json` (providers/copilot.py) both used a non-greedy fenced-block regex:

```
r"```(?:json)?\s*\n?(.*?)\n?```"
```

When an agent emitted JSON whose string values contained triple-backtick substrings (common for Markdown- or shell-snippet-bearing payloads), the first inner ` ``` ` closed the match prematurely. The extracted substring was invalid JSON, triggering parse-recovery loops and burning tokens — the exact failure observed in the brainstorm timeline.

**Fix:** switch both call sites to a greedy capture with `re.DOTALL`:

```
r"```(?:json)?\s*\n(.*)\n```"
```

With `DOTALL` the greedy `.*` terminates at the last triple-backtick in the string, which is the correct boundary. The existing first-`{`/`[` heuristic and brace-match fallback remain as final attempts; the canonical `json.loads` at the end is the unchanged failure point for genuinely malformed JSON.

**Test:** `tests/test_executor/test_output.py::test_parse_json_with_triple_backticks_inside_string` fails on `main` and passes after this commit. The malformed-input test is retained as a regression guard for the unchanged error message.

## Issue 4: --web-bg crashes silently when workflow contains human_gate

**Failure mode:** `conductor run --web-bg` (and `resume --web-bg`) forked a detached background process. When the workflow reached a `human_gate` step, `Prompt.ask()` read from the closed stdin and the child crashed with `EOFError`. The parent only saw `"Background process exited immediately with code 1"` — nothing pointed at the actual incompatibility, the `--skip-gates` workaround, or the foreground `--web` alternative.

**Fix:** `_abort_web_bg_if_human_gate()` helper in `cli/app.py` loads the workflow, walks `config.agents`, and if any `type: human_gate` is present (and `--skip-gates` is not set) aborts with this guidance message before `launch_background()` forks anything:

```
--web-bg is incompatible with workflows that contain human_gate steps
because the detached process has no stdin to prompt on.

Options:
  1. Use --web (foreground) instead of --web-bg
  2. Add --skip-gates to auto-accept the first option
  3. Remove human_gate steps from the workflow
  4. Wait for CLI gate-resolution support (planned follow-up)
```

Call sites added to both `run` and `resume` per the run/resume parity rule in `AGENTS.md`.

**Tests:** `tests/test_cli/test_web_flags.py::TestWebBgHumanGateValidation`:

- `test_web_bg_with_human_gate_aborts_before_fork`
- `test_web_bg_with_human_gate_and_skip_gates_proceeds`
- `test_resume_web_bg_with_human_gate_aborts_before_fork`

All three mock `launch_background`, run in-process via `CliRunner`, and produce no subprocess. Deterministic.

## Issue 2 (docs-only): when to declare `output:` vs omit it

**Failure mode:** the external contributor declared `output:` on a synthesizer agent that produced 80 KB of nested JSON. This injected a schema instruction that the model partially complied with, fell into parse-recovery, and burned cost. The brainstorm proposed adding an `output_mode` field; the plan §2 NG1 rejected that as API bloat — the "raw" behavior already exists as "omit `output:`". The fix is docs.

**Change:** new "Choosing whether to declare `output:`" section in `docs/workflow-syntax.md` describing the trade-off in one sentence, the two clear cases (small structured JSON → declare; prose or large JSON → omit and read `<agent>.output.result`), and the YAML for both. Cross-linked from the `output:` reference subsection.

## Additional documentation

- **`docs/cli-reference.md` `--web-bg` section** — now documents the `human_gate` incompatibility and the four supported options matching the new pre-fork validation. Closes a gap noticed while implementing Issue 4.
- **`CHANGELOG.md` [Unreleased]** — entries under `Fixed` and `Documentation` for each change.
- **Plan and brainstorm in-tree at `docs/projects/usability-features/`** — kept so future contributors can answer "why was issue X not done?" without spelunking PR history. The plan §6 table lists each deferred issue with the threshold that would justify reopening it.

## What this PR does NOT do

Plan §2 NG1-NG7 (also §6) enumerate the five brainstorm issues explicitly out of scope:

- **Issue #2 `output_mode` field** — synonym for "absence of `output:`"; docs fix (Item 3) likely sufficient.
- **Issue #3 Windows path normalization** — no Python-only reproduction; likely shell/YAML environmental.
- **Issue #4 env-var regex rewrite** — inspection shows the current regex already accepts colons in defaults; reported failure is likely YAML quoting or PowerShell variable expansion.
- **Issue #5 dashboard keepalive, CLI gate command, dashboard auth, webhooks** — out of scope by user decision; revisit in a follow-up plan.
- **Issue #6 configurable retry budget** — no observed demand.
- **Issue #9 `command:` vs `args:` parity** — author labels anecdotal.

Each entry in the plan table includes a re-open threshold so the next person who hits one of these knows what evidence would justify reopening.

## Verification

- `make check` (ruff + ruff format + ty) — passes.
- `uv run pytest tests/test_executor/test_output.py tests/test_cli/test_web_flags.py -q` — 41 / 41 pass.
- Full suite passes (modulo the 11 pre-existing failures on `main` unrelated to this branch).

## Reviewer guidance

- **Item 1 is the highest-value change** — the brainstorm timeline shows it was the proximate cause of the multi-hour debugging session. Review the regex carefully; the test specifically guards the "string field containing ` ``` `" case that the old regex failed on.
- **Item 4 is pre-fork on purpose** — crashing the child after fork loses observability; failing fast at load is cheaper and clearer. Both `run` and `resume` get the check by necessity (run/resume parity rule in AGENTS.md), not as gold-plating.
- **The docs/plan files are intentionally verbose** — they enumerate explicitly-deferred work with reopen thresholds so this PR doesn't quietly become "the time someone shipped fixes 1, 3, 4 and #5 was never reconsidered."
