### PR TITLE
[codex] Add Codex provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Conductor
 
-A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK and Anthropic Claude.
+A CLI tool for defining and running multi-agent workflows with GitHub Copilot, Anthropic Claude, Claude Agent SDK, and OpenAI Codex.
 
 [![CI](https://github.com/microsoft/conductor/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/conductor/actions/workflows/ci.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
@@ -16,7 +16,7 @@ Conductor makes multi-agent workflows — code review pipelines, research-then-s
 ## Features
 
 - **YAML-based workflows** - Define multi-agent workflows in readable YAML
-- **Multiple providers** - GitHub Copilot, Anthropic Claude, or Claude Agent SDK with seamless switching
+- **Multiple providers** - GitHub Copilot, Anthropic Claude, Claude Agent SDK, or OpenAI Codex with seamless switching
 - **Parallel execution** - Run agents concurrently (static groups or dynamic for-each)
 - **Sub-workflow composition** - Reusable sub-workflows with templated `input_mapping`, usable inside `for_each` groups for dynamic fan-out
 - **Script steps** - Run shell commands and route on exit code or parsed JSON stdout
@@ -211,13 +211,13 @@ conductor stop
 
 Conductor supports multiple AI providers. Choose based on your needs:
 
-| Feature | Copilot | Claude | Claude Agent SDK |
-|---------|---------|--------|------------------|
-| **Pricing** | Subscription ($10-39/mo) | Pay-per-token | Via Claude Code CLI |
-| **Context Window** | 8K-128K tokens | 200K tokens | 200K tokens |
-| **Tool Support (MCP)** | Yes | Planned | Yes (built-in) |
-| **Streaming** | Yes | Planned | Yes |
-| **Best For** | Heavy usage, tools | Large context, pay-per-use | Full Claude Code toolset |
+| Feature | Copilot | Claude | Claude Agent SDK | Codex |
+|---------|---------|--------|------------------|-------|
+| **Pricing** | Subscription ($10-39/mo) | Pay-per-token | Via Claude Code CLI | Via Codex auth/API |
+| **Context Window** | per-model | 200K tokens | 200K tokens | per-model |
+| **Tool Support (MCP)** | Yes | Yes (stdio) | Yes (CLI-managed) | Yes |
+| **Streaming** | Yes | Yes | Yes | Yes |
+| **Best For** | Heavy usage, tools | Large context, pay-per-use | Full Claude Code toolset | Codex coding agent workflows |
 
 ### Using Claude
 
@@ -242,6 +242,23 @@ workflow:
 Requires the `claude` CLI to be installed and authenticated. Install the SDK: `uv add 'claude-agent-sdk>=0.1.0'`
 
 > **Note:** The `claude-agent-sdk` provider delegates tool and MCP server management to the `claude` CLI. Workflow-level `tools` and `runtime.mcp_servers` fields are ignored — configure these through your Claude Code settings instead.
+
+### Using Codex
+
+```yaml
+workflow:
+  runtime:
+    provider: codex
+    default_model: gpt-5.4
+```
+
+Requires Codex authentication and the optional SDK extra. Install with:
+`uv add --prerelease allow 'openai-codex==0.1.0b3'`.
+
+Codex runs through the official `openai-codex` Python SDK and local
+`codex app-server`. Conductor maps workflow MCP servers, per-agent
+`tools:`, reasoning effort, structured output schemas, streaming events,
+interrupts, and checkpoint resume to Codex threads.
 
 **See also:** [Claude Documentation](docs/providers/claude.md) | [Provider Comparison](docs/providers/comparison.md) | [Migration Guide](docs/providers/migration.md)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,7 +26,7 @@ conductor run <workflow.yaml> [OPTIONS]
 | `--metadata KEY=VALUE` | `-m` | Workflow metadata (repeatable). Merged on top of YAML `metadata:` and surfaced in the `workflow_started` event. |
 | `--workspace-instructions` | | Auto-discover convention files (`AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, and `.github/instructions/**/*.instructions.md`) by walking from CWD up to the git root. Concatenated and prepended to every agent's prompt. See [Workspace Instructions](#workspace-instructions) below for details on the `.github/instructions/` directory convention. |
 | `--instructions PATH` | | Explicit path to an instructions file (repeatable). Combines with auto-discovered files when both flags are used. |
-| `--provider PROVIDER` | `-p` | Override provider (copilot, claude, claude-agent-sdk) |
+| `--provider PROVIDER` | `-p` | Override provider (copilot, claude, claude-agent-sdk, codex) |
 | `--dry-run` | | Show execution plan without running |
 | `--skip-gates` | | Auto-select first option at human gates |
 | `--quiet` | `-q` | Minimal output (agent lifecycle and routing only) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ The `runtime` section of your workflow defines provider settings and global defa
 ```yaml
 workflow:
   runtime:
-    provider: copilot  # or 'claude' or 'claude-agent-sdk'
+    provider: copilot  # or 'claude', 'claude-agent-sdk', or 'codex'
     default_model: gpt-5.2
     temperature: 0.7
     max_tokens: 4096
@@ -70,6 +70,32 @@ workflow:
 **Models**: `claude-sonnet-4.5`, `claude-haiku-4.5`, `claude-opus-4.5`
 
 **See**: [Claude Provider Documentation](providers/claude.md)
+
+### Codex Provider
+
+Uses the official `openai-codex` Python SDK and local `codex app-server`
+for agent execution.
+
+```yaml
+workflow:
+  runtime:
+    provider:
+      name: codex
+      codex:
+        sandbox: workspace-write
+        approval_mode: auto_review
+    default_model: gpt-5.4
+    default_reasoning_effort: high
+```
+
+**Features**:
+- Native Codex threads with checkpoint resume
+- Native JSON Schema structured output
+- Streaming message, reasoning, and tool events
+- Workflow MCP server and per-agent `tools:` mapping
+
+Install the optional SDK extra before using this provider:
+`uv add --prerelease allow 'openai-codex==0.1.0b3'`.
 
 ### Custom Provider Routing (Ollama / vLLM / Azure OpenAI)
 
@@ -204,7 +230,8 @@ OpenAI (commented variant).
 
 ## Common Configuration Options
 
-These options work with both providers:
+These options apply across model providers unless a provider-specific note
+below says otherwise.
 
 ### Model Selection
 
@@ -238,6 +265,9 @@ workflow:
 **Ranges**:
 - **Copilot (OpenAI)**: 0.0 - 2.0
 - **Claude**: 0.0 - 1.0 (enforced by SDK)
+
+**Provider note**: Codex does not accept `runtime.temperature`; remove this
+field for workflows that use `provider: codex`.
 
 **Guidelines**:
 - `0.0 - 0.3`: Factual, deterministic (data extraction, classification)
@@ -318,14 +348,18 @@ agents (none of which call a model).
   `temperature` to `1.0` (required by the Anthropic API for extended thinking,
   logged at INFO) and bumps `max_tokens` to fit `budget + 4096`, capped at
   `64000` (logged at INFO when clamped).
+- **Codex** — Forwards the chosen effort as `effort` on each Codex turn and
+  validates it against Codex model capability metadata when available.
 
 Reasoning / thinking content emitted by the model is surfaced via
 `agent_reasoning` events and rendered in the dashboard, JSONL logs, and
-`-vv` console output for both providers.
+`-vv` console output.
 
 ## MCP Servers
 
-Configure [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers for tool access. Both the Copilot and Claude providers support MCP tools.
+Configure [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
+servers for tool access. Copilot, Claude, and Codex providers support MCP
+tools with provider-specific transport and routing behavior.
 
 ```yaml
 workflow:
@@ -343,7 +377,9 @@ workflow:
         tools: ["*"]
 ```
 
-> **Provider note:** The Claude provider supports `stdio` servers only. HTTP and SSE servers are Copilot-only.
+> **Provider note:** The Claude provider supports `stdio` servers only. Copilot
+> and Codex receive Conductor MCP server definitions through their native SDK
+> configuration surfaces.
 
 For full details on server types, tool filtering, environment variables, and OAuth authentication, see the [MCP Tools guide](mcp-tools.md).
 

--- a/docs/providers/comparison.md
+++ b/docs/providers/comparison.md
@@ -1,24 +1,24 @@
-# Provider Comparison: Copilot vs Claude vs Claude Agent SDK
+# Provider Comparison: Copilot vs Claude vs Claude Agent SDK vs Codex
 
-This guide helps you choose between GitHub Copilot, Anthropic Claude, and Claude Agent SDK providers for your workflows.
+This guide helps you choose between GitHub Copilot, Anthropic Claude, Claude Agent SDK, and Codex providers for your workflows.
 
 ## Quick Comparison
 
-| Feature | Copilot | Claude | Claude Agent SDK | Winner |
-|---------|---------|--------|------------------|--------|
-| **Tier** | Stable | Stable | Experimental ([#241](https://github.com/microsoft/conductor/issues/241)) | Copilot / Claude |
-| **Context Window** | per-model (SDK-reported) | per-model (SDK-reported) | 200K | Tie |
-| **Pricing Model** | Subscription ($10-39/mo) | Pay-per-token | Via Claude Code CLI | Depends |
-| **Setup** | GitHub auth | API key | `claude` CLI auth | Copilot (easier) |
-| **Model Selection** | GPT-5.2, o1 | Haiku, Sonnet, Opus | Haiku, Sonnet, Opus | Tie |
-| **Streaming** | Yes | No (Phase 1) | Yes | Copilot / Claude Agent SDK |
-| **Tool Support** | Yes (MCP, all types) | Yes (MCP, stdio only) | Yes (built-in, CLI-managed) | Copilot |
-| **Reasoning / Extended Thinking** | Yes (`reasoning_effort` on session) | Yes (extended `thinking` budget) | Inherits from CLI config | Tie |
-| **Speed** | Fast | Fast | Fast | Tie |
-| **Output Quality** | Excellent | Excellent | Excellent | Tie |
-| **Cost Predictability** | High (flat rate) | Variable (usage-based) | Variable | Copilot |
-| **Multi-provider** | No | Yes (via Conductor) | No | Claude |
-| **Agentic Loop** | SDK-managed | Manual (provider code) | SDK-managed (delegated to CLI) | Depends |
+| Feature | Copilot | Claude | Claude Agent SDK | Codex | Winner |
+|---------|---------|--------|------------------|-------|--------|
+| **Tier** | Stable | Stable | Experimental ([#241](https://github.com/microsoft/conductor/issues/241)) | Experimental | Copilot / Claude |
+| **Context Window** | per-model (SDK-reported) | per-model (SDK-reported) | 200K | per-model | Tie |
+| **Pricing Model** | Subscription ($10-39/mo) | Pay-per-token | Via Claude Code CLI | Via Codex auth/API | Depends |
+| **Setup** | GitHub auth | API key | `claude` CLI auth | Codex auth | Copilot (easier) |
+| **Model Selection** | GPT-5.2, o1 | Haiku, Sonnet, Opus | Haiku, Sonnet, Opus | GPT/Codex models | Tie |
+| **Streaming** | Yes | No (Phase 1) | Yes | Yes | Copilot / SDK providers |
+| **Tool Support** | Yes (MCP, all types) | Yes (MCP, stdio only) | Yes (built-in, CLI-managed) | Yes (MCP via Codex config) | Copilot / Codex |
+| **Reasoning / Extended Thinking** | Yes (`reasoning_effort` on session) | Yes (extended `thinking` budget) | Inherits from CLI config | Yes (`effort` on turn) | Tie |
+| **Speed** | Fast | Fast | Fast | Fast | Tie |
+| **Output Quality** | Excellent | Excellent | Excellent | Excellent | Tie |
+| **Cost Predictability** | High (flat rate) | Variable (usage-based) | Variable | Variable | Copilot |
+| **Multi-provider** | No | Yes (via Conductor) | No | Yes (via Conductor) | Claude / Codex |
+| **Agentic Loop** | SDK-managed | Manual (provider code) | SDK-managed (delegated to CLI) | SDK-managed (app-server) | Depends |
 
 > **About the experimental tier.** `claude-agent-sdk` declares specific
 > capability carve-outs (no MCP, no per-agent tools allowlist, no
@@ -27,6 +27,12 @@ This guide helps you choose between GitHub Copilot, Anthropic Claude, and Claude
 > CLI prints a one-time banner when the workflow runs. See
 > [docs/providers/experimental.md](./experimental.md) for the stability
 > policy and promotion criteria.
+
+`codex` is also experimental because the upstream `openai-codex` Python
+SDK and bundled app-server runtime are beta. Unlike `claude-agent-sdk`,
+Conductor declares no capability carve-outs for Codex: workflow MCP
+servers, per-agent `tools:`, reasoning effort, native structured output,
+streaming events, interrupts, usage, and checkpoint resume are wired.
 
 ## When to Use Copilot
 
@@ -168,6 +174,42 @@ workflow:
 agents:
   - name: researcher
     prompt: "Research {{ topic }} using web search"
+```
+
+## When to Use Codex
+
+### ✅ Choose Codex if:
+
+1. **You want Codex's coding-agent behavior inside Conductor**
+   - Local repository understanding
+   - Codex thread persistence and resume
+   - Native Codex sandbox and approval controls
+
+2. **You need native JSON Schema output**
+   - Conductor `output:` schemas are passed to Codex as `output_schema`
+   - Returned JSON is still validated by Conductor
+
+3. **You want Codex streaming and reasoning events**
+   - Message deltas
+   - Reasoning deltas
+   - Tool lifecycle events
+
+### Example Codex Workflow
+
+```yaml
+workflow:
+  name: codex-workflow
+  runtime:
+    provider: codex
+    default_model: gpt-5.4
+    default_reasoning_effort: high
+
+agents:
+  - name: planner
+    prompt: "Inspect this repository and propose the next change."
+    output:
+      summary:
+        type: string
 ```
 
 ## Cost Comparison

--- a/docs/providers/experimental.md
+++ b/docs/providers/experimental.md
@@ -98,6 +98,7 @@ adopting one does not inflate the install surface for others.
 | Provider | Upstream pin | Maintainer | Capability carve-outs |
 |---|---|---|---|
 | `claude-agent-sdk` | `claude-agent-sdk>=0.1.0` | `@lesandiz (best-effort)` | no `mcp_tools`, no `workflow_tools_passthrough`, no `reasoning_effort`, `prompt_injection` structured output, no `checkpoint_resume` |
+| `codex` | `openai-codex==0.1.0b3` | `@microsoft/conductor` | none declared; experimental because the upstream SDK/runtime is beta |
 
 ## See also
 

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -45,7 +45,7 @@ workflow:
   context_mode: accumulate          # accumulate | snapshot | minimal (default: accumulate)
 
   runtime:
-    provider: copilot               # copilot | claude
+    provider: copilot               # copilot | claude | claude-agent-sdk | codex
     default_model: gpt-5.2
     temperature: 0.7
     max_tokens: 4096

--- a/examples/codex-repo-review.yaml
+++ b/examples/codex-repo-review.yaml
@@ -1,0 +1,287 @@
+# Codex Repository Review Workflow
+#
+# This example is based on the repository's parallel research and dashboard
+# workflows, but uses provider: codex. It exercises:
+# - A deterministic script step with typed output
+# - A Codex planning agent
+# - A parallel Codex review group
+# - A final synthesis agent that aggregates parallel outputs
+#
+# Usage:
+#   uv run conductor run examples/codex-repo-review.yaml
+#   uv run conductor run examples/codex-repo-review.yaml --input focus="provider resume support"
+
+workflow:
+  name: codex-repo-review
+  description: Review selected Conductor implementation areas with Codex
+  version: "1.0.0"
+  entry_point: repo_snapshot
+
+  runtime:
+    provider:
+      name: codex
+      codex:
+        sandbox: read-only
+        approval_mode: auto_review
+    default_model: gpt-5.4
+    default_reasoning_effort: low
+
+  input:
+    focus:
+      type: string
+      required: false
+      default: "Codex provider implementation"
+      description: Review focus for the Codex agents
+
+  context:
+    mode: explicit
+
+  limits:
+    max_iterations: 10
+    timeout_seconds: 480
+
+  cost:
+    show_summary: true
+
+parallel:
+  - name: codex_parallel_review
+    description: Run independent Codex reviewers in parallel
+    agents:
+      - provider_contract_reviewer
+      - workflow_integration_reviewer
+    failure_mode: continue_on_error
+    routes:
+      - to: final_synthesis
+
+agents:
+  - name: repo_snapshot
+    type: script
+    description: Collect a small deterministic repository snapshot
+    command: python3
+    args:
+      - "-c"
+      - |
+        import json
+        import pathlib
+        import subprocess
+
+        files = [
+            "src/conductor/providers/codex.py",
+            "src/conductor/providers/factory.py",
+            "src/conductor/providers/registry.py",
+            "src/conductor/config/schema.py",
+            "tests/test_providers/test_codex.py",
+            "examples/codex-simple.yaml",
+        ]
+
+        def git(args):
+            try:
+                return subprocess.check_output(
+                    ["git", *args],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+            except Exception:
+                return ""
+
+        print(json.dumps({
+            "branch": git(["branch", "--show-current"]) or "unknown",
+            "head": git(["rev-parse", "--short", "HEAD"]) or "unknown",
+            "changed_files": [
+                line.strip()
+                for line in git(["status", "--short"]).splitlines()
+                if line.strip()
+            ],
+            "review_files": [
+                {"path": path, "exists": pathlib.Path(path).exists()}
+                for path in files
+            ],
+        }))
+    output:
+      branch:
+        type: string
+        description: Current git branch
+      head:
+        type: string
+        description: Current git commit
+      changed_files:
+        type: array
+        description: Current working tree changes
+      review_files:
+        type: array
+        description: Files the reviewers should inspect
+    routes:
+      - to: review_planner
+
+  - name: review_planner
+    description: Plan the Codex review areas
+    input:
+      - workflow.input.focus
+      - repo_snapshot.output
+    prompt: |
+      You are planning a focused code review for this Conductor repository.
+
+      Focus: {{ workflow.input.focus }}
+      Branch: {{ repo_snapshot.output.branch }}
+      Head: {{ repo_snapshot.output.head }}
+      Files to inspect:
+      {{ repo_snapshot.output.review_files | json }}
+
+      Create a concise review plan for two reviewers:
+      1. provider contract and runtime behavior
+      2. workflow/schema integration and examples
+
+      Keep the plan specific to the listed files.
+    output:
+      review_goal:
+        type: string
+        description: One-sentence review goal
+      provider_contract_questions:
+        type: array
+        items:
+          type: string
+        description: Questions for the provider contract reviewer
+      workflow_integration_questions:
+        type: array
+        items:
+          type: string
+        description: Questions for the workflow integration reviewer
+      success_criteria:
+        type: array
+        items:
+          type: string
+        description: Criteria for a successful review
+    routes:
+      - to: codex_parallel_review
+
+  - name: provider_contract_reviewer
+    description: Review Codex provider runtime behavior
+    input:
+      - workflow.input.focus
+      - repo_snapshot.output
+      - review_planner.output
+    prompt: |
+      You are reviewing provider contract behavior for Conductor.
+
+      Focus: {{ workflow.input.focus }}
+      Questions:
+      {{ review_planner.output.provider_contract_questions | json }}
+
+      Inspect these files in read-only mode:
+      - src/conductor/providers/codex.py
+      - src/conductor/providers/factory.py
+      - src/conductor/providers/capabilities.py
+      - tests/test_providers/test_codex.py
+
+      Report concrete findings. If you find no blocking issues, say so and
+      still include residual risks.
+    output:
+      findings:
+        type: array
+        items:
+          type: string
+        description: Concrete provider-contract findings
+      risk_level:
+        type: string
+        description: low, medium, or high
+      recommendation:
+        type: string
+        description: Recommended follow-up
+
+  - name: workflow_integration_reviewer
+    description: Review schema, checkpoint, and example integration
+    input:
+      - workflow.input.focus
+      - repo_snapshot.output
+      - review_planner.output
+    prompt: |
+      You are reviewing workflow integration behavior for Conductor.
+
+      Focus: {{ workflow.input.focus }}
+      Questions:
+      {{ review_planner.output.workflow_integration_questions | json }}
+
+      Inspect these files in read-only mode:
+      - src/conductor/config/schema.py
+      - src/conductor/providers/registry.py
+      - src/conductor/engine/checkpoint.py
+      - examples/codex-simple.yaml
+      - examples/codex-repo-review.yaml
+
+      Report concrete findings. If you find no blocking issues, say so and
+      still include residual risks.
+    output:
+      findings:
+        type: array
+        items:
+          type: string
+        description: Concrete workflow-integration findings
+      risk_level:
+        type: string
+        description: low, medium, or high
+      recommendation:
+        type: string
+        description: Recommended follow-up
+
+  - name: final_synthesis
+    description: Aggregate the parallel Codex review findings
+    input:
+      - workflow.input.focus
+      - repo_snapshot.output
+      - review_planner.output
+      - codex_parallel_review.outputs
+      - codex_parallel_review.errors
+    prompt: |
+      Synthesize the Codex review results into a compact final report.
+
+      Focus: {{ workflow.input.focus }}
+      Review goal: {{ review_planner.output.review_goal }}
+
+      {% if codex_parallel_review.errors %}
+      Some reviewers failed:
+      {% for agent, error in codex_parallel_review.errors.items() %}
+      - {{ agent }}: {{ error.message }}
+      {% endfor %}
+      {% endif %}
+
+      Provider contract reviewer:
+      {% if 'provider_contract_reviewer' in codex_parallel_review.outputs %}
+      {{ codex_parallel_review.outputs.provider_contract_reviewer | json }}
+      {% else %}
+      No provider contract output was available.
+      {% endif %}
+
+      Workflow integration reviewer:
+      {% if 'workflow_integration_reviewer' in codex_parallel_review.outputs %}
+      {{ codex_parallel_review.outputs.workflow_integration_reviewer | json }}
+      {% else %}
+      No workflow integration output was available.
+      {% endif %}
+
+      Produce an actionable report for a maintainer.
+    output:
+      summary:
+        type: string
+        description: Overall review summary
+      top_risks:
+        type: array
+        items:
+          type: string
+        description: Highest-priority risks or gaps
+      next_steps:
+        type: array
+        items:
+          type: string
+        description: Recommended next steps
+      ready_for_pr:
+        type: boolean
+        description: Whether the reviewed changes look ready for PR discussion
+    routes:
+      - to: $end
+
+output:
+  focus: "{{ workflow.input.focus }}"
+  summary: "{{ final_synthesis.output.summary }}"
+  top_risks: "{{ final_synthesis.output.top_risks | json }}"
+  next_steps: "{{ final_synthesis.output.next_steps | json }}"
+  ready_for_pr: "{{ final_synthesis.output.ready_for_pr }}"

--- a/examples/codex-simple.yaml
+++ b/examples/codex-simple.yaml
@@ -1,0 +1,37 @@
+# Simple Codex provider workflow
+#
+# Requires:
+#   uv add --prerelease allow 'openai-codex==0.1.0b3'
+#   codex authentication already configured
+#
+# Run:
+#   uv run conductor run examples/codex-simple.yaml
+
+workflow:
+  name: codex-simple
+  version: "1.0.0"
+  description: Minimal workflow using the OpenAI Codex provider
+  entry_point: inspect_repo
+  runtime:
+    provider:
+      name: codex
+      codex:
+        sandbox: read-only
+        approval_mode: auto_review
+    default_model: gpt-5.4
+    default_reasoning_effort: medium
+
+agents:
+  - name: inspect_repo
+    description: Summarize the repository with Codex
+    prompt: |
+      Summarize this repository in three concise bullets.
+    output:
+      summary:
+        type: string
+        description: Three-bullet repository summary
+    routes:
+      - to: $end
+
+output:
+  summary: "{{ inspect_repo.output.summary }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dependencies = [
 claude-agent-sdk = [
     "claude-agent-sdk>=0.1.64",
 ]
+codex = [
+    "openai-codex==0.1.0b3",
+    "openai-codex-cli-bin==0.137.0a4",
+]
 
 [project.urls]
 Homepage = "https://github.com/microsoft/conductor"

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -1971,8 +1971,13 @@ async def resume_workflow_async(
         async with ProviderRegistry(config, mcp_servers=mcp_servers) as registry:
             verbose_log("Starting resumed workflow execution...")
 
-            # Pass stored session IDs to registry for Copilot session resume
-            if cp.copilot_session_ids:
+            # Pass stored session IDs to registry for provider-specific resume
+            # (Copilot session IDs, Codex thread IDs, etc.). Older checkpoints
+            # only have ``copilot_session_ids``; CheckpointManager projects
+            # those into provider_session_ids["copilot"] on load.
+            if cp.provider_session_ids:
+                registry.set_provider_resume_session_ids(cp.provider_session_ids)
+            elif cp.copilot_session_ids:
                 registry.set_resume_session_ids(cp.copilot_session_ids)
 
             # Set up interrupt listener if interactive mode is enabled

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -505,7 +505,7 @@ class AgentDef(BaseModel):
     ) = None
     """Agent type. Defaults to 'agent' if not specified."""
 
-    provider: Literal["copilot", "claude", "claude-agent-sdk"] | None = None
+    provider: Literal["copilot", "claude", "claude-agent-sdk", "codex"] | None = None
     """Provider override for this agent.
 
     If None (default), the agent uses the workflow.runtime.provider.
@@ -1293,6 +1293,34 @@ class AzureProviderOptions(BaseModel):
     falls back to its own default when unset."""
 
 
+class CodexProviderOptions(BaseModel):
+    """Codex-specific provider options forwarded to ``openai-codex``.
+
+    These settings intentionally mirror stable knobs exposed by the Codex
+    Python SDK / app-server boundary. Shared runtime settings such as
+    ``default_model``, ``default_reasoning_effort``, ``max_session_seconds``,
+    and ``mcp_servers`` remain on :class:`RuntimeConfig`.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    codex_bin: str | None = None
+    """Optional path to a specific ``codex`` executable. When omitted, the
+    ``openai-codex`` SDK uses its pinned bundled runtime."""
+
+    sandbox: Literal["read-only", "workspace-write", "full-access"] | None = None
+    """Filesystem sandbox preset for Codex turns."""
+
+    approval_mode: Literal["deny_all", "auto_review"] | None = None
+    """Approval behavior used when starting/resuming Codex threads."""
+
+    model_provider: str | None = None
+    """Optional Codex model provider name, e.g. a configured Bedrock provider."""
+
+    service_tier: str | None = None
+    """Optional Codex service tier."""
+
+
 class ProviderSettings(BaseModel):
     """Structured provider configuration for ``runtime.provider``.
 
@@ -1319,7 +1347,7 @@ class ProviderSettings(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    name: Literal["copilot", "openai-agents", "claude", "claude-agent-sdk"] = "copilot"
+    name: Literal["copilot", "openai-agents", "claude", "claude-agent-sdk", "codex"] = "copilot"
     """SDK provider to use for agent execution."""
 
     type: Literal["openai", "azure", "anthropic"] | None = None
@@ -1356,6 +1384,9 @@ class ProviderSettings(BaseModel):
     """Azure-specific options (e.g. ``api_version``). Requires
     ``type: azure``. Copilot-only."""
 
+    codex: CodexProviderOptions | None = None
+    """Codex-specific options. Only valid when ``name: codex``."""
+
     @model_validator(mode="after")
     def _check_field_compatibility(self) -> ProviderSettings:
         copilot_only_fields = {
@@ -1365,6 +1396,9 @@ class ProviderSettings(BaseModel):
             "headers": self.headers,
             "azure": self.azure,
         }
+        if self.codex is not None and self.name != "codex":
+            raise ValueError("'codex' provider options are only supported when name='codex'")
+
         if self.name != "copilot":
             extras = sorted(k for k, v in copilot_only_fields.items() if v is not None)
             if extras:
@@ -1440,6 +1474,7 @@ class ProviderSettings(BaseModel):
                 self.bearer_token,
                 self.headers,
                 self.azure,
+                self.codex,
             )
         )
 

--- a/src/conductor/engine/checkpoint.py
+++ b/src/conductor/engine/checkpoint.py
@@ -76,7 +76,9 @@ class CheckpointData:
         current_agent: Name of the agent that was executing when failure occurred.
         context: Serialized ``WorkflowContext`` state.
         limits: Serialized ``LimitEnforcer`` state.
-        copilot_session_ids: Mapping of agent names to Copilot session IDs.
+        provider_session_ids: Mapping of provider names to their per-agent
+            resumable session/thread IDs.
+        copilot_session_ids: Legacy mapping of agent names to Copilot session IDs.
         file_path: Path where the checkpoint file is stored.
         instructions_preamble: Workspace instructions preamble that was
             active during the original run, or ``None``.
@@ -100,6 +102,7 @@ class CheckpointData:
     current_agent: str
     context: dict[str, Any]
     limits: dict[str, Any]
+    provider_session_ids: dict[str, dict[str, str]] = field(default_factory=dict)
     copilot_session_ids: dict[str, str] = field(default_factory=dict)
     file_path: Path = field(default_factory=lambda: Path())
     instructions_preamble: str | None = None
@@ -155,6 +158,7 @@ class CheckpointManager:
         current_agent: str,
         error: BaseException,
         inputs: dict[str, Any],
+        provider_session_ids: dict[str, dict[str, str]] | None = None,
         copilot_session_ids: dict[str, str] | None = None,
         system_metadata: dict[str, Any] | None = None,
         instructions_preamble: str | None = None,
@@ -176,7 +180,10 @@ class CheckpointManager:
             current_agent: Name of the agent executing when the error occurred.
             error: The exception that triggered the checkpoint.
             inputs: Workflow inputs.
-            copilot_session_ids: Optional mapping of agent names to session IDs.
+            provider_session_ids: Optional provider-keyed mapping of agent names
+                to resumable provider session/thread IDs.
+            copilot_session_ids: Optional legacy mapping of agent names to
+                Copilot session IDs.
             system_metadata: Optional system metadata captured at workflow start.
             instructions_preamble: Optional workspace instructions preamble to persist.
             run_id: Original run identifier (from ``EventLogSubscriber``).
@@ -207,6 +214,10 @@ class CheckpointManager:
             timestamp = f"{timestamp}-{suffix}"
             created_at = datetime.now(UTC).isoformat()
             workflow_name = workflow_path.stem
+            provider_ids = dict(provider_session_ids or {})
+            if copilot_session_ids and "copilot" not in provider_ids:
+                provider_ids["copilot"] = dict(copilot_session_ids)
+            legacy_copilot_ids = copilot_session_ids or provider_ids.get("copilot", {})
 
             checkpoint = {
                 "version": CheckpointManager.CHECKPOINT_VERSION,
@@ -223,7 +234,8 @@ class CheckpointManager:
                 "current_agent": current_agent,
                 "context": _make_json_serializable(context.to_dict()),
                 "limits": _make_json_serializable(limits.to_dict()),
-                "copilot_session_ids": copilot_session_ids or {},
+                "provider_session_ids": _make_json_serializable(provider_ids),
+                "copilot_session_ids": _make_json_serializable(legacy_copilot_ids),
                 "system": system_metadata or {},
                 "instructions_preamble": instructions_preamble,
                 "run_id": run_id,
@@ -331,6 +343,14 @@ class CheckpointManager:
                     checkpoint_path=str(checkpoint_path),
                 )
 
+        provider_session_ids = data.get("provider_session_ids", {}) or {}
+        copilot_session_ids = data.get("copilot_session_ids", {}) or {}
+        if copilot_session_ids and "copilot" not in provider_session_ids:
+            provider_session_ids = {
+                **provider_session_ids,
+                "copilot": copilot_session_ids,
+            }
+
         return CheckpointData(
             version=data["version"],
             workflow_path=data["workflow_path"],
@@ -341,7 +361,8 @@ class CheckpointManager:
             current_agent=data["current_agent"],
             context=data["context"],
             limits=data["limits"],
-            copilot_session_ids=data.get("copilot_session_ids", {}),
+            provider_session_ids=provider_session_ids,
+            copilot_session_ids=copilot_session_ids,
             file_path=checkpoint_path,
             instructions_preamble=data.get("instructions_preamble"),
             run_id=data.get("run_id", "") or "",

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -1694,16 +1694,27 @@ class WorkflowEngine:
             logger.debug("No workflow_path set; skipping checkpoint save")
             return
 
-        # Collect session IDs from provider if available
+        # Collect provider-specific session IDs from active providers if available.
+        # ``copilot_session_ids`` remains as a legacy checkpoint field; the
+        # provider-neutral map is the source of truth for new checkpoints.
+        provider_session_ids: dict[str, dict[str, str]] = {}
         copilot_session_ids: dict[str, str] | None = None
         provider = self._single_provider
         if provider is not None and hasattr(provider, "get_session_ids"):
-            copilot_session_ids = provider.get_session_ids()  # type: ignore[union-attr]
+            provider_name = self.config.workflow.runtime.provider.name
+            ids = provider.get_session_ids()  # type: ignore[union-attr]
+            if ids:
+                provider_session_ids[provider_name] = ids
+                if provider_name == "copilot":
+                    copilot_session_ids = ids
         elif self._registry is not None:
-            for p in self._registry.get_active_providers().values():
+            for provider_name, p in self._registry.get_active_providers().items():
                 if hasattr(p, "get_session_ids"):
-                    copilot_session_ids = p.get_session_ids()  # type: ignore[union-attr]
-                    break
+                    ids = p.get_session_ids()  # type: ignore[union-attr]
+                    if ids:
+                        provider_session_ids[provider_name] = ids
+                        if provider_name == "copilot":
+                            copilot_session_ids = ids
 
         checkpoint_path = CheckpointManager.save_checkpoint(
             workflow_path=self.workflow_path,
@@ -1712,6 +1723,7 @@ class WorkflowEngine:
             current_agent=self._current_agent_name or "unknown",
             error=error,
             inputs=self.context.workflow_inputs,
+            provider_session_ids=provider_session_ids,
             copilot_session_ids=copilot_session_ids,
             system_metadata=self._system_metadata,
             instructions_preamble=self._instructions_preamble,

--- a/src/conductor/executor/output.py
+++ b/src/conductor/executor/output.py
@@ -116,6 +116,17 @@ def parse_json_output(raw_response: str) -> dict[str, Any]:
 
     text = raw_response.strip()
 
+    # Native structured-output providers can return a raw JSON object whose
+    # string fields contain markdown fences. Parse that first so inner fences
+    # are treated as ordinary string content instead of extraction delimiters.
+    try:
+        result = json.loads(text)
+        if isinstance(result, dict):
+            return result
+        return {"result": result}
+    except json.JSONDecodeError:
+        pass
+
     # Try to extract JSON from markdown code blocks. Two-stage strategy:
     # 1. Non-greedy findall + try-parse each candidate (first valid wins).
     #    Handles the common case of multiple fenced blocks in one response

--- a/src/conductor/providers/__init__.py
+++ b/src/conductor/providers/__init__.py
@@ -13,6 +13,7 @@ from conductor.providers.base import AgentOutput, AgentProvider
 if TYPE_CHECKING:
     from conductor.providers.claude import ClaudeProvider
     from conductor.providers.claude_agent_sdk import ClaudeAgentSdkProvider
+    from conductor.providers.codex import CodexProvider
     from conductor.providers.copilot import CopilotProvider
     from conductor.providers.factory import create_provider
 
@@ -21,6 +22,7 @@ __all__ = [
     "AgentProvider",
     "ClaudeAgentSdkProvider",
     "ClaudeProvider",
+    "CodexProvider",
     "CopilotProvider",
     "create_provider",
 ]
@@ -39,6 +41,10 @@ def __getattr__(name: str) -> Any:
         from conductor.providers.copilot import CopilotProvider
 
         return CopilotProvider
+    if name == "CodexProvider":
+        from conductor.providers.codex import CodexProvider
+
+        return CodexProvider
     if name == "create_provider":
         from conductor.providers.factory import create_provider
 

--- a/src/conductor/providers/capabilities.py
+++ b/src/conductor/providers/capabilities.py
@@ -204,6 +204,7 @@ _PROVIDER_CLASS_PATHS: Final[dict[str, str]] = {
     "copilot": "conductor.providers.copilot:CopilotProvider",
     "claude": "conductor.providers.claude:ClaudeProvider",
     "claude-agent-sdk": "conductor.providers.claude_agent_sdk:ClaudeAgentSdkProvider",
+    "codex": "conductor.providers.codex:CodexProvider",
 }
 
 # Provider names that appear in the schema / factory but are not yet

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -140,6 +140,10 @@ def _codex_effort(effort: ReasoningEffort | None) -> Any:
     }[effort]
 
 
+def _reasoning_effort_value(effort_option: Any) -> str:
+    return str(_enum_value(getattr(effort_option, "reasoning_effort", effort_option)))
+
+
 def _tool_name_from_item(item: Any) -> str | None:
     root = _thread_item(item)
     item_type = _item_type(root)
@@ -312,8 +316,11 @@ class CodexProvider(AgentProvider):
     async def validate_connection(self) -> bool:
         try:
             async with self._new_codex() as codex:
-                account = await codex.account(refresh_token=False)
-                return not bool(getattr(account, "requires_openai_auth", False))
+                account_state = await codex.account(refresh_token=True)
+                return (
+                    getattr(account_state, "account", None) is not None
+                    or not bool(getattr(account_state, "requires_openai_auth", False))
+                )
         except Exception as exc:
             logger.debug("Codex validate_connection failed: %s", exc, exc_info=True)
             return False
@@ -517,10 +524,13 @@ class CodexProvider(AgentProvider):
         message_deltas: list[str] = []
         started_turn_emitted = False
         start_time = time.monotonic()
+        next_event_task: asyncio.Task[Any] | None = asyncio.create_task(anext(stream))
 
         try:
             while True:
                 if interrupt_signal is not None and interrupt_signal.is_set():
+                    if next_event_task is not None:
+                        next_event_task.cancel()
                     await turn.interrupt()
                     final_response = _final_response_from_items(items, "".join(message_deltas))
                     return _CodexRunResult(
@@ -536,6 +546,8 @@ class CodexProvider(AgentProvider):
                     max_session_seconds is not None
                     and time.monotonic() - start_time > max_session_seconds
                 ):
+                    if next_event_task is not None:
+                        next_event_task.cancel()
                     await turn.interrupt()
                     raise ProviderError(
                         f"Agent '{agent.name}' exceeded maximum session duration "
@@ -544,12 +556,18 @@ class CodexProvider(AgentProvider):
                         is_retryable=False,
                     )
 
-                try:
-                    event = await asyncio.wait_for(anext(stream), timeout=0.25)
-                except TimeoutError:
+                if next_event_task is None:
+                    next_event_task = asyncio.create_task(anext(stream))
+                done, _pending = await asyncio.wait({next_event_task}, timeout=0.25)
+                if not done:
                     continue
+
+                try:
+                    event = next_event_task.result()
                 except StopAsyncIteration:
                     break
+                finally:
+                    next_event_task = None
 
                 payload = event.payload
                 method = getattr(event, "method", "")
@@ -579,6 +597,8 @@ class CodexProvider(AgentProvider):
                     completed_turn = getattr(payload, "turn", None)
                     break
         finally:
+            if next_event_task is not None:
+                next_event_task.cancel()
             await stream.aclose()
 
         if completed_turn is None:
@@ -711,7 +731,7 @@ class CodexProvider(AgentProvider):
                     return
                 efforts = getattr(selected, "supported_reasoning_efforts", None)
                 supported = (
-                    tuple(str(_enum_value(effort_option)) for effort_option in efforts)
+                    tuple(_reasoning_effort_value(effort) for effort in efforts)
                     if efforts
                     else None
                 )

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL: Final[str] = "gpt-5.4"
 _TOOL_RESULT_PREVIEW_LEN: Final[int] = 500
+_REASONING_DELTA_METHODS: Final[frozenset[str]] = frozenset(
+    {"item/reasoning/textDelta", "item/reasoning/summaryTextDelta"}
+)
+_ReasoningKey = tuple[str, Any, Any]
 
 
 @dataclass(slots=True)
@@ -53,6 +57,7 @@ class _CodexRunResult:
 
     turn_id: str
     final_response: str
+    streamed_response: str
     items: list[Any]
     usage: Any | None
     raw_turn: Any | None
@@ -144,6 +149,14 @@ def _reasoning_effort_value(effort_option: Any) -> str:
     return str(_enum_value(getattr(effort_option, "reasoning_effort", effort_option)))
 
 
+def _reasoning_delta_key(method: str, payload: Any) -> _ReasoningKey:
+    """Group Codex reasoning deltas that belong to the same text stream."""
+    item_id = getattr(payload, "item_id", None)
+    if method == "item/reasoning/summaryTextDelta":
+        return (method, item_id, getattr(payload, "summary_index", None))
+    return (method, item_id, getattr(payload, "content_index", None))
+
+
 def _tool_name_from_item(item: Any) -> str | None:
     root = _thread_item(item)
     item_type = _item_type(root)
@@ -169,8 +182,10 @@ def _final_response_from_items(items: list[Any], fallback: str) -> str:
             continue
         phase = _enum_value(getattr(root, "phase", None))
         if phase == "final_answer":
-            return text
-        if phase is None and last_unknown_phase is None:
+            if text.strip():
+                return text
+            continue
+        if phase is None and text.strip() and last_unknown_phase is None:
             last_unknown_phase = text
     return last_unknown_phase or fallback
 
@@ -522,9 +537,24 @@ class CodexProvider(AgentProvider):
         usage: Any | None = None
         completed_turn: Any | None = None
         message_deltas: list[str] = []
+        reasoning_deltas: list[str] = []
+        reasoning_key: _ReasoningKey | None = None
         started_turn_emitted = False
         start_time = time.monotonic()
         next_event_task: asyncio.Task[Any] | None = asyncio.create_task(anext(stream))
+
+        def flush_reasoning() -> None:
+            nonlocal reasoning_key
+            if not reasoning_deltas:
+                reasoning_key = None
+                return
+            _safe_callback(
+                event_callback,
+                "agent_reasoning",
+                {"content": "".join(reasoning_deltas)},
+            )
+            reasoning_deltas.clear()
+            reasoning_key = None
 
         try:
             while True:
@@ -532,10 +562,13 @@ class CodexProvider(AgentProvider):
                     if next_event_task is not None:
                         next_event_task.cancel()
                     await turn.interrupt()
+                    flush_reasoning()
                     final_response = _final_response_from_items(items, "".join(message_deltas))
+                    streamed_response = "".join(message_deltas)
                     return _CodexRunResult(
                         turn_id=turn.id,
                         final_response=final_response,
+                        streamed_response=streamed_response,
                         items=items,
                         usage=usage,
                         raw_turn=completed_turn,
@@ -549,6 +582,7 @@ class CodexProvider(AgentProvider):
                     if next_event_task is not None:
                         next_event_task.cancel()
                     await turn.interrupt()
+                    flush_reasoning()
                     raise ProviderError(
                         f"Agent '{agent.name}' exceeded maximum session duration "
                         f"of {max_session_seconds:.0f}s",
@@ -571,34 +605,51 @@ class CodexProvider(AgentProvider):
 
                 payload = event.payload
                 method = getattr(event, "method", "")
+                is_reasoning_delta = method in _REASONING_DELTA_METHODS
 
                 if method == "turn/started" and not started_turn_emitted:
                     started_turn_emitted = True
                     _safe_callback(event_callback, "agent_turn_start", {"turn": 1})
                 elif method == "item/agentMessage/delta":
+                    flush_reasoning()
                     delta = getattr(payload, "delta", "")
                     if delta:
                         message_deltas.append(delta)
                         _safe_callback(event_callback, "agent_message", {"content": delta})
-                elif method in {"item/reasoning/textDelta", "item/reasoning/summaryTextDelta"}:
+                elif is_reasoning_delta:
                     delta = getattr(payload, "delta", "")
                     if delta:
-                        _safe_callback(event_callback, "agent_reasoning", {"content": delta})
+                        next_reasoning_key = _reasoning_delta_key(method, payload)
+                        if reasoning_key is not None and reasoning_key != next_reasoning_key:
+                            flush_reasoning()
+                        reasoning_key = next_reasoning_key
+                        reasoning_deltas.append(delta)
                 elif method == "item/started":
+                    flush_reasoning()
                     self._handle_item_started(payload, event_callback)
                 elif method == "item/completed":
                     if getattr(payload, "turn_id", None) == turn.id:
                         items.append(payload.item)
+                    if _tool_name_from_item(getattr(payload, "item", None)):
+                        flush_reasoning()
                     self._handle_item_completed(payload, event_callback)
                 elif method == "thread/tokenUsage/updated":
                     if getattr(payload, "turn_id", None) == turn.id:
                         usage = getattr(payload, "token_usage", None)
                 elif method == "turn/completed":
+                    flush_reasoning()
                     completed_turn = getattr(payload, "turn", None)
                     break
+            flush_reasoning()
         finally:
             if next_event_task is not None:
                 next_event_task.cancel()
+                try:
+                    await next_event_task
+                except (asyncio.CancelledError, StopAsyncIteration):
+                    pass
+                except Exception:
+                    logger.debug("Ignored Codex stream task error during cleanup", exc_info=True)
             await stream.aclose()
 
         if completed_turn is None:
@@ -614,10 +665,12 @@ class CodexProvider(AgentProvider):
             message = getattr(error, "message", None) or "Codex turn failed"
             raise ProviderError(message, provider_name="codex", is_retryable=False)
 
-        final_response = _final_response_from_items(items, "".join(message_deltas))
+        streamed_response = "".join(message_deltas)
+        final_response = _final_response_from_items(items, streamed_response)
         return _CodexRunResult(
             turn_id=turn.id,
             final_response=final_response,
+            streamed_response=streamed_response,
             items=items,
             usage=usage,
             raw_turn=completed_turn,
@@ -667,13 +720,26 @@ class CodexProvider(AgentProvider):
         model: str,
     ) -> AgentOutput:
         content: dict[str, Any]
+        selected_response = result.final_response
         if agent.output:
             try:
-                content = parse_json_output(result.final_response)
-            except ValidationError:
-                if not result.partial:
+                content = parse_json_output(selected_response)
+            except ValidationError as exc:
+                if (
+                    result.streamed_response
+                    and result.streamed_response != selected_response
+                ):
+                    try:
+                        selected_response = result.streamed_response
+                        content = parse_json_output(selected_response)
+                    except ValidationError as fallback_exc:
+                        if not result.partial:
+                            raise exc from fallback_exc
+                        content = {"result": result.final_response}
+                elif not result.partial:
                     raise
-                content = {"result": result.final_response}
+                else:
+                    content = {"result": result.final_response}
             if not result.partial:
                 validate_output(content, agent.output)
         else:
@@ -690,6 +756,8 @@ class CodexProvider(AgentProvider):
             "items": _dump_model(result.items),
             "usage": _dump_model(result.usage),
             "final_response": result.final_response,
+            "streamed_response": result.streamed_response,
+            "selected_response": selected_response,
         }
         return AgentOutput(
             content=content,

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -1,0 +1,737 @@
+"""OpenAI Codex SDK provider implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final
+
+from conductor.exceptions import ProviderError, ValidationError
+from conductor.executor.output import parse_json_output, validate_output
+from conductor.providers._event_format import extract_tool_result_text, format_tool_arguments
+from conductor.providers.base import AgentOutput, AgentProvider, EventCallback, match_model_id
+from conductor.providers.capabilities import ProviderCapabilities
+from conductor.providers.reasoning import ReasoningEffort, resolve_reasoning_effort
+
+if TYPE_CHECKING:
+    from conductor.config.schema import AgentDef, OutputField, ProviderSettings
+
+ApprovalMode: Any = None
+AsyncCodex: Any = None
+CodexConfig: Any = None
+CodexReasoningEffort: Any = None
+Sandbox: Any = None
+_codex_is_retryable_error: Any = None
+
+try:
+    _openai_codex = importlib.import_module("openai_codex")
+    _openai_codex_errors = importlib.import_module("openai_codex.errors")
+    _openai_codex_types = importlib.import_module("openai_codex.types")
+    ApprovalMode = _openai_codex.ApprovalMode
+    AsyncCodex = _openai_codex.AsyncCodex
+    CodexConfig = _openai_codex.CodexConfig
+    CodexReasoningEffort = _openai_codex_types.ReasoningEffort
+    Sandbox = _openai_codex.Sandbox
+    _codex_is_retryable_error = _openai_codex_errors.is_retryable_error
+    CODEX_SDK_AVAILABLE = True
+except ImportError:
+    CODEX_SDK_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL: Final[str] = "gpt-5.4"
+_TOOL_RESULT_PREVIEW_LEN: Final[int] = 500
+
+
+@dataclass(slots=True)
+class _CodexRunResult:
+    """Collected Codex turn result in Conductor-friendly form."""
+
+    turn_id: str
+    final_response: str
+    items: list[Any]
+    usage: Any | None
+    raw_turn: Any | None
+    partial: bool = False
+
+
+def _build_field_schema(field: OutputField, depth: int = 0) -> dict[str, Any]:
+    if depth > 10:
+        raise ProviderError("Output schema nesting exceeds 10 levels")
+
+    schema: dict[str, Any] = {"type": field.type}
+    if field.description:
+        schema["description"] = field.description
+    if field.type == "object" and field.properties:
+        schema["properties"] = _build_properties(field.properties, depth + 1)
+        schema["required"] = list(field.properties.keys())
+        schema["additionalProperties"] = False
+    if field.type == "array" and field.items:
+        schema["items"] = _build_field_schema(field.items, depth + 1)
+    return schema
+
+
+def _build_properties(fields: dict[str, OutputField], depth: int = 0) -> dict[str, Any]:
+    return {name: _build_field_schema(field, depth) for name, field in fields.items()}
+
+
+def _build_output_schema(output: dict[str, OutputField]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": _build_properties(output),
+        "required": list(output.keys()),
+        "additionalProperties": False,
+    }
+
+
+def _safe_callback(
+    event_callback: EventCallback | None,
+    event_type: str,
+    data: dict[str, Any],
+) -> None:
+    if event_callback is None:
+        return
+    try:
+        event_callback(event_type, data)
+    except Exception:
+        logger.debug("Error in event_callback for %s", event_type, exc_info=True)
+
+
+def _dump_model(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [_dump_model(item) for item in value]
+    if isinstance(value, tuple):
+        return [_dump_model(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _dump_model(v) for k, v in value.items()}
+    if hasattr(value, "model_dump"):
+        return value.model_dump(by_alias=True, exclude_none=True, mode="json")
+    if hasattr(value, "value"):
+        return value.value
+    return str(value)
+
+
+def _thread_item(item: Any) -> Any:
+    return getattr(item, "root", item)
+
+
+def _item_type(item: Any) -> str | None:
+    return getattr(_thread_item(item), "type", None)
+
+
+def _enum_value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _codex_effort(effort: ReasoningEffort | None) -> Any:
+    if effort is None or CodexReasoningEffort is None:
+        return effort
+    return {
+        "low": CodexReasoningEffort.low,
+        "medium": CodexReasoningEffort.medium,
+        "high": CodexReasoningEffort.high,
+        "xhigh": CodexReasoningEffort.xhigh,
+    }[effort]
+
+
+def _tool_name_from_item(item: Any) -> str | None:
+    root = _thread_item(item)
+    item_type = _item_type(root)
+    if item_type in {"mcpToolCall", "dynamicToolCall"}:
+        return getattr(root, "tool", None)
+    if item_type == "commandExecution":
+        command = getattr(root, "command", None)
+        return command or "shell"
+    if item_type == "collabAgentToolCall":
+        tool = getattr(root, "tool", None)
+        return _enum_value(tool) if tool is not None else "collab_agent"
+    return None
+
+
+def _final_response_from_items(items: list[Any], fallback: str) -> str:
+    last_unknown_phase: str | None = None
+    for item in reversed(items):
+        root = _thread_item(item)
+        if _item_type(root) != "agentMessage":
+            continue
+        text = getattr(root, "text", None)
+        if not isinstance(text, str):
+            continue
+        phase = _enum_value(getattr(root, "phase", None))
+        if phase == "final_answer":
+            return text
+        if phase is None and last_unknown_phase is None:
+            last_unknown_phase = text
+    return last_unknown_phase or fallback
+
+
+class CodexProvider(AgentProvider):
+    """OpenAI Codex provider backed by ``openai-codex`` and app-server."""
+
+    CAPABILITIES = ProviderCapabilities(
+        tier="experimental",
+        mcp_tools=True,
+        workflow_tools_passthrough=True,
+        streaming_events=True,
+        agent_reasoning_events=True,
+        reasoning_effort=("low", "medium", "high", "xhigh"),
+        structured_output="native",
+        interrupt=True,
+        max_session_seconds=True,
+        checkpoint_resume=True,
+        usage_tracking=True,
+        concurrent_safe=True,
+        upstream_pin="openai-codex==0.1.0b3",
+        maintainer="@microsoft/conductor",
+    )
+
+    def __init__(
+        self,
+        model: str | None = None,
+        mcp_servers: dict[str, Any] | None = None,
+        max_session_seconds: float | None = None,
+        default_reasoning_effort: ReasoningEffort | None = None,
+        provider_settings: ProviderSettings | None = None,
+    ) -> None:
+        if not CODEX_SDK_AVAILABLE:
+            raise ProviderError(
+                "OpenAI Codex SDK not installed",
+                suggestion="Install with: uv add --prerelease allow 'openai-codex==0.1.0b3'",
+            )
+
+        codex_options = (
+            provider_settings.codex
+            if provider_settings is not None and provider_settings.name == "codex"
+            else None
+        )
+        self._default_model = model or _DEFAULT_MODEL
+        self._mcp_servers = mcp_servers or {}
+        self._max_session_seconds = max_session_seconds
+        self._default_reasoning_effort = default_reasoning_effort
+        self._codex_bin = codex_options.codex_bin if codex_options else None
+        self._sandbox_name = codex_options.sandbox if codex_options else None
+        self._approval_mode_name = codex_options.approval_mode if codex_options else None
+        self._model_provider = codex_options.model_provider if codex_options else None
+        self._service_tier = codex_options.service_tier if codex_options else None
+        self._session_ids: dict[str, str] = {}
+        self._resume_session_ids: dict[str, str] = {}
+        self._model_effort_cache: dict[str, tuple[str, ...] | None] = {}
+
+    async def execute(
+        self,
+        agent: AgentDef,
+        context: dict[str, Any],
+        rendered_prompt: str,
+        tools: list[str] | None = None,
+        interrupt_signal: asyncio.Event | None = None,
+        event_callback: EventCallback | None = None,
+    ) -> AgentOutput:
+        del context
+        model = agent.model or self._default_model
+        effort = resolve_reasoning_effort(agent, self._default_reasoning_effort)
+        output_schema = _build_output_schema(agent.output) if agent.output else None
+        max_session_seconds = (
+            agent.max_session_seconds
+            if agent.max_session_seconds is not None
+            else self._max_session_seconds
+        )
+
+        try:
+            async with self._new_codex() as codex:
+                if effort is not None:
+                    await self._validate_reasoning_effort_for_model(codex, model, effort)
+                thread = await self._start_or_resume_thread(codex, agent, model, tools)
+                result = await self._run_turn(
+                    thread=thread,
+                    agent=agent,
+                    rendered_prompt=rendered_prompt,
+                    model=model,
+                    effort=effort,
+                    output_schema=output_schema,
+                    max_session_seconds=max_session_seconds,
+                    interrupt_signal=interrupt_signal,
+                    event_callback=event_callback,
+                )
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"Codex execution failed for agent '{agent.name}': {exc}",
+                provider_name="codex",
+                is_retryable=self._is_retryable_error(exc),
+            ) from exc
+
+        return self._build_agent_output(result, agent, model)
+
+    async def execute_dialog_turn(
+        self,
+        system_prompt: str,
+        user_message: str,
+        history: list[dict[str, str]] | None = None,
+        model: str | None = None,
+    ) -> str:
+        prompt_parts: list[str] = []
+        for entry in history or []:
+            role = entry.get("role", "user")
+            content = entry.get("content", "")
+            prompt_parts.append(f"{role}: {content}")
+        prompt_parts.append(f"user: {user_message}")
+        prompt = "\n\n".join(prompt_parts)
+        selected_model = model or self._default_model
+
+        try:
+            async with self._new_codex() as codex:
+                thread = await codex.thread_start(
+                    developer_instructions=system_prompt or None,
+                    model=selected_model,
+                    model_provider=self._model_provider,
+                    cwd=os.getcwd(),
+                    sandbox=self._sandbox(),
+                    service_tier=self._service_tier,
+                    **self._approval_kwargs(),
+                )
+                result = await thread.run(
+                    prompt,
+                    model=selected_model,
+                    service_tier=self._service_tier,
+                )
+                return result.final_response or ""
+        except Exception as exc:
+            raise ProviderError(
+                f"Codex dialog turn failed: {exc}",
+                provider_name="codex",
+                is_retryable=self._is_retryable_error(exc),
+            ) from exc
+
+    async def validate_connection(self) -> bool:
+        try:
+            async with self._new_codex() as codex:
+                account = await codex.account(refresh_token=False)
+                return not bool(getattr(account, "requires_openai_auth", False))
+        except Exception as exc:
+            logger.debug("Codex validate_connection failed: %s", exc, exc_info=True)
+            return False
+
+    async def close(self) -> None:
+        """Release provider resources.
+
+        Codex clients are scoped to individual executions, so there is no
+        persistent app-server process to close here.
+        """
+
+    def get_session_ids(self) -> dict[str, str]:
+        """Return tracked Codex thread IDs by agent name."""
+        return self._session_ids.copy()
+
+    def set_resume_session_ids(self, ids: dict[str, str]) -> None:
+        """Set Codex thread IDs to attempt on future executions."""
+        self._resume_session_ids = dict(ids)
+
+    def _new_codex(self) -> Any:
+        if AsyncCodex is None or CodexConfig is None:
+            raise ProviderError(
+                "OpenAI Codex SDK not installed",
+                suggestion="Install with: uv add --prerelease allow 'openai-codex==0.1.0b3'",
+            )
+        config = CodexConfig(
+            codex_bin=self._codex_bin,
+            cwd=os.getcwd(),
+            client_name="conductor",
+            client_title="Conductor",
+        )
+        return AsyncCodex(config)
+
+    async def _start_or_resume_thread(
+        self,
+        codex: Any,
+        agent: AgentDef,
+        model: str,
+        tools: list[str] | None,
+    ) -> Any:
+        kwargs = self._thread_kwargs(agent, model, tools)
+        resume_thread_id = self._resume_session_ids.get(agent.name)
+        if resume_thread_id:
+            try:
+                thread = await codex.thread_resume(resume_thread_id, **kwargs)
+                logger.info("Resumed Codex thread %s for agent '%s'", resume_thread_id, agent.name)
+                self._session_ids[agent.name] = thread.id
+                return thread
+            except Exception as exc:
+                logger.warning(
+                    "Could not resume Codex thread %s for agent '%s': %s. "
+                    "Falling back to a new thread.",
+                    resume_thread_id,
+                    agent.name,
+                    exc,
+                )
+
+        thread = await codex.thread_start(ephemeral=False, **kwargs)
+        self._session_ids[agent.name] = thread.id
+        return thread
+
+    def _thread_kwargs(
+        self,
+        agent: AgentDef,
+        model: str,
+        tools: list[str] | None,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "developer_instructions": agent.system_prompt,
+            "model": model,
+            "model_provider": self._model_provider,
+            "cwd": os.getcwd(),
+            "sandbox": self._sandbox(),
+            "service_tier": self._service_tier,
+            "config": self._codex_config_for_agent(agent, tools),
+        }
+        kwargs.update(self._approval_kwargs())
+        return {key: value for key, value in kwargs.items() if value is not None}
+
+    def _approval_kwargs(self) -> dict[str, Any]:
+        if self._approval_mode_name is None or ApprovalMode is None:
+            return {}
+        return {
+            "approval_mode": {
+                "deny_all": ApprovalMode.deny_all,
+                "auto_review": ApprovalMode.auto_review,
+            }[self._approval_mode_name]
+        }
+
+    def _sandbox(self) -> Any:
+        if self._sandbox_name is None or Sandbox is None:
+            return None
+        return {
+            "read-only": Sandbox.read_only,
+            "workspace-write": Sandbox.workspace_write,
+            "full-access": Sandbox.full_access,
+        }[self._sandbox_name]
+
+    def _codex_config_for_agent(
+        self,
+        agent: AgentDef,
+        tools: list[str] | None,
+    ) -> dict[str, Any] | None:
+        if not self._mcp_servers:
+            return None
+
+        mcp_servers: dict[str, Any] = {}
+        for server_name, server_config in self._mcp_servers.items():
+            codex_server = self._codex_mcp_server_config(server_config)
+            enabled_tools = self._enabled_tools_for_server(server_name, server_config, agent, tools)
+            if enabled_tools is not None:
+                codex_server["enabled_tools"] = enabled_tools
+            if agent.tools == []:
+                codex_server["enabled"] = False
+            mcp_servers[server_name] = codex_server
+
+        return {"mcp_servers": mcp_servers}
+
+    def _codex_mcp_server_config(self, server_config: dict[str, Any]) -> dict[str, Any]:
+        server_type = server_config.get("type", "stdio")
+        if server_type == "stdio":
+            codex_server: dict[str, Any] = {
+                "command": server_config.get("command"),
+                "args": server_config.get("args", []),
+            }
+            if server_config.get("env"):
+                codex_server["env"] = server_config["env"]
+        else:
+            codex_server = {"url": server_config.get("url")}
+            if server_config.get("headers"):
+                codex_server["http_headers"] = server_config["headers"]
+
+        timeout_ms = server_config.get("timeout")
+        if timeout_ms:
+            timeout_sec = max(1, int(round(float(timeout_ms) / 1000.0)))
+            codex_server["startup_timeout_sec"] = timeout_sec
+            codex_server["tool_timeout_sec"] = timeout_sec
+        return {key: value for key, value in codex_server.items() if value is not None}
+
+    def _enabled_tools_for_server(
+        self,
+        server_name: str,
+        server_config: dict[str, Any],
+        agent: AgentDef,
+        tools: list[str] | None,
+    ) -> list[str] | None:
+        server_tools = server_config.get("tools") or ["*"]
+        server_allows_all = "*" in server_tools
+
+        if agent.tools == []:
+            return []
+        if agent.tools is None:
+            return None if server_allows_all else list(server_tools)
+
+        requested = tools or []
+        if "*" in requested:
+            return None if server_allows_all else list(server_tools)
+
+        enabled: list[str] = []
+        prefix = f"{server_name}__"
+        for tool_name in requested:
+            if tool_name.startswith(prefix):
+                enabled.append(tool_name[len(prefix) :])
+            elif "__" not in tool_name:
+                enabled.append(tool_name)
+
+        if not server_allows_all:
+            allowed = set(server_tools)
+            enabled = [name for name in enabled if name in allowed]
+
+        return sorted(set(enabled))
+
+    async def _run_turn(
+        self,
+        *,
+        thread: Any,
+        agent: AgentDef,
+        rendered_prompt: str,
+        model: str,
+        effort: ReasoningEffort | None,
+        output_schema: dict[str, Any] | None,
+        max_session_seconds: float | None,
+        interrupt_signal: asyncio.Event | None,
+        event_callback: EventCallback | None,
+    ) -> _CodexRunResult:
+        _safe_callback(event_callback, "agent_turn_start", {"turn": "awaiting_model"})
+
+        turn = await thread.turn(
+            rendered_prompt,
+            model=model,
+            effort=_codex_effort(effort),
+            output_schema=output_schema,
+            sandbox=self._sandbox(),
+            service_tier=self._service_tier,
+            **self._approval_kwargs(),
+        )
+        stream = turn.stream()
+        items: list[Any] = []
+        usage: Any | None = None
+        completed_turn: Any | None = None
+        message_deltas: list[str] = []
+        started_turn_emitted = False
+        start_time = time.monotonic()
+
+        try:
+            while True:
+                if interrupt_signal is not None and interrupt_signal.is_set():
+                    await turn.interrupt()
+                    final_response = _final_response_from_items(items, "".join(message_deltas))
+                    return _CodexRunResult(
+                        turn_id=turn.id,
+                        final_response=final_response,
+                        items=items,
+                        usage=usage,
+                        raw_turn=completed_turn,
+                        partial=True,
+                    )
+
+                if (
+                    max_session_seconds is not None
+                    and time.monotonic() - start_time > max_session_seconds
+                ):
+                    await turn.interrupt()
+                    raise ProviderError(
+                        f"Agent '{agent.name}' exceeded maximum session duration "
+                        f"of {max_session_seconds:.0f}s",
+                        provider_name="codex",
+                        is_retryable=False,
+                    )
+
+                try:
+                    event = await asyncio.wait_for(anext(stream), timeout=0.25)
+                except TimeoutError:
+                    continue
+                except StopAsyncIteration:
+                    break
+
+                payload = event.payload
+                method = getattr(event, "method", "")
+
+                if method == "turn/started" and not started_turn_emitted:
+                    started_turn_emitted = True
+                    _safe_callback(event_callback, "agent_turn_start", {"turn": 1})
+                elif method == "item/agentMessage/delta":
+                    delta = getattr(payload, "delta", "")
+                    if delta:
+                        message_deltas.append(delta)
+                        _safe_callback(event_callback, "agent_message", {"content": delta})
+                elif method in {"item/reasoning/textDelta", "item/reasoning/summaryTextDelta"}:
+                    delta = getattr(payload, "delta", "")
+                    if delta:
+                        _safe_callback(event_callback, "agent_reasoning", {"content": delta})
+                elif method == "item/started":
+                    self._handle_item_started(payload, event_callback)
+                elif method == "item/completed":
+                    if getattr(payload, "turn_id", None) == turn.id:
+                        items.append(payload.item)
+                    self._handle_item_completed(payload, event_callback)
+                elif method == "thread/tokenUsage/updated":
+                    if getattr(payload, "turn_id", None) == turn.id:
+                        usage = getattr(payload, "token_usage", None)
+                elif method == "turn/completed":
+                    completed_turn = getattr(payload, "turn", None)
+                    break
+        finally:
+            await stream.aclose()
+
+        if completed_turn is None:
+            raise ProviderError(
+                f"Codex turn for agent '{agent.name}' ended without a completion event",
+                provider_name="codex",
+                is_retryable=True,
+            )
+
+        status = _enum_value(getattr(completed_turn, "status", None))
+        if status == "failed":
+            error = getattr(completed_turn, "error", None)
+            message = getattr(error, "message", None) or "Codex turn failed"
+            raise ProviderError(message, provider_name="codex", is_retryable=False)
+
+        final_response = _final_response_from_items(items, "".join(message_deltas))
+        return _CodexRunResult(
+            turn_id=turn.id,
+            final_response=final_response,
+            items=items,
+            usage=usage,
+            raw_turn=completed_turn,
+        )
+
+    def _handle_item_started(self, payload: Any, event_callback: EventCallback | None) -> None:
+        item = getattr(payload, "item", None)
+        tool_name = _tool_name_from_item(item)
+        if not tool_name:
+            return
+        arguments = getattr(_thread_item(item), "arguments", None)
+        try:
+            formatted_arguments = format_tool_arguments(arguments) if arguments else None
+        except Exception:
+            formatted_arguments = _dump_model(arguments)
+        _safe_callback(
+            event_callback,
+            "agent_tool_start",
+            {"tool_name": tool_name, "arguments": formatted_arguments},
+        )
+
+    def _handle_item_completed(self, payload: Any, event_callback: EventCallback | None) -> None:
+        item = getattr(payload, "item", None)
+        root = _thread_item(item)
+        tool_name = _tool_name_from_item(root)
+        if not tool_name:
+            return
+        result = getattr(root, "result", None) or getattr(root, "output", None)
+        error = getattr(root, "error", None)
+        if error is not None:
+            result_text = f"Error: {_dump_model(error)}"
+        else:
+            result_text = extract_tool_result_text(_dump_model(result)) or ""
+        _safe_callback(
+            event_callback,
+            "agent_tool_complete",
+            {
+                "tool_name": tool_name,
+                "result": result_text[:_TOOL_RESULT_PREVIEW_LEN],
+            },
+        )
+
+    def _build_agent_output(
+        self,
+        result: _CodexRunResult,
+        agent: AgentDef,
+        model: str,
+    ) -> AgentOutput:
+        content: dict[str, Any]
+        if agent.output:
+            try:
+                content = parse_json_output(result.final_response)
+            except ValidationError:
+                if not result.partial:
+                    raise
+                content = {"result": result.final_response}
+            if not result.partial:
+                validate_output(content, agent.output)
+        else:
+            content = {"result": result.final_response}
+
+        total_usage = getattr(result.usage, "total", None)
+        input_tokens = getattr(total_usage, "input_tokens", None)
+        output_tokens = getattr(total_usage, "output_tokens", None)
+        total_tokens = getattr(total_usage, "total_tokens", None)
+        cache_read_tokens = getattr(total_usage, "cached_input_tokens", None)
+        raw_response = {
+            "turn_id": result.turn_id,
+            "turn": _dump_model(result.raw_turn),
+            "items": _dump_model(result.items),
+            "usage": _dump_model(result.usage),
+            "final_response": result.final_response,
+        }
+        return AgentOutput(
+            content=content,
+            raw_response=raw_response,
+            tokens_used=total_tokens,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            model=model,
+            partial=result.partial,
+        )
+
+    async def _validate_reasoning_effort_for_model(
+        self,
+        codex: Any,
+        model: str,
+        effort: ReasoningEffort,
+    ) -> None:
+        supported = self._model_effort_cache.get(model)
+        if supported is None and model not in self._model_effort_cache:
+            try:
+                response = await codex.models()
+                model_entries = getattr(response, "models", None) or getattr(response, "data", [])
+                known_ids = [
+                    str(getattr(entry, "model", None) or getattr(entry, "id", ""))
+                    for entry in model_entries
+                ]
+                matched = match_model_id(model, [known_id for known_id in known_ids if known_id])
+                selected = next(
+                    (
+                        entry
+                        for entry in model_entries
+                        if matched in {getattr(entry, "model", None), getattr(entry, "id", None)}
+                    ),
+                    None,
+                )
+                if selected is None:
+                    self._model_effort_cache[model] = None
+                    return
+                efforts = getattr(selected, "supported_reasoning_efforts", None)
+                supported = (
+                    tuple(str(_enum_value(effort_option)) for effort_option in efforts)
+                    if efforts
+                    else None
+                )
+                self._model_effort_cache[model] = supported
+            except Exception:
+                logger.debug("Could not fetch Codex model capabilities", exc_info=True)
+                self._model_effort_cache[model] = None
+                return
+
+        if supported is not None and effort not in supported:
+            raise ValidationError(
+                f"Model {model!r} does not support reasoning.effort={effort!r}; "
+                f"supported values: {sorted(supported)}",
+                suggestion="Choose an effort listed in the model's capabilities.",
+            )
+
+    def _is_retryable_error(self, exc: BaseException) -> bool:
+        if _codex_is_retryable_error is None:
+            return False
+        try:
+            return bool(_codex_is_retryable_error(exc))
+        except Exception:
+            return False

--- a/src/conductor/providers/factory.py
+++ b/src/conductor/providers/factory.py
@@ -15,6 +15,7 @@ from conductor.providers.claude_agent_sdk import (
     CLAUDE_AGENT_SDK_AVAILABLE,
     ClaudeAgentSdkProvider,
 )
+from conductor.providers.codex import CODEX_SDK_AVAILABLE, CodexProvider
 from conductor.providers.copilot import CopilotProvider, IdleRecoveryConfig
 from conductor.providers.reasoning import ReasoningEffort
 
@@ -23,7 +24,9 @@ if TYPE_CHECKING:
 
 
 async def create_provider(
-    provider_type: Literal["copilot", "openai-agents", "claude", "claude-agent-sdk"] = "copilot",
+    provider_type: Literal[
+        "copilot", "openai-agents", "claude", "claude-agent-sdk", "codex"
+    ] = "copilot",
     validate: bool = True,
     mcp_servers: dict[str, Any] | None = None,
     default_model: str | None = None,
@@ -152,10 +155,53 @@ async def create_provider(
                 max_turns=max_agent_iterations,
                 max_session_seconds=max_session_seconds,
             )
+        case "codex":
+            if not CODEX_SDK_AVAILABLE:
+                raise ProviderError(
+                    "Codex provider requires the openai-codex SDK",
+                    suggestion=(
+                        "Install with: uv add --prerelease allow 'openai-codex==0.1.0b3'"
+                    ),
+                )
+            if temperature is not None:
+                raise ProviderError(
+                    f"codex does not support `temperature` (received {temperature!r}).",
+                    suggestion="Remove `runtime.temperature` for workflows that use codex.",
+                )
+            if max_tokens is not None:
+                raise ProviderError(
+                    f"codex does not support `max_tokens` (received {max_tokens!r}).",
+                    suggestion="Remove `runtime.max_tokens` for workflows that use codex.",
+                )
+            if timeout is not None:
+                raise ProviderError(
+                    f"codex does not support `timeout` (received {timeout!r}).",
+                    suggestion=(
+                        "Use `runtime.max_session_seconds`, per-agent "
+                        "`max_session_seconds`, or workflow `limits.timeout_seconds`."
+                    ),
+                )
+            if max_agent_iterations is not None:
+                raise ProviderError(
+                    "codex does not support `max_agent_iterations`.",
+                    suggestion=(
+                        "Remove `runtime.max_agent_iterations` for workflows that use codex."
+                    ),
+                )
+            provider = CodexProvider(
+                model=default_model,
+                mcp_servers=mcp_servers,
+                max_session_seconds=max_session_seconds,
+                default_reasoning_effort=default_reasoning_effort,
+                provider_settings=provider_settings,
+            )
         case _:
             raise ProviderError(
                 f"Unknown provider: {provider_type}",
-                suggestion="Valid providers are: copilot, openai-agents, claude, claude-agent-sdk",
+                suggestion=(
+                    "Valid providers are: copilot, openai-agents, claude, "
+                    "claude-agent-sdk, codex"
+                ),
             )
 
     if validate and not await provider.validate_connection():

--- a/src/conductor/providers/registry.py
+++ b/src/conductor/providers/registry.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from conductor.config.schema import AgentDef, WorkflowConfig
 
 
-ProviderType = Literal["copilot", "openai-agents", "claude", "claude-agent-sdk"]
+ProviderType = Literal["copilot", "openai-agents", "claude", "claude-agent-sdk", "codex"]
 
 
 class ProviderRegistry:
@@ -52,7 +52,7 @@ class ProviderRegistry:
         self._mcp_servers = mcp_servers
         self._providers: dict[ProviderType, AgentProvider] = {}
         self._default_provider_type: ProviderType = config.workflow.runtime.provider.name
-        self._resume_session_ids: dict[str, str] = {}
+        self._resume_session_ids_by_provider: dict[str, dict[str, str]] = {}
 
     @property
     def default_provider_type(self) -> ProviderType:
@@ -123,12 +123,16 @@ class ProviderRegistry:
             timeout=runtime.timeout,
             max_session_seconds=runtime.max_session_seconds,
             max_agent_iterations=runtime.max_agent_iterations,
+            default_reasoning_effort=runtime.default_reasoning_effort,
             provider_settings=provider_settings,
         )
 
-        # Pass stored resume session IDs to newly created providers
-        if self._resume_session_ids and hasattr(provider, "set_resume_session_ids"):
-            provider.set_resume_session_ids(self._resume_session_ids)  # type: ignore[union-attr]
+        # Pass stored resume session IDs to newly created providers. Session
+        # identifiers are provider-specific (Copilot session IDs, Codex thread
+        # IDs, etc.), so never forward another provider's IDs across the boundary.
+        resume_ids = self._resume_session_ids_by_provider.get(provider_type)
+        if resume_ids and hasattr(provider, "set_resume_session_ids"):
+            provider.set_resume_session_ids(resume_ids)  # type: ignore[union-attr]
 
         self._providers[provider_type] = provider
         return provider
@@ -181,16 +185,29 @@ class ProviderRegistry:
         return provider_type in self._providers
 
     def set_resume_session_ids(self, ids: dict[str, str]) -> None:
-        """Store session IDs for Copilot session resume.
+        """Store legacy Copilot session IDs for session resume.
 
-        The IDs are forwarded to providers that support
-        ``set_resume_session_ids`` — both already-active providers
-        and providers created lazily in the future.
+        Kept for compatibility with older checkpoint files and tests. New
+        callers should use :meth:`set_provider_resume_session_ids`.
 
         Args:
             ids: Mapping of agent names to Copilot session IDs.
         """
-        self._resume_session_ids = dict(ids)
-        for provider in self._providers.values():
-            if hasattr(provider, "set_resume_session_ids"):
-                provider.set_resume_session_ids(ids)  # type: ignore[union-attr]
+        self.set_provider_resume_session_ids({"copilot": ids})
+
+    def set_provider_resume_session_ids(self, ids_by_provider: dict[str, dict[str, str]]) -> None:
+        """Store provider-specific session IDs for workflow resume.
+
+        Args:
+            ids_by_provider: Mapping of provider name to that provider's
+                ``{agent_name: session_or_thread_id}`` mapping.
+        """
+        self._resume_session_ids_by_provider = {
+            provider_name: dict(ids)
+            for provider_name, ids in ids_by_provider.items()
+            if ids
+        }
+        for provider_type, provider in self._providers.items():
+            resume_ids = self._resume_session_ids_by_provider.get(provider_type)
+            if resume_ids and hasattr(provider, "set_resume_session_ids"):
+                provider.set_resume_session_ids(resume_ids)  # type: ignore[union-attr]

--- a/tests/test_config/test_backward_compatibility.py
+++ b/tests/test_config/test_backward_compatibility.py
@@ -43,8 +43,8 @@ def get_copilot_example_files() -> list[Path]:
     copilot_examples = []
 
     for example in all_examples:
-        # Skip Claude-specific examples
-        if "claude" in example.name.lower():
+        # Skip provider-specific examples that are not Copilot.
+        if "claude" in example.name.lower() or "codex" in example.name.lower():
             continue
 
         copilot_examples.append(example)

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -399,6 +399,31 @@ class TestRuntimeConfig:
         assert config.provider.name == "claude"
         assert config.temperature == 0.7
 
+    def test_codex_provider_with_options(self) -> None:
+        """Test Codex provider structured options."""
+        config = RuntimeConfig(
+            provider={
+                "name": "codex",
+                "codex": {
+                    "codex_bin": "/usr/local/bin/codex",
+                    "sandbox": "workspace-write",
+                    "approval_mode": "auto_review",
+                    "model_provider": "openai",
+                    "service_tier": "priority",
+                },
+            }
+        )
+        assert config.provider.name == "codex"
+        assert config.provider.codex is not None
+        assert config.provider.codex.codex_bin == "/usr/local/bin/codex"
+        assert config.provider.codex.sandbox == "workspace-write"
+        assert config.provider.codex.approval_mode == "auto_review"
+
+    def test_codex_options_rejected_for_other_provider(self) -> None:
+        """Codex-specific provider options cannot be attached to another provider."""
+        with pytest.raises(ValidationError, match="only supported when name='codex'"):
+            RuntimeConfig(provider={"name": "copilot", "codex": {"sandbox": "read-only"}})
+
     def test_temperature_boundary_values(self) -> None:
         """Test temperature field accepts boundary values."""
         # Lower bound

--- a/tests/test_engine/test_checkpoint.py
+++ b/tests/test_engine/test_checkpoint.py
@@ -274,6 +274,64 @@ class TestSaveCheckpoint:
         assert path is not None
         data = json.loads(path.read_text())
         assert data["copilot_session_ids"] == {"agent_a": "sid-123"}
+        assert data["provider_session_ids"] == {"copilot": {"agent_a": "sid-123"}}
+
+    def test_provider_session_ids_roundtrip(self, tmp_path: Path) -> None:
+        wf = _write_workflow(tmp_path)
+        ctx = _make_context()
+        limits = _make_limits()
+        error = RuntimeError("err")
+
+        with patch.object(CheckpointManager, "get_checkpoints_dir", return_value=tmp_path):
+            path = CheckpointManager.save_checkpoint(
+                wf,
+                ctx,
+                limits,
+                "a",
+                error,
+                {},
+                provider_session_ids={
+                    "copilot": {"agent_a": "sid-123"},
+                    "codex": {"agent_b": "thread-456"},
+                },
+            )
+
+        assert path is not None
+        data = json.loads(path.read_text())
+        assert data["provider_session_ids"] == {
+            "copilot": {"agent_a": "sid-123"},
+            "codex": {"agent_b": "thread-456"},
+        }
+        assert data["copilot_session_ids"] == {"agent_a": "sid-123"}
+
+        cp = CheckpointManager.load_checkpoint(path)
+        assert cp.provider_session_ids["codex"] == {"agent_b": "thread-456"}
+        assert cp.provider_session_ids["copilot"] == {"agent_a": "sid-123"}
+
+    def test_legacy_copilot_session_ids_project_to_provider_session_ids(
+        self, tmp_path: Path
+    ) -> None:
+        wf = _write_workflow(tmp_path)
+        checkpoint_path = tmp_path / "legacy.json"
+        checkpoint_path.write_text(
+            json.dumps(
+                {
+                    "version": CheckpointManager.CHECKPOINT_VERSION,
+                    "workflow_path": str(wf),
+                    "workflow_hash": "sha256:abc",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "failure": {"error_type": "RuntimeError", "message": "err"},
+                    "current_agent": "agent_a",
+                    "context": _make_context().to_dict(),
+                    "limits": _make_limits().to_dict(),
+                    "copilot_session_ids": {"agent_a": "sid-123"},
+                }
+            )
+        )
+
+        cp = CheckpointManager.load_checkpoint(checkpoint_path)
+        assert cp.copilot_session_ids == {"agent_a": "sid-123"}
+        assert cp.provider_session_ids == {"copilot": {"agent_a": "sid-123"}}
 
     def test_run_id_and_event_log_path_included(self, tmp_path: Path) -> None:
         """``run_id`` and ``event_log_path`` round-trip through save+load.

--- a/tests/test_executor/test_output.py
+++ b/tests/test_executor/test_output.py
@@ -282,6 +282,19 @@ class TestParseJsonOutput:
 
         assert result == {"code": "use ```fenced``` blocks", "n": 1}
 
+    def test_parse_raw_json_with_markdown_fence_inside_string(self) -> None:
+        """Raw JSON may contain fenced code blocks inside string fields."""
+        raw = (
+            '{"passed": false, "details": "Preferred:\\n'
+            '```python\\ndef add(a, b):\\n    return a + b\\n```"}'
+        )
+        result = parse_json_output(raw)
+
+        assert result == {
+            "passed": False,
+            "details": "Preferred:\n```python\ndef add(a, b):\n    return a + b\n```",
+        }
+
     def test_parse_json_with_multiple_fenced_blocks_first_wins(self) -> None:
         """When the response contains multiple fenced JSON blocks, the first
         valid block wins.

--- a/tests/test_providers/test_capabilities.py
+++ b/tests/test_providers/test_capabilities.py
@@ -152,12 +152,13 @@ class TestResolver:
         assert "copilot" in names
         assert "claude" in names
         assert "claude-agent-sdk" in names
+        assert "codex" in names
 
     def test_unknown_provider_raises_keyerror(self) -> None:
         with pytest.raises(KeyError, match="Unknown provider"):
             get_capabilities("nonexistent-provider")
 
-    @pytest.mark.parametrize("provider_name", ["copilot", "claude", "claude-agent-sdk"])
+    @pytest.mark.parametrize("provider_name", ["copilot", "claude", "claude-agent-sdk", "codex"])
     def test_every_production_provider_has_capabilities(self, provider_name: str) -> None:
         """Hard requirement: every provider in the registry declares CAPABILITIES.
 

--- a/tests/test_providers/test_codex.py
+++ b/tests/test_providers/test_codex.py
@@ -57,8 +57,60 @@ class _FakeTurn:
         return self._iter_events()
 
 
+class _BlockingStream:
+    """Async stream that reproduces close-while-anext-is-pending failures."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.closed = False
+
+    def __aiter__(self) -> _BlockingStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        self.started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            await asyncio.sleep(0)
+            raise
+        raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        if not self.cancelled.is_set():
+            raise RuntimeError("aclose(): asynchronous generator is already running")
+        self.closed = True
+
+
+class _BlockingTurn:
+    id = "turn-blocking"
+    thread_id = "thread-new"
+
+    def __init__(self, stream: _BlockingStream) -> None:
+        self._stream = stream
+        self.interrupted = False
+
+    async def interrupt(self) -> None:
+        self.interrupted = True
+
+    def stream(self) -> _BlockingStream:
+        return self._stream
+
+
+class _BlockingThread:
+    def __init__(self, turn: _BlockingTurn) -> None:
+        self.id = "thread-new"
+        self.turn_obj = turn
+
+    async def turn(self, _input_text: str, **_kwargs: Any) -> _BlockingTurn:
+        return self.turn_obj
+
+
 class _FakeThread:
     last_turn_kwargs: dict[str, Any] = {}
+    next_events: list[Any] | None = None
     event_delay: float = 0.0
 
     def __init__(self, thread_id: str = "thread-new") -> None:
@@ -66,6 +118,11 @@ class _FakeThread:
 
     async def turn(self, input_text: str, **kwargs: Any) -> _FakeTurn:
         _FakeThread.last_turn_kwargs = {"input": input_text, **kwargs}
+        if _FakeThread.next_events is not None:
+            events = _FakeThread.next_events
+            _FakeThread.next_events = None
+            return _FakeTurn(events, event_delay=self.event_delay)
+
         agent_message = SimpleNamespace(
             type="agentMessage",
             phase=SimpleNamespace(value="final_answer"),
@@ -113,6 +170,7 @@ class _FakeAsyncCodex:
     last_thread_start_kwargs: dict[str, Any] = {}
     last_thread_resume_kwargs: dict[str, Any] = {}
     account_response: Any = SimpleNamespace(requires_openai_auth=False)
+    last_account_refresh_token: bool | None = None
 
     def __init__(self, config: Any | None = None) -> None:
         self.config = config
@@ -124,6 +182,7 @@ class _FakeAsyncCodex:
         return None
 
     async def account(self, *, refresh_token: bool = False) -> Any:
+        _FakeAsyncCodex.last_account_refresh_token = refresh_token
         return self.account_response
 
     async def models(self) -> Any:
@@ -154,6 +213,11 @@ class _FakeAsyncCodex:
 @pytest.fixture(autouse=True)
 def fake_codex_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
     _FakeAsyncCodex.account_response = SimpleNamespace(requires_openai_auth=False)
+    _FakeAsyncCodex.last_account_refresh_token = None
+    _FakeAsyncCodex.last_thread_start_kwargs = {}
+    _FakeAsyncCodex.last_thread_resume_kwargs = {}
+    _FakeThread.last_turn_kwargs = {}
+    _FakeThread.next_events = None
     _FakeThread.event_delay = 0.0
     monkeypatch.setattr(codex_module, "CODEX_SDK_AVAILABLE", True)
     monkeypatch.setattr(codex_module, "AsyncCodex", _FakeAsyncCodex)
@@ -210,6 +274,223 @@ async def test_execute_does_not_cancel_codex_stream_while_polling_interrupts() -
 
 
 @pytest.mark.asyncio
+async def test_reasoning_deltas_are_buffered_until_next_non_reasoning_event() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+    agent = AgentDef(name="answerer", prompt="answer")
+    agent_message = SimpleNamespace(
+        type="agentMessage",
+        phase=SimpleNamespace(value="final_answer"),
+        text='{"answer": "42"}',
+    )
+    tool_item = SimpleNamespace(type="commandExecution", command="pwd")
+    _FakeThread.next_events = [
+        SimpleNamespace(method="turn/started", payload=SimpleNamespace()),
+        SimpleNamespace(
+            method="item/reasoning/textDelta",
+            payload=SimpleNamespace(delta="I"),
+        ),
+        SimpleNamespace(
+            method="item/reasoning/textDelta",
+            payload=SimpleNamespace(delta=" need"),
+        ),
+        SimpleNamespace(
+            method="item/reasoning/textDelta",
+            payload=SimpleNamespace(delta=" to inspect"),
+        ),
+        SimpleNamespace(
+            method="item/started",
+            payload=SimpleNamespace(item=tool_item),
+        ),
+        SimpleNamespace(
+            method="item/agentMessage/delta",
+            payload=SimpleNamespace(delta='{"answer": "42"}'),
+        ),
+        SimpleNamespace(
+            method="item/completed",
+            payload=SimpleNamespace(turn_id="turn-1", item=agent_message),
+        ),
+        SimpleNamespace(
+            method="turn/completed",
+            payload=SimpleNamespace(
+                turn=SimpleNamespace(status=SimpleNamespace(value="completed"))
+            ),
+        ),
+    ]
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    result = await provider.execute(
+        agent=agent,
+        context={},
+        rendered_prompt="answer",
+        event_callback=lambda event_type, data: events.append((event_type, data)),
+    )
+
+    reasoning_events = [data for event_type, data in events if event_type == "agent_reasoning"]
+    event_types = [event_type for event_type, _ in events]
+    assert result.content == {"result": '{"answer": "42"}'}
+    assert reasoning_events == [{"content": "I need to inspect"}]
+    assert event_types.index("agent_reasoning") < event_types.index("agent_tool_start")
+    assert event_types.index("agent_reasoning") < event_types.index("agent_message")
+
+
+@pytest.mark.asyncio
+async def test_reasoning_deltas_ignore_token_usage_updates_until_visible_boundary() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+    agent = AgentDef(name="answerer", prompt="answer")
+    agent_message = SimpleNamespace(
+        type="agentMessage",
+        phase=SimpleNamespace(value="final_answer"),
+        text='{"answer": "42"}',
+    )
+    usage = SimpleNamespace(total=SimpleNamespace(total_tokens=3))
+    _FakeThread.next_events = [
+        SimpleNamespace(method="turn/started", payload=SimpleNamespace()),
+        SimpleNamespace(
+            method="item/reasoning/textDelta",
+            payload=SimpleNamespace(
+                delta="I",
+                item_id="reasoning-1",
+                content_index=0,
+            ),
+        ),
+        SimpleNamespace(
+            method="thread/tokenUsage/updated",
+            payload=SimpleNamespace(turn_id="turn-1", token_usage=usage),
+        ),
+        SimpleNamespace(
+            method="item/reasoning/textDelta",
+            payload=SimpleNamespace(
+                delta=" need",
+                item_id="reasoning-1",
+                content_index=0,
+            ),
+        ),
+        SimpleNamespace(
+            method="thread/tokenUsage/updated",
+            payload=SimpleNamespace(turn_id="turn-1", token_usage=usage),
+        ),
+        SimpleNamespace(
+            method="item/reasoning/textDelta",
+            payload=SimpleNamespace(
+                delta=" to inspect",
+                item_id="reasoning-1",
+                content_index=0,
+            ),
+        ),
+        SimpleNamespace(
+            method="item/agentMessage/delta",
+            payload=SimpleNamespace(delta='{"answer": "42"}'),
+        ),
+        SimpleNamespace(
+            method="item/completed",
+            payload=SimpleNamespace(turn_id="turn-1", item=agent_message),
+        ),
+        SimpleNamespace(
+            method="turn/completed",
+            payload=SimpleNamespace(
+                turn=SimpleNamespace(status=SimpleNamespace(value="completed"))
+            ),
+        ),
+    ]
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    await provider.execute(
+        agent=agent,
+        context={},
+        rendered_prompt="answer",
+        event_callback=lambda event_type, data: events.append((event_type, data)),
+    )
+
+    reasoning_events = [data for event_type, data in events if event_type == "agent_reasoning"]
+    event_types = [event_type for event_type, _ in events]
+    assert reasoning_events == [{"content": "I need to inspect"}]
+    assert event_types.index("agent_reasoning") < event_types.index("agent_message")
+
+
+@pytest.mark.asyncio
+async def test_reasoning_delta_method_change_flushes_current_buffer() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+    agent = AgentDef(name="answerer", prompt="answer")
+    agent_message = SimpleNamespace(
+        type="agentMessage",
+        phase=SimpleNamespace(value="final_answer"),
+        text='{"answer": "42"}',
+    )
+    _FakeThread.next_events = [
+        SimpleNamespace(method="turn/started", payload=SimpleNamespace()),
+        SimpleNamespace(
+            method="item/reasoning/textDelta",
+            payload=SimpleNamespace(delta="private text"),
+        ),
+        SimpleNamespace(
+            method="item/reasoning/summaryTextDelta",
+            payload=SimpleNamespace(delta="summary text"),
+        ),
+        SimpleNamespace(
+            method="item/agentMessage/delta",
+            payload=SimpleNamespace(delta='{"answer": "42"}'),
+        ),
+        SimpleNamespace(
+            method="item/completed",
+            payload=SimpleNamespace(turn_id="turn-1", item=agent_message),
+        ),
+        SimpleNamespace(
+            method="turn/completed",
+            payload=SimpleNamespace(
+                turn=SimpleNamespace(status=SimpleNamespace(value="completed"))
+            ),
+        ),
+    ]
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    await provider.execute(
+        agent=agent,
+        context={},
+        rendered_prompt="answer",
+        event_callback=lambda event_type, data: events.append((event_type, data)),
+    )
+
+    reasoning_contents = [
+        data["content"] for event_type, data in events if event_type == "agent_reasoning"
+    ]
+    event_types = [event_type for event_type, _ in events]
+    assert reasoning_contents == ["private text", "summary text"]
+    assert event_types.index("agent_reasoning") < event_types.index("agent_message")
+
+
+@pytest.mark.asyncio
+async def test_run_turn_awaits_cancelled_stream_task_before_close() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+    agent = AgentDef(name="answerer", prompt="answer")
+    stream = _BlockingStream()
+    turn = _BlockingTurn(stream)
+    interrupt_signal = asyncio.Event()
+
+    async def interrupt_after_stream_starts() -> None:
+        await stream.started.wait()
+        interrupt_signal.set()
+
+    trigger = asyncio.create_task(interrupt_after_stream_starts())
+
+    result = await provider._run_turn(
+        thread=_BlockingThread(turn),
+        agent=agent,
+        rendered_prompt="answer",
+        model="gpt-5.4",
+        effort=None,
+        output_schema=None,
+        max_session_seconds=None,
+        interrupt_signal=interrupt_signal,
+        event_callback=None,
+    )
+    await trigger
+
+    assert result.partial is True
+    assert turn.interrupted is True
+    assert stream.closed is True
+
+
+@pytest.mark.asyncio
 async def test_resume_thread_id_is_used() -> None:
     provider = CodexProvider(model="gpt-5.4")
     provider.set_resume_session_ids({"answerer": "thread-old"})
@@ -252,11 +533,49 @@ def test_mcp_config_translates_agent_tool_filter() -> None:
     }
 
 
+def test_final_response_uses_stream_fallback_for_blank_completed_message() -> None:
+    completed_item = SimpleNamespace(
+        type="agentMessage",
+        phase=SimpleNamespace(value="final_answer"),
+        text="",
+    )
+
+    response = codex_module._final_response_from_items(
+        [completed_item],
+        '{"answer": "42"}',
+    )
+
+    assert response == '{"answer": "42"}'
+
+
+def test_build_agent_output_falls_back_to_streamed_json() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+    agent = AgentDef(
+        name="answerer",
+        prompt="answer",
+        output={"answer": OutputField(type="string")},
+    )
+    result = codex_module._CodexRunResult(
+        turn_id="turn-1",
+        final_response="not json",
+        streamed_response='{"answer": "42"}',
+        items=[],
+        usage=None,
+        raw_turn=None,
+    )
+
+    output = provider._build_agent_output(result, agent, "gpt-5.4")
+
+    assert output.content == {"answer": "42"}
+    assert output.raw_response["selected_response"] == '{"answer": "42"}'
+
+
 @pytest.mark.asyncio
 async def test_validate_connection_uses_account_state() -> None:
     provider = CodexProvider(model="gpt-5.4")
 
     assert await provider.validate_connection() is True
+    assert _FakeAsyncCodex.last_account_refresh_token is True
 
 
 @pytest.mark.asyncio
@@ -268,6 +587,7 @@ async def test_validate_connection_accepts_chatgpt_account_requiring_openai_auth
     provider = CodexProvider(model="gpt-5.4")
 
     assert await provider.validate_connection() is True
+    assert _FakeAsyncCodex.last_account_refresh_token is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_providers/test_codex.py
+++ b/tests/test_providers/test_codex.py
@@ -1,0 +1,250 @@
+"""Unit tests for the OpenAI Codex provider."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from conductor.config.schema import AgentDef, OutputField
+from conductor.providers import codex as codex_module
+from conductor.providers.codex import CodexProvider
+
+
+class _FakeCodexConfig:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+class _FakeSandbox:
+    read_only = "read-only"
+    workspace_write = "workspace-write"
+    full_access = "full-access"
+
+
+class _FakeApprovalMode:
+    deny_all = "deny_all"
+    auto_review = "auto_review"
+
+
+class _FakeReasoningEffort:
+    low = "low"
+    medium = "medium"
+    high = "high"
+    xhigh = "xhigh"
+
+
+class _FakeTurn:
+    def __init__(self, events: list[Any]) -> None:
+        self.id = "turn-1"
+        self.thread_id = "thread-new"
+        self._events = events
+        self.interrupted = False
+
+    async def interrupt(self) -> None:
+        self.interrupted = True
+
+    async def _iter_events(self):
+        for event in self._events:
+            yield event
+
+    def stream(self):
+        return self._iter_events()
+
+
+class _FakeThread:
+    last_turn_kwargs: dict[str, Any] = {}
+
+    def __init__(self, thread_id: str = "thread-new") -> None:
+        self.id = thread_id
+
+    async def turn(self, input_text: str, **kwargs: Any) -> _FakeTurn:
+        _FakeThread.last_turn_kwargs = {"input": input_text, **kwargs}
+        agent_message = SimpleNamespace(
+            type="agentMessage",
+            phase=SimpleNamespace(value="final_answer"),
+            text='{"answer": "42"}',
+        )
+        usage = SimpleNamespace(
+            total=SimpleNamespace(
+                input_tokens=3,
+                output_tokens=4,
+                total_tokens=7,
+                cached_input_tokens=1,
+            )
+        )
+        events = [
+            SimpleNamespace(method="turn/started", payload=SimpleNamespace()),
+            SimpleNamespace(
+                method="item/reasoning/textDelta",
+                payload=SimpleNamespace(delta="thinking"),
+            ),
+            SimpleNamespace(
+                method="item/agentMessage/delta",
+                payload=SimpleNamespace(delta='{"answer": "42"}'),
+            ),
+            SimpleNamespace(
+                method="item/completed",
+                payload=SimpleNamespace(turn_id="turn-1", item=agent_message),
+            ),
+            SimpleNamespace(
+                method="thread/tokenUsage/updated",
+                payload=SimpleNamespace(turn_id="turn-1", token_usage=usage),
+            ),
+            SimpleNamespace(
+                method="turn/completed",
+                payload=SimpleNamespace(turn=SimpleNamespace(status=SimpleNamespace(value="completed"))),
+            ),
+        ]
+        return _FakeTurn(events)
+
+    async def run(self, input_text: str, **kwargs: Any) -> Any:
+        _FakeThread.last_turn_kwargs = {"input": input_text, **kwargs}
+        return SimpleNamespace(final_response="dialog response")
+
+
+class _FakeAsyncCodex:
+    last_thread_start_kwargs: dict[str, Any] = {}
+    last_thread_resume_kwargs: dict[str, Any] = {}
+
+    def __init__(self, config: Any | None = None) -> None:
+        self.config = config
+
+    async def __aenter__(self) -> _FakeAsyncCodex:
+        return self
+
+    async def __aexit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+        return None
+
+    async def account(self, *, refresh_token: bool = False) -> Any:
+        return SimpleNamespace(requires_openai_auth=False)
+
+    async def models(self) -> Any:
+        return SimpleNamespace(
+            models=[
+                SimpleNamespace(
+                    id="gpt-5.4",
+                    model="gpt-5.4",
+                    supported_reasoning_efforts=[
+                        SimpleNamespace(value="low"),
+                        SimpleNamespace(value="medium"),
+                        SimpleNamespace(value="high"),
+                        SimpleNamespace(value="xhigh"),
+                    ],
+                )
+            ]
+        )
+
+    async def thread_start(self, **kwargs: Any) -> _FakeThread:
+        _FakeAsyncCodex.last_thread_start_kwargs = kwargs
+        return _FakeThread()
+
+    async def thread_resume(self, thread_id: str, **kwargs: Any) -> _FakeThread:
+        _FakeAsyncCodex.last_thread_resume_kwargs = {"thread_id": thread_id, **kwargs}
+        return _FakeThread(thread_id)
+
+
+@pytest.fixture(autouse=True)
+def fake_codex_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(codex_module, "CODEX_SDK_AVAILABLE", True)
+    monkeypatch.setattr(codex_module, "AsyncCodex", _FakeAsyncCodex)
+    monkeypatch.setattr(codex_module, "CodexConfig", _FakeCodexConfig)
+    monkeypatch.setattr(codex_module, "CodexReasoningEffort", _FakeReasoningEffort)
+    monkeypatch.setattr(codex_module, "Sandbox", _FakeSandbox)
+    monkeypatch.setattr(codex_module, "ApprovalMode", _FakeApprovalMode)
+
+
+@pytest.mark.asyncio
+async def test_execute_uses_native_output_schema_and_tracks_usage() -> None:
+    provider = CodexProvider(model="gpt-5.4", default_reasoning_effort="high")
+    agent = AgentDef(
+        name="answerer",
+        prompt="answer",
+        output={"answer": OutputField(type="string")},
+    )
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    result = await provider.execute(
+        agent=agent,
+        context={},
+        rendered_prompt="answer",
+        event_callback=lambda event_type, data: events.append((event_type, data)),
+    )
+
+    assert result.content == {"answer": "42"}
+    assert result.tokens_used == 7
+    assert result.input_tokens == 3
+    assert result.output_tokens == 4
+    assert result.cache_read_tokens == 1
+    assert result.model == "gpt-5.4"
+    assert provider.get_session_ids() == {"answerer": "thread-new"}
+    assert _FakeThread.last_turn_kwargs["effort"] == "high"
+    assert _FakeThread.last_turn_kwargs["output_schema"]["properties"]["answer"]["type"] == "string"
+    assert ("agent_turn_start", {"turn": "awaiting_model"}) in events
+    assert any(event_type == "agent_reasoning" for event_type, _ in events)
+    assert any(event_type == "agent_message" for event_type, _ in events)
+
+
+@pytest.mark.asyncio
+async def test_resume_thread_id_is_used() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+    provider.set_resume_session_ids({"answerer": "thread-old"})
+    agent = AgentDef(name="answerer", prompt="answer")
+
+    result = await provider.execute(agent=agent, context={}, rendered_prompt="answer")
+
+    assert result.content == {"result": '{"answer": "42"}'}
+    assert _FakeAsyncCodex.last_thread_resume_kwargs["thread_id"] == "thread-old"
+    assert provider.get_session_ids() == {"answerer": "thread-old"}
+
+
+def test_mcp_config_translates_agent_tool_filter() -> None:
+    provider = CodexProvider(
+        model="gpt-5.4",
+        mcp_servers={
+            "docs": {
+                "type": "stdio",
+                "command": "docs-server",
+                "args": ["--stdio"],
+                "tools": ["search", "read"],
+                "timeout": 2000,
+            }
+        },
+    )
+    agent = AgentDef(name="researcher", prompt="hi", tools=["docs__search"])
+
+    config = provider._codex_config_for_agent(agent, ["docs__search"])
+
+    assert config == {
+        "mcp_servers": {
+            "docs": {
+                "command": "docs-server",
+                "args": ["--stdio"],
+                "startup_timeout_sec": 2,
+                "tool_timeout_sec": 2,
+                "enabled_tools": ["search"],
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_connection_uses_account_state() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+
+    assert await provider.validate_connection() is True
+
+
+@pytest.mark.asyncio
+async def test_execute_dialog_turn() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+
+    result = await provider.execute_dialog_turn(
+        system_prompt="be brief",
+        user_message="hello",
+        history=[{"role": "assistant", "content": "previous"}],
+    )
+
+    assert result == "dialog response"
+    assert "assistant: previous" in _FakeThread.last_turn_kwargs["input"]

--- a/tests/test_providers/test_codex.py
+++ b/tests/test_providers/test_codex.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 
@@ -36,16 +37,19 @@ class _FakeReasoningEffort:
 
 
 class _FakeTurn:
-    def __init__(self, events: list[Any]) -> None:
+    def __init__(self, events: list[Any], event_delay: float = 0.0) -> None:
         self.id = "turn-1"
         self.thread_id = "thread-new"
         self._events = events
+        self._event_delay = event_delay
         self.interrupted = False
 
     async def interrupt(self) -> None:
         self.interrupted = True
 
     async def _iter_events(self):
+        if self._event_delay:
+            await asyncio.sleep(self._event_delay)
         for event in self._events:
             yield event
 
@@ -55,6 +59,7 @@ class _FakeTurn:
 
 class _FakeThread:
     last_turn_kwargs: dict[str, Any] = {}
+    event_delay: float = 0.0
 
     def __init__(self, thread_id: str = "thread-new") -> None:
         self.id = thread_id
@@ -97,7 +102,7 @@ class _FakeThread:
                 payload=SimpleNamespace(turn=SimpleNamespace(status=SimpleNamespace(value="completed"))),
             ),
         ]
-        return _FakeTurn(events)
+        return _FakeTurn(events, event_delay=self.event_delay)
 
     async def run(self, input_text: str, **kwargs: Any) -> Any:
         _FakeThread.last_turn_kwargs = {"input": input_text, **kwargs}
@@ -107,6 +112,7 @@ class _FakeThread:
 class _FakeAsyncCodex:
     last_thread_start_kwargs: dict[str, Any] = {}
     last_thread_resume_kwargs: dict[str, Any] = {}
+    account_response: Any = SimpleNamespace(requires_openai_auth=False)
 
     def __init__(self, config: Any | None = None) -> None:
         self.config = config
@@ -118,7 +124,7 @@ class _FakeAsyncCodex:
         return None
 
     async def account(self, *, refresh_token: bool = False) -> Any:
-        return SimpleNamespace(requires_openai_auth=False)
+        return self.account_response
 
     async def models(self) -> Any:
         return SimpleNamespace(
@@ -127,10 +133,10 @@ class _FakeAsyncCodex:
                     id="gpt-5.4",
                     model="gpt-5.4",
                     supported_reasoning_efforts=[
-                        SimpleNamespace(value="low"),
-                        SimpleNamespace(value="medium"),
-                        SimpleNamespace(value="high"),
-                        SimpleNamespace(value="xhigh"),
+                        SimpleNamespace(reasoning_effort=SimpleNamespace(value="low")),
+                        SimpleNamespace(reasoning_effort=SimpleNamespace(value="medium")),
+                        SimpleNamespace(reasoning_effort=SimpleNamespace(value="high")),
+                        SimpleNamespace(reasoning_effort=SimpleNamespace(value="xhigh")),
                     ],
                 )
             ]
@@ -147,6 +153,8 @@ class _FakeAsyncCodex:
 
 @pytest.fixture(autouse=True)
 def fake_codex_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeAsyncCodex.account_response = SimpleNamespace(requires_openai_auth=False)
+    _FakeThread.event_delay = 0.0
     monkeypatch.setattr(codex_module, "CODEX_SDK_AVAILABLE", True)
     monkeypatch.setattr(codex_module, "AsyncCodex", _FakeAsyncCodex)
     monkeypatch.setattr(codex_module, "CodexConfig", _FakeCodexConfig)
@@ -184,6 +192,21 @@ async def test_execute_uses_native_output_schema_and_tracks_usage() -> None:
     assert ("agent_turn_start", {"turn": "awaiting_model"}) in events
     assert any(event_type == "agent_reasoning" for event_type, _ in events)
     assert any(event_type == "agent_message" for event_type, _ in events)
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_cancel_codex_stream_while_polling_interrupts() -> None:
+    _FakeThread.event_delay = 0.3
+    provider = CodexProvider(model="gpt-5.4", default_reasoning_effort="medium")
+    agent = AgentDef(
+        name="answerer",
+        prompt="answer",
+        output={"answer": OutputField(type="string")},
+    )
+
+    result = await provider.execute(agent=agent, context={}, rendered_prompt="answer")
+
+    assert result.content == {"answer": "42"}
 
 
 @pytest.mark.asyncio
@@ -231,6 +254,17 @@ def test_mcp_config_translates_agent_tool_filter() -> None:
 
 @pytest.mark.asyncio
 async def test_validate_connection_uses_account_state() -> None:
+    provider = CodexProvider(model="gpt-5.4")
+
+    assert await provider.validate_connection() is True
+
+
+@pytest.mark.asyncio
+async def test_validate_connection_accepts_chatgpt_account_requiring_openai_auth() -> None:
+    _FakeAsyncCodex.account_response = SimpleNamespace(
+        account=SimpleNamespace(email="user@example.com"),
+        requires_openai_auth=True,
+    )
     provider = CodexProvider(model="gpt-5.4")
 
     assert await provider.validate_connection() is True

--- a/tests/test_providers/test_factory.py
+++ b/tests/test_providers/test_factory.py
@@ -1,7 +1,7 @@
 """Unit tests for the provider factory."""
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -154,6 +154,50 @@ class TestCreateProvider:
         assert "copilot" in suggestion
         assert "openai-agents" in suggestion
         assert "claude" in suggestion
+        assert "codex" in suggestion
+
+
+class TestCodexFactory:
+    """Tests for Codex provider factory wiring."""
+
+    @patch("conductor.providers.factory.CODEX_SDK_AVAILABLE", False)
+    @pytest.mark.asyncio
+    async def test_create_codex_provider_raises_when_sdk_not_available(self) -> None:
+        with pytest.raises(ProviderError, match="openai-codex SDK"):
+            await create_provider("codex", validate=False)
+
+    @patch("conductor.providers.factory.CODEX_SDK_AVAILABLE", True)
+    @patch("conductor.providers.factory.CodexProvider")
+    @pytest.mark.asyncio
+    async def test_create_codex_provider_success(self, mock_codex_provider: Any) -> None:
+        provider = MagicMock()
+        provider.validate_connection = AsyncMock(return_value=True)
+        mock_codex_provider.return_value = provider
+
+        result = await create_provider(
+            "codex",
+            validate=False,
+            default_model="gpt-5.4",
+            max_session_seconds=120.0,
+        )
+
+        assert result is provider
+        mock_codex_provider.assert_called_once()
+        kwargs = mock_codex_provider.call_args.kwargs
+        assert kwargs["model"] == "gpt-5.4"
+        assert kwargs["max_session_seconds"] == 120.0
+
+    @patch("conductor.providers.factory.CODEX_SDK_AVAILABLE", True)
+    @pytest.mark.asyncio
+    async def test_codex_rejects_unsupported_runtime_fields(self) -> None:
+        with pytest.raises(ProviderError, match="temperature"):
+            await create_provider("codex", validate=False, temperature=0.2)
+        with pytest.raises(ProviderError, match="max_tokens"):
+            await create_provider("codex", validate=False, max_tokens=100)
+        with pytest.raises(ProviderError, match="timeout"):
+            await create_provider("codex", validate=False, timeout=30.0)
+        with pytest.raises(ProviderError, match="max_agent_iterations"):
+            await create_provider("codex", validate=False, max_agent_iterations=5)
 
 
 class TestProviderValidation:

--- a/tests/test_providers/test_registry.py
+++ b/tests/test_providers/test_registry.py
@@ -331,6 +331,7 @@ class TestConfigPassing:
             timeout=60.0,
             max_session_seconds=None,
             max_agent_iterations=None,
+            default_reasoning_effort=None,
             provider_settings=config.workflow.runtime.provider,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -191,6 +191,10 @@ dependencies = [
 claude-agent-sdk = [
     { name = "claude-agent-sdk" },
 ]
+codex = [
+    { name = "openai-codex" },
+    { name = "openai-codex-cli-bin" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -210,6 +214,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mcp", specifier = ">=1.0.0" },
+    { name = "openai-codex", marker = "extra == 'codex'", specifier = "==0.1.0b3" },
+    { name = "openai-codex-cli-bin", marker = "extra == 'codex'", specifier = "==0.137.0a4" },
     { name = "packaging", specifier = ">=21.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
@@ -219,7 +225,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["claude-agent-sdk"]
+provides-extras = ["claude-agent-sdk", "codex"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -686,6 +692,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "openai-codex"
+version = "0.1.0b3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openai-codex-cli-bin" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1c/1e5e8b83ea72164d32b1f4e67fc703c8b83591f498a7aaf96f39d352b453/openai_codex-0.1.0b3.tar.gz", hash = "sha256:b76b7afe97953ac65648e9b8ca116b5ff273de91086549bd7ec88037cdc16cab", size = 58995, upload-time = "2026-06-03T19:17:34.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/ef/f77037d9ccde80a688a17a06aea5a56813ad9c365d49b3f1c7913422af8b/openai_codex-0.1.0b3-py3-none-any.whl", hash = "sha256:8d1f9d346667aeecb435c6a45d0edb3f016187276ec452cf8094d813896276c4", size = 65639, upload-time = "2026-06-03T19:17:33.208Z" },
+]
+
+[[package]]
+name = "openai-codex-cli-bin"
+version = "0.137.0a4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/60/af73ef1676cd477fa83ed4b889bf3b57c63c47dd87025b2cc4262793cff6/openai_codex_cli_bin-0.137.0a4-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b33c3917e0b58d527ee11a11a78ad390f7d8e6aa25577dd21665ab3c8bf5cf9a", size = 94300191, upload-time = "2026-06-03T18:44:36.312Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/d1a5f8c87176e00ef6a85798794f4530f5eb04e5a1a13468b5b3c3a361f9/openai_codex_cli_bin-0.137.0a4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3d0f0bc5becc88c61952fbfa9bd792ac9d74fa78b3a6bd40f545b612048b07eb", size = 83924479, upload-time = "2026-06-03T18:44:40.854Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3c/fc00bcdc0c302208317d5eb1d0bfaab3024f351cd0121400f19baa6b19aa/openai_codex_cli_bin-0.137.0a4-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2f1656339e2736868c4cce59f6d9e5c633879123687169b03b1137d42bf2c11a", size = 83363315, upload-time = "2026-06-03T18:44:44.851Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/09/39362e944ebeb12fcbfb86881fbb4dd6e806f77f7541c1f1f993bb9351a0/openai_codex_cli_bin-0.137.0a4-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:6454f838d44c56c1ed07a29b391fa412785e5dd2ffd06db0b62e62478c19bb64", size = 90611239, upload-time = "2026-06-03T18:44:49.338Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/38/87b1247fdfe95cddce7f7fe8331d6843cf037e14292c0f5004e23247133b/openai_codex_cli_bin-0.137.0a4-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:f5ae7401d00c65d56a75d9645d7bf87d809566a12d238e4b2a8b328a02f2316e", size = 83363315, upload-time = "2026-06-03T18:44:53.428Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c4/3c693ad07e587f6b3a28128c417f2e831d81a40cdbd85c0e5f0f36aaff82/openai_codex_cli_bin-0.137.0a4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:3dcec1e649448be498d6e7ec0e1f71dca83efa76063d90890dafb41e987069b7", size = 90611238, upload-time = "2026-06-03T18:44:57.612Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/26/81e037066b9b8d312a6f9e09015e452ce17630d5ab88e02a4c1d9503e4e8/openai_codex_cli_bin-0.137.0a4-py3-none-win_amd64.whl", hash = "sha256:9e13bf68e18e36bd3a0efd51213281c83e9f6ec22bdb7a45bd2e0211822733a9", size = 94744969, upload-time = "2026-06-03T18:45:02.23Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/a3/952bc2a5d62373a51fea161effe3b338b3417c2f6e65fe467ed91b205e2b/openai_codex_cli_bin-0.137.0a4-py3-none-win_arm64.whl", hash = "sha256:5ec4303ca2dcb5f838e0de3ca7f44050b6bcdd41d281a178c3a1420a985a515d", size = 86963504, upload-time = "2026-06-03T18:45:07.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add experimental `provider: codex` backed by the official `openai-codex` SDK and local `codex app-server`.
- Wire Codex into schema, factory, provider capabilities, registry, checkpoint resume, docs, and examples.
- Add provider-scoped checkpoint session IDs so Copilot sessions and Codex threads can coexist safely.
- Add mocked Codex provider tests plus schema, factory, capability, registry, and checkpoint coverage.

## Validation

- `uv run pytest -m "not install_scripts and not real_api"` -> `3266 passed, 14 skipped, 17 deselected`
- `make typecheck` -> passes with the existing unrelated `dialog_evaluator.py` warning
- `uv run conductor validate examples/codex-simple.yaml` -> passes
- `uv run --extra codex ...` -> verified pinned `openai-codex` imports and SDK signatures

Full `make test` was also attempted; the only remaining failure was an environment-dependent real Copilot API case where model `claude-opus-4.7-1m-internal` was unavailable.