### PR TITLE
feat(executor): add stdin payload transport for script steps

### DIFF
--- a/docs/projects/usability-features/script-execution-steps.plan.md
+++ b/docs/projects/usability-features/script-execution-steps.plan.md
@@ -29,7 +29,7 @@ Adding `type: script` as a first-class workflow step type allows shell commands 
 
 ### Non-Goals
 
-- **NG1:** Interactive/stdin-driven scripts (no stdin piping).
+- **NG1:** Interactive/stdin-driven scripts (no stdin piping). _(Partially superseded by issue #18: a one-shot `stdin:` payload field was later added for cross-platform payload transport. Interactive / streaming stdin remains out of scope.)_
 - **NG2:** Streaming stdout in real-time to the console (captured in bulk after completion).
 - **NG3:** Script steps inside `parallel` groups or `for_each` groups (future work; validation rejects this in v1).
 - **NG4:** Shell expansion / piping (`command` is exec'd directly, not via `sh -c`). Users who need shell features can use `command: sh` with `args: ["-c", "pipeline | here"]`.

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -229,6 +229,7 @@ agents:
       PYTHONPATH: "/app/src"
     working_dir: "/app"                         # Optional: working directory (Jinja2 template)
     timeout: 120                                # Optional: per-step timeout in seconds
+    stdin: "{{ planner.output | tojson }}"      # Optional: payload piped to the child's stdin (Jinja2 template)
     routes:
       - to: analyzer
         when: "exit_code == 0"
@@ -319,6 +320,29 @@ routes:
 **Restrictions** — script steps cannot have `prompt`, `model`, `provider`, `tools`, `system_prompt`, or `options`. Script steps also cannot be used inside `parallel` groups or `for_each` groups.
 
 **Environment variable note** — values in `env` are passed as-is to the subprocess (they are not rendered as Jinja2 templates). Use `${VAR}` syntax in the workflow YAML loader if you need environment variable substitution in env values.
+
+**Passing payloads via stdin** — set `stdin:` to pipe a rendered payload to the script's standard input instead of (or in addition to) command-line `args`. This is the cross-platform way to hand large or structured data to a script: command-line arguments are subject to OS length limits (notably Windows, where the total command line is capped at ~32 KB), but stdin is not. Reach for `stdin:` whenever a script consumes an upstream agent's structured output.
+
+```yaml
+agents:
+  - name: analyze
+    type: script
+    command: python3
+    args: ["scripts/analyze.py"]
+    stdin: "{{ evaluator.output.evaluations | tojson }}"   # JSON payload via the tojson filter
+    routes:
+      - to: $end
+```
+
+- **`stdin:` is a Jinja2 string template**, rendered against the workflow context and written to the child as UTF-8.
+  - For JSON, use the built-in `tojson` filter: `stdin: "{{ data | tojson }}"`. Plain `{{ data }}` renders a Python `repr` (single-quoted), which is **not** valid JSON.
+  - For arbitrary text — a diff, CSV, or a prompt — use it directly: `stdin: "{{ patch }}"`.
+  - The script reads it like any stdin source: `data = json.load(sys.stdin)` (Python), or pipe into `jq` / `cat` (shell).
+- **Omitting `stdin`** keeps the legacy behavior — the child inherits the parent's stdin.
+- **An explicit empty string** (`stdin: ""`) still pipes, sending the child immediate EOF (distinct from omitting it).
+- **`stdin` and `args` are orthogonal.** When both are set, `args` are passed on the command line *and* `stdin` is piped — there is no precedence conflict. Keep flags in `args` and put the bulky/structured payload in `stdin`.
+
+This replaces the older pattern of writing large structured arguments to a temp file and passing `--something-file <path>`; the engine pipes the payload directly, so there is no temp file to manage or clean up.
 
 ### Wait Steps
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -213,7 +213,7 @@ conductor run examples/script-step.yaml
 
 Hand a structured payload to a script step via **stdin** instead of
 command-line `args` — the cross-platform-safe way to pass large or
-structured data (no Windows `ARG_MAX` limit, no temp files). Demonstrates:
+structured data (no Windows ~32 KB command-line limit, no temp files). Demonstrates:
 - `stdin:` as a Jinja2 string template piped to the child as UTF-8
 - JSON handoff via the built-in `tojson` filter (`{{ x | tojson }}`)
 - A script consuming an upstream agent's structured output (`json.load(sys.stdin)`)

--- a/examples/README.md
+++ b/examples/README.md
@@ -209,6 +209,19 @@ Demonstrates:
 conductor run examples/script-step.yaml
 ```
 
+### script-stdin.yaml
+
+Hand a structured payload to a script step via **stdin** instead of
+command-line `args` — the cross-platform-safe way to pass large or
+structured data (no Windows `ARG_MAX` limit, no temp files). Demonstrates:
+- `stdin:` as a Jinja2 string template piped to the child as UTF-8
+- JSON handoff via the built-in `tojson` filter (`{{ x | tojson }}`)
+- A script consuming an upstream agent's structured output (`json.load(sys.stdin)`)
+
+```bash
+conductor run examples/script-stdin.yaml --input topic="error handling"
+```
+
 ### wait-step.yaml
 
 Polling pattern with a wait step and a routing loop-back. Demonstrates:

--- a/examples/script-stdin.yaml
+++ b/examples/script-stdin.yaml
@@ -1,0 +1,80 @@
+# Script Stdin Payload Example (issue #18)
+#
+# Demonstrates handing a structured payload to a script step via stdin
+# instead of command-line args. This is the cross-platform-safe way to pass
+# large or structured data into scripts: command-line arguments have OS
+# length limits (notably Windows ARG_MAX, ~32 KB), but stdin does not.
+#
+# Flow:
+#   1. `evaluate` (LLM agent) produces a structured list of findings as JSON.
+#   2. `summarize` (script) receives that JSON on stdin via `{{ ... | tojson }}`,
+#      aggregates it with Python, and prints a JSON summary to stdout.
+#   3. The script's auto-parsed JSON output flows to the workflow output.
+#
+# Key line:  stdin: "{{ evaluate.output | tojson }}"
+#   - `stdin:` is a Jinja2 string template written to the child as UTF-8.
+#   - The `tojson` filter emits valid JSON (plain `{{ x }}` would emit a
+#     Python repr, which is not valid JSON).
+#   - `stdin` and `args` are orthogonal — both reach the child when set.
+#
+# Usage:
+#   conductor run examples/script-stdin.yaml --input topic="error handling"
+
+workflow:
+  name: script-stdin-demo
+  description: Pass a structured payload to a script step via stdin
+  version: "1.0.0"
+  entry_point: evaluate
+
+  runtime:
+    provider: copilot
+
+  limits:
+    max_iterations: 10
+
+agents:
+  - name: evaluate
+    description: Produce a structured list of findings about the topic
+    model: claude-haiku-4.5
+    prompt: |
+      Produce exactly 3 short findings about "{{ workflow.input.topic }}".
+      Each finding is an object with a `title` (string) and a `severity`
+      integer from 1 (minor) to 5 (critical).
+    output:
+      findings:
+        type: array
+        description: List of {title, severity} objects
+        items:
+          type: object
+          properties:
+            title:
+              type: string
+            severity:
+              type: number
+    routes:
+      - to: summarize
+
+  - name: summarize
+    type: script
+    description: Aggregate the findings received as JSON on stdin
+    command: python3
+    args:
+      - "-c"
+      - |
+        import sys, json
+        data = json.load(sys.stdin)
+        findings = data["findings"]
+        severities = [int(f["severity"]) for f in findings]
+        print(json.dumps({
+            "count": len(findings),
+            "total_severity": sum(severities),
+            "max_severity": max(severities),
+        }))
+    stdin: "{{ evaluate.output | tojson }}"
+    routes:
+      - to: $end
+
+output:
+  count: "{{ summarize.output.count }}"
+  total_severity: "{{ summarize.output.total_severity }}"
+  max_severity: "{{ summarize.output.max_severity }}"

--- a/examples/script-stdin.yaml
+++ b/examples/script-stdin.yaml
@@ -3,7 +3,8 @@
 # Demonstrates handing a structured payload to a script step via stdin
 # instead of command-line args. This is the cross-platform-safe way to pass
 # large or structured data into scripts: command-line arguments have OS
-# length limits (notably Windows ARG_MAX, ~32 KB), but stdin does not.
+# length limits (notably Windows, where the command line is capped at
+# ~32 KB), but stdin does not.
 #
 # Flow:
 #   1. `evaluate` (LLM agent) produces a structured list of findings as JSON.

--- a/plugins/conductor/skills/conductor/references/authoring.md
+++ b/plugins/conductor/skills/conductor/references/authoring.md
@@ -207,11 +207,14 @@ agents:
     working_dir: /tmp            # Working directory (optional, Jinja2 templated)
     env:                         # Extra environment variables (optional)
       MY_VAR: "value"
+    stdin: "{{ data | tojson }}" # Payload piped to the child's stdin (optional, Jinja2 templated)
     routes:
       - to: analyzer
         when: "exit_code == 0"
       - to: error_handler
 ```
+
+Use `stdin:` to hand large or structured payloads to a script without hitting command-line length limits (notably Windows `ARG_MAX`). It is a Jinja2 string template rendered to the child's stdin as UTF-8 — use `{{ x | tojson }}` for JSON, or render text directly. Omitting it inherits the parent's stdin (legacy behavior); `stdin` and `args` can be set together (orthogonal).
 
 ### Script Output
 

--- a/plugins/conductor/skills/conductor/references/authoring.md
+++ b/plugins/conductor/skills/conductor/references/authoring.md
@@ -214,7 +214,7 @@ agents:
       - to: error_handler
 ```
 
-Use `stdin:` to hand large or structured payloads to a script without hitting command-line length limits (notably Windows `ARG_MAX`). It is a Jinja2 string template rendered to the child's stdin as UTF-8 — use `{{ x | tojson }}` for JSON, or render text directly. Omitting it inherits the parent's stdin (legacy behavior); `stdin` and `args` can be set together (orthogonal).
+Use `stdin:` to hand large or structured payloads to a script without hitting OS command-line length limits (notably Windows's ~32 KB command-line cap). It is a Jinja2 string template rendered to the child's stdin as UTF-8 — use `{{ x | tojson }}` for JSON, or render text directly. Omitting it inherits the parent's stdin (legacy behavior); `stdin` and `args` can be set together (orthogonal).
 
 ### Script Output
 

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -572,8 +572,8 @@ class AgentDef(BaseModel):
 
     A Jinja2 string template rendered against the workflow context and written
     to the child process's stdin as UTF-8. Use this to hand large structured
-    payloads to scripts without hitting command-line length limits (notably
-    Windows ``ARG_MAX``):
+    payloads to scripts without hitting OS command-line length limits (notably
+    Windows's ~32 KB command-line cap):
 
     - JSON: ``stdin: "{{ upstream.output.evaluations | tojson }}"`` — the
       built-in ``tojson`` filter emits valid JSON.
@@ -902,10 +902,12 @@ class AgentDef(BaseModel):
                     )
 
         # Field exclusive to ``type: script`` — reject if set on any other
-        # type. Mirrors the terminate-exclusive guard above so the error
-        # message clearly names the conflict, and covers ``agent`` /
-        # ``human_gate`` (which the per-type ``command``/``args`` rejections
-        # below do not).
+        # type. No per-type branch below inspects ``stdin``, so this single
+        # guard is the sole rejection path for every non-script type. It
+        # mirrors the terminate-exclusive guard above so the message names the
+        # conflict; being a standalone guard (rather than a per-branch check)
+        # it also covers ``agent`` / ``human_gate``, which have no
+        # ``command``/``args`` branch.
         if self.type != "script" and self.stdin is not None:
             raise ValueError(
                 f"'{self.type or 'agent'}' agents cannot have 'stdin' "

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -567,6 +567,28 @@ class AgentDef(BaseModel):
     working_dir: str | None = None
     """Working directory for script subprocess execution."""
 
+    stdin: str | None = None
+    """Payload written to the script subprocess's stdin (script type only).
+
+    A Jinja2 string template rendered against the workflow context and written
+    to the child process's stdin as UTF-8. Use this to hand large structured
+    payloads to scripts without hitting command-line length limits (notably
+    Windows ``ARG_MAX``):
+
+    - JSON: ``stdin: "{{ upstream.output.evaluations | tojson }}"`` — the
+      built-in ``tojson`` filter emits valid JSON.
+    - Arbitrary text: ``stdin: "{{ diff }}"``.
+
+    Semantics:
+
+    - Omitted (``None``) — the child inherits the parent's stdin (the
+      unchanged legacy behavior).
+    - Present (any string, including ``""``) — stdin is piped; an explicit
+      empty string sends immediate EOF.
+    - Orthogonal to ``args`` — when both are set, ``args`` are still passed on
+      the command line and ``stdin`` is piped.
+    """
+
     timeout: int | None = None
     """Per-script timeout in seconds."""
 
@@ -878,6 +900,17 @@ class AgentDef(BaseModel):
                         f"'{self.type or 'agent'}' agents cannot have '{field_name}' "
                         "(only 'terminate' agents support this field)"
                     )
+
+        # Field exclusive to ``type: script`` — reject if set on any other
+        # type. Mirrors the terminate-exclusive guard above so the error
+        # message clearly names the conflict, and covers ``agent`` /
+        # ``human_gate`` (which the per-type ``command``/``args`` rejections
+        # below do not).
+        if self.type != "script" and self.stdin is not None:
+            raise ValueError(
+                f"'{self.type or 'agent'}' agents cannot have 'stdin' "
+                "(only 'script' agents support this field)"
+            )
 
         if self.type == "human_gate":
             if not self.options:

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -2734,6 +2734,7 @@ class WorkflowEngine:
                                     "stdout": script_output.stdout,
                                     "stderr": script_output.stderr,
                                     "exit_code": script_output.exit_code,
+                                    "stdin_bytes": script_output.stdin_bytes,
                                 },
                             )
 

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -822,7 +822,7 @@ class WorkflowEngine:
             context: Workflow context for template rendering.
 
         Returns:
-            ScriptOutput with stdout, stderr, and exit_code.
+            ScriptOutput with stdout, stderr, exit_code, and stdin_bytes.
 
         Raises:
             ExecutionError: If script fails or times out.

--- a/src/conductor/executor/script.py
+++ b/src/conductor/executor/script.py
@@ -38,7 +38,8 @@ class ScriptOutput:
         stdout: Captured standard output as text.
         stderr: Captured standard error as text.
         exit_code: Process exit code.
-        stdin_bytes: Number of UTF-8 bytes written to the child's stdin, or
+        stdin_bytes: Number of UTF-8 bytes in the stdin payload submitted to
+            the child (the child may read fewer if it exits early), or
             ``None`` when no ``stdin`` payload was configured (stdin inherited).
     """
 
@@ -73,9 +74,11 @@ class ScriptExecutor:
 
         Renders command/args with Jinja2, spawns the subprocess, and captures
         output. If ``agent.stdin`` is set, the rendered payload is piped to the
-        child's stdin as UTF-8 (via ``communicate``, so large payloads don't
-        deadlock or hit command-line length limits); otherwise the child
-        inherits the parent's stdin.
+        child's stdin as UTF-8 via ``communicate`` (which streams stdin while
+        draining stdout/stderr, so large payloads can't deadlock the pipe);
+        routing the payload through stdin also keeps it off the command line
+        and clear of OS argv length limits. Otherwise the child inherits the
+        parent's stdin.
 
         Args:
             agent: Agent definition with type="script".
@@ -99,13 +102,32 @@ class ScriptExecutor:
         # Render the optional stdin payload. ``None`` means "inherit the
         # parent's stdin" (the legacy behavior); any string — including an
         # empty one — means "pipe this to the child", so we check
-        # ``is not None`` rather than truthiness. Writing via
-        # ``communicate(input=...)`` streams stdin in the background while
-        # draining stdout/stderr, so large payloads cannot deadlock the pipe
-        # or hit command-line length limits (e.g. Windows ARG_MAX).
+        # ``is not None`` rather than truthiness. Routing the payload through
+        # stdin (rather than argv) is what keeps it clear of OS command-line
+        # length limits — Windows caps the command line at ~32 KB; POSIX
+        # ARG_MAX is larger. We write it via ``communicate(input=...)``, which
+        # feeds stdin concurrently with draining stdout/stderr so a large
+        # payload can't deadlock the pipe.
         stdin_payload: bytes | None = None
         if agent.stdin is not None:
-            stdin_payload = self.renderer.render(agent.stdin, context).encode("utf-8")
+            rendered_stdin = self.renderer.render(agent.stdin, context)
+            try:
+                stdin_payload = rendered_stdin.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                # Strict encode (unlike the lenient ``decode(errors="replace")``
+                # on output) — surface a clear, named error instead of a bare
+                # codec traceback. Do NOT use ``errors="replace"`` here: that
+                # would silently corrupt the payload delivered to the child.
+                raise ExecutionError(
+                    f"Script '{agent.name}': stdin payload is not valid UTF-8 ({exc})",
+                    agent_name=agent.name,
+                    suggestion=(
+                        "The rendered stdin contains characters that cannot be "
+                        "UTF-8 encoded (e.g. unpaired surrogates from upstream "
+                        "JSON). Sanitize the value or render it through the "
+                        "'tojson' filter."
+                    ),
+                ) from exc
 
         # Build environment (merge os.environ + agent.env)
         # Note: ${VAR:-default} patterns in agent.env are already resolved

--- a/src/conductor/executor/script.py
+++ b/src/conductor/executor/script.py
@@ -38,11 +38,14 @@ class ScriptOutput:
         stdout: Captured standard output as text.
         stderr: Captured standard error as text.
         exit_code: Process exit code.
+        stdin_bytes: Number of UTF-8 bytes written to the child's stdin, or
+            ``None`` when no ``stdin`` payload was configured (stdin inherited).
     """
 
     stdout: str
     stderr: str
     exit_code: int
+    stdin_bytes: int | None = None
 
 
 class ScriptExecutor:
@@ -68,14 +71,18 @@ class ScriptExecutor:
     ) -> ScriptOutput:
         """Execute a script step.
 
-        Renders command/args with Jinja2, spawns subprocess, captures output.
+        Renders command/args with Jinja2, spawns the subprocess, and captures
+        output. If ``agent.stdin`` is set, the rendered payload is piped to the
+        child's stdin as UTF-8 (via ``communicate``, so large payloads don't
+        deadlock or hit command-line length limits); otherwise the child
+        inherits the parent's stdin.
 
         Args:
             agent: Agent definition with type="script".
             context: Workflow context for template rendering.
 
         Returns:
-            ScriptOutput with stdout, stderr, and exit_code.
+            ScriptOutput with stdout, stderr, exit_code, and stdin_bytes.
 
         Raises:
             ExecutionError: If the script times out or cannot be started.
@@ -89,6 +96,17 @@ class ScriptExecutor:
             self.renderer.render(agent.working_dir, context) if agent.working_dir else None
         )
 
+        # Render the optional stdin payload. ``None`` means "inherit the
+        # parent's stdin" (the legacy behavior); any string — including an
+        # empty one — means "pipe this to the child", so we check
+        # ``is not None`` rather than truthiness. Writing via
+        # ``communicate(input=...)`` streams stdin in the background while
+        # draining stdout/stderr, so large payloads cannot deadlock the pipe
+        # or hit command-line length limits (e.g. Windows ARG_MAX).
+        stdin_payload: bytes | None = None
+        if agent.stdin is not None:
+            stdin_payload = self.renderer.render(agent.stdin, context).encode("utf-8")
+
         # Build environment (merge os.environ + agent.env)
         # Note: ${VAR:-default} patterns in agent.env are already resolved
         # by the config loader during YAML parsing.
@@ -99,12 +117,15 @@ class ScriptExecutor:
         env = {**base_env, **agent.env} if agent.env else base_env
 
         _verbose_log(f"  Script: {rendered_command} {' '.join(rendered_args)}")
+        if stdin_payload is not None:
+            _verbose_log(f"  Script stdin: {len(stdin_payload)} bytes")
 
         # Create subprocess
         try:
             process = await asyncio.create_subprocess_exec(
                 rendered_command,
                 *rendered_args,
+                stdin=asyncio.subprocess.PIPE if stdin_payload is not None else None,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=rendered_working_dir,
@@ -126,7 +147,7 @@ class ScriptExecutor:
         timeout = agent.timeout
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                process.communicate(), timeout=timeout
+                process.communicate(input=stdin_payload), timeout=timeout
             )
         except TimeoutError:
             process.kill()
@@ -149,4 +170,5 @@ class ScriptExecutor:
             stdout=stdout_text,
             stderr=stderr_text,
             exit_code=process.returncode,
+            stdin_bytes=len(stdin_payload) if stdin_payload is not None else None,
         )

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -1696,3 +1696,52 @@ class TestTerminateAgent:
             input=["precheck.output"],
         )
         assert a.input == ["precheck.output"]
+
+
+class TestScriptStdinField:
+    """The `stdin` field is exclusive to `type: script` (issue #18)."""
+
+    def test_stdin_accepted_on_script(self) -> None:
+        """A script step may declare a stdin payload template."""
+        agent = AgentDef(
+            name="s",
+            type="script",
+            command="cat",
+            stdin="{{ upstream.output.evaluations | tojson }}",
+        )
+        assert agent.stdin == "{{ upstream.output.evaluations | tojson }}"
+
+    def test_stdin_empty_string_accepted_on_script(self) -> None:
+        """An explicit empty stdin is valid (pipes immediate EOF), distinct from omission."""
+        agent = AgentDef(name="s", type="script", command="cat", stdin="")
+        assert agent.stdin == ""
+
+    def test_stdin_defaults_to_none(self) -> None:
+        """Omitting stdin leaves it None (legacy inherit-stdin behavior)."""
+        agent = AgentDef(name="s", type="script", command="echo")
+        assert agent.stdin is None
+
+    @pytest.mark.parametrize(
+        "step_type",
+        ["agent", "human_gate", "set", "wait", "terminate", "workflow"],
+    )
+    def test_stdin_rejected_on_non_script_types(self, step_type: str) -> None:
+        """The script-exclusive guard trips for every non-script step type."""
+        payload: dict[str, object] = {"name": "a", "type": step_type, "stdin": "data"}
+        if step_type == "human_gate":
+            payload["prompt"] = "Pick"
+            payload["options"] = [GateOption(value="x", label="X", route="$end")]
+        elif step_type == "set":
+            payload["value"] = "{{ 1 }}"
+        elif step_type == "wait":
+            payload["duration"] = "1s"
+        elif step_type == "terminate":
+            payload["status"] = "success"
+            payload["reason"] = "r"
+        elif step_type == "workflow":
+            payload["workflow"] = "./sub.yaml"
+        with pytest.raises(ValidationError) as exc_info:
+            AgentDef.model_validate(payload)
+        message = str(exc_info.value)
+        assert "stdin" in message
+        assert "only 'script' agents support this field" in message

--- a/tests/test_engine/test_script_workflow.py
+++ b/tests/test_engine/test_script_workflow.py
@@ -947,3 +947,92 @@ class TestScriptOutputSchema:
 
         assert engine.context.agent_outputs["detector"]["phase"] == "planning"
         assert "planner" in engine.context.agent_outputs
+
+
+class TestScriptStdinWorkflow:
+    """End-to-end stdin payload transport through the engine (issue #18)."""
+
+    @pytest.mark.asyncio
+    async def test_structured_payload_piped_via_stdin(self) -> None:
+        """A structured upstream payload is handed to a script as JSON over stdin.
+
+        The script parses it, transforms it, and the auto-parsed result flows to
+        the workflow output — exercising the full render → pipe → parse round trip.
+        """
+        reader = (
+            "import sys, json; "
+            "d = json.load(sys.stdin); "
+            "print(json.dumps({'received_name': d['name'], 'doubled': d['count'] * 2}))"
+        )
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="script-stdin",
+                entry_point="consume",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="consume",
+                    type="script",
+                    command=sys.executable,
+                    args=["-c", reader],
+                    stdin="{{ workflow.input.payload | tojson }}",
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={
+                "name": "{{ consume.output.received_name }}",
+                "doubled": "{{ consume.output.doubled }}",
+            },
+        )
+        engine = WorkflowEngine(config, MagicMock())
+        result = await engine.run({"payload": {"name": "widget", "count": 21}})
+
+        assert result["name"] == "widget"
+        assert str(result["doubled"]) == "42"
+
+    @pytest.mark.asyncio
+    async def test_large_payload_via_stdin_reports_byte_count(self) -> None:
+        """A payload far larger than ARG_MAX flows through stdin intact.
+
+        Also asserts the ``script_completed`` event carries ``stdin_bytes`` so the
+        dashboard / JSONL log can surface payload size without the payload itself.
+        """
+        payload = "z" * (1024 * 1024)  # 1 MB — well beyond any OS arg-length limit
+        reader = "import sys; print(len(sys.stdin.read()))"
+
+        events: list[WorkflowEvent] = []
+        emitter = WorkflowEventEmitter()
+        emitter.subscribe(events.append)
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="script-stdin-large",
+                entry_point="sizer",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=10),
+            ),
+            agents=[
+                AgentDef(
+                    name="sizer",
+                    type="script",
+                    command=sys.executable,
+                    args=["-c", reader],
+                    stdin="{{ workflow.input.blob }}",
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"size": "{{ sizer.output.stdout | trim }}"},
+        )
+        engine = WorkflowEngine(config, MagicMock(), event_emitter=emitter)
+        result = await engine.run({"blob": payload})
+
+        # The output template auto-parses the numeric stdout to an int; compare
+        # type-robustly. The point is the full 1 MB survived the stdin round trip.
+        assert str(result["size"]) == str(len(payload))
+        completed = [e for e in events if e.type == "script_completed"]
+        assert len(completed) == 1
+        assert completed[0].data["stdin_bytes"] == len(payload)

--- a/tests/test_executor/test_script.py
+++ b/tests/test_executor/test_script.py
@@ -14,6 +14,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 import tempfile
@@ -21,7 +22,7 @@ import tempfile
 import pytest
 
 from conductor.config.schema import AgentDef
-from conductor.exceptions import ExecutionError
+from conductor.exceptions import ExecutionError, TemplateError
 from conductor.executor.script import ScriptExecutor, ScriptOutput
 
 
@@ -425,3 +426,94 @@ class TestScriptExecutorStdin:
         assert output.stdin_bytes == len(payload.encode("utf-8"))
         # Byte length exceeds character length for multi-byte code points.
         assert output.stdin_bytes > len(payload)
+
+    @pytest.mark.asyncio
+    async def test_stdin_large_bidirectional_no_deadlock(self, executor: ScriptExecutor) -> None:
+        """A multi-MB payload in AND multi-MB out streams without deadlock.
+
+        The other large-payload tests use a tiny stdout, which always fits the
+        OS pipe buffer — so a regression to write-then-read piping would pass
+        them yet deadlock here. The child echoes the full payload back, so both
+        pipes exceed the buffer simultaneously. Wrapped in a timeout so a
+        deadlock regression fails fast instead of hanging CI.
+        """
+        payload = "m" * (4 * 1024 * 1024)  # 4 MB each direction
+        agent = AgentDef(
+            name="test_stdin_bidi",
+            type="script",
+            command=sys.executable,
+            args=["-c", _ECHO_STDIN],
+            stdin="{{ blob }}",
+        )
+        output = await asyncio.wait_for(executor.execute(agent, {"blob": payload}), timeout=30)
+        assert len(output.stdout) == len(payload)
+        assert output.exit_code == 0
+        assert output.stdin_bytes == len(payload)
+
+    @pytest.mark.asyncio
+    async def test_stdin_child_exits_without_reading(self, executor: ScriptExecutor) -> None:
+        """A child that exits before reading a large stdin payload is handled cleanly.
+
+        ``communicate`` lets asyncio absorb the resulting BrokenPipeError, so the
+        step completes with the child's real exit code rather than crashing.
+        """
+        agent = AgentDef(
+            name="test_stdin_early_exit",
+            type="script",
+            command=sys.executable,
+            args=["-c", "import sys; sys.exit(3)"],  # never reads stdin
+            stdin="y" * (2 * 1024 * 1024),
+        )
+        output = await executor.execute(agent, {})
+        assert output.exit_code == 3
+        # Byte count reflects the submitted payload even though the child read none.
+        assert output.stdin_bytes == 2 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_stdin_timeout_while_writing(self, executor: ScriptExecutor) -> None:
+        """Timeout fires cleanly even while a large stdin payload is mid-write."""
+        agent = AgentDef(
+            name="test_stdin_timeout",
+            type="script",
+            command=sys.executable,
+            args=["-c", "import time; time.sleep(30)"],  # sleeps, never drains stdin
+            stdin="q" * (4 * 1024 * 1024),
+            timeout=1,
+        )
+        with pytest.raises(ExecutionError, match="timed out after 1s"):
+            await executor.execute(agent, {})
+
+    @pytest.mark.asyncio
+    async def test_stdin_invalid_utf8_raises_execution_error(
+        self, executor: ScriptExecutor
+    ) -> None:
+        """A payload that can't be UTF-8 encoded raises a clear ExecutionError.
+
+        Lone surrogates reach the context via upstream JSON (``json.loads`` of
+        ``"\\ud800"``). The strict ``.encode`` must surface a named error, not a
+        bare UnicodeEncodeError.
+        """
+        agent = AgentDef(
+            name="test_stdin_bad_utf8",
+            type="script",
+            command=sys.executable,
+            args=["-c", _ECHO_STDIN],
+            stdin="{{ bad }}",
+        )
+        with pytest.raises(ExecutionError, match="not valid UTF-8"):
+            await executor.execute(agent, {"bad": "\ud800"})
+
+    @pytest.mark.asyncio
+    async def test_stdin_render_failure_raises_template_error(
+        self, executor: ScriptExecutor
+    ) -> None:
+        """An undefined variable in stdin fails like command/args (TemplateError)."""
+        agent = AgentDef(
+            name="test_stdin_bad_template",
+            type="script",
+            command=sys.executable,
+            args=["-c", _ECHO_STDIN],
+            stdin="{{ does_not_exist }}",
+        )
+        with pytest.raises(TemplateError):
+            await executor.execute(agent, {})

--- a/tests/test_executor/test_script.py
+++ b/tests/test_executor/test_script.py
@@ -281,3 +281,147 @@ class TestScriptExecutorErrors:
         )
         output = await executor.execute(agent, {})
         assert output.exit_code == 42
+
+
+# Child snippet that echoes whatever it reads from stdin straight to stdout.
+_ECHO_STDIN = "import sys; sys.stdout.write(sys.stdin.read())"
+# Child snippet that prints the number of characters it read from stdin.
+_LEN_STDIN = "import sys; sys.stdout.write(str(len(sys.stdin.read())))"
+
+
+class TestScriptExecutorStdin:
+    """Tests for piping a rendered ``stdin`` payload to the subprocess (issue #18)."""
+
+    @pytest.mark.asyncio
+    async def test_stdin_round_trip(self, executor: ScriptExecutor) -> None:
+        """A rendered stdin payload is delivered verbatim to the child."""
+        agent = AgentDef(
+            name="test_stdin",
+            type="script",
+            command=sys.executable,
+            args=["-c", _ECHO_STDIN],
+            stdin="hello from stdin",
+        )
+        output = await executor.execute(agent, {})
+        assert output.stdout == "hello from stdin"
+        assert output.exit_code == 0
+        assert output.stdin_bytes == len("hello from stdin")
+
+    @pytest.mark.asyncio
+    async def test_stdin_jinja2_rendered_from_context(self, executor: ScriptExecutor) -> None:
+        """The stdin field is a Jinja2 template rendered against the context."""
+        agent = AgentDef(
+            name="test_stdin_tpl",
+            type="script",
+            command=sys.executable,
+            args=["-c", _ECHO_STDIN],
+            stdin="{{ workflow.input.message }}",
+        )
+        context = {"workflow": {"input": {"message": "rendered payload"}}}
+        output = await executor.execute(agent, context)
+        assert output.stdout == "rendered payload"
+
+    @pytest.mark.asyncio
+    async def test_stdin_json_via_tojson_filter(self, executor: ScriptExecutor) -> None:
+        """Structured data is handed off as valid JSON via the ``tojson`` filter."""
+        agent = AgentDef(
+            name="test_stdin_json",
+            type="script",
+            command=sys.executable,
+            args=[
+                "-c",
+                "import sys, json; d = json.load(sys.stdin); "
+                "print(d['name'], d['count'], len(d['items']))",
+            ],
+            stdin="{{ payload | tojson }}",
+        )
+        context = {"payload": {"name": "widget", "count": 3, "items": [1, 2, 3, 4]}}
+        output = await executor.execute(agent, context)
+        assert output.stdout.strip() == "widget 3 4"
+        assert output.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_stdin_large_payload_bypasses_arg_limits(self, executor: ScriptExecutor) -> None:
+        """A multi-MB payload streams through stdin without deadlock or ARG_MAX.
+
+        Passing this many bytes as a command-line argument would exceed the OS
+        argument-length limit (~256 KB on macOS) and raise OSError; via stdin it
+        is delivered intact. This is the core cross-platform fix for issue #18.
+        """
+        payload = "x" * (2 * 1024 * 1024)  # 2 MB, well beyond ARG_MAX
+        agent = AgentDef(
+            name="test_stdin_large",
+            type="script",
+            command=sys.executable,
+            args=["-c", _LEN_STDIN],
+            stdin="{{ blob }}",
+        )
+        output = await executor.execute(agent, {"blob": payload})
+        assert output.stdout.strip() == str(len(payload))
+        assert output.exit_code == 0
+        assert output.stdin_bytes == len(payload)
+
+    @pytest.mark.asyncio
+    async def test_stdin_empty_string_pipes_immediate_eof(self, executor: ScriptExecutor) -> None:
+        """An explicit empty string still pipes (sends immediate EOF), unlike omission."""
+        agent = AgentDef(
+            name="test_stdin_empty",
+            type="script",
+            command=sys.executable,
+            args=["-c", _LEN_STDIN],
+            stdin="",
+        )
+        output = await executor.execute(agent, {})
+        assert output.stdout.strip() == "0"
+        assert output.exit_code == 0
+        # Present-but-empty is distinct from omitted: 0 bytes, not None.
+        assert output.stdin_bytes == 0
+
+    @pytest.mark.asyncio
+    async def test_stdin_omitted_is_backwards_compatible(self, executor: ScriptExecutor) -> None:
+        """Omitting stdin keeps legacy behavior: nothing piped, stdin_bytes is None."""
+        agent = AgentDef(
+            name="test_stdin_omitted",
+            type="script",
+            command=sys.executable,
+            args=["-c", "print('no stdin')"],
+        )
+        output = await executor.execute(agent, {})
+        assert output.stdout.strip() == "no stdin"
+        assert output.exit_code == 0
+        assert output.stdin_bytes is None
+
+    @pytest.mark.asyncio
+    async def test_stdin_coexists_with_args(self, executor: ScriptExecutor) -> None:
+        """stdin and args are orthogonal — both reach the child when set."""
+        agent = AgentDef(
+            name="test_stdin_args",
+            type="script",
+            command=sys.executable,
+            args=[
+                "-c",
+                "import sys; print(sys.argv[1]); sys.stdout.write(sys.stdin.read())",
+                "from-args",
+            ],
+            stdin="from-stdin",
+        )
+        output = await executor.execute(agent, {})
+        assert output.stdout == "from-args\nfrom-stdin"
+        assert output.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_stdin_utf8_payload_byte_count(self, executor: ScriptExecutor) -> None:
+        """Non-ASCII payloads are UTF-8 encoded; stdin_bytes counts bytes, not chars."""
+        payload = "café ☕ 日本語"
+        agent = AgentDef(
+            name="test_stdin_utf8",
+            type="script",
+            command=sys.executable,
+            args=["-c", _ECHO_STDIN],
+            stdin="{{ msg }}",
+        )
+        output = await executor.execute(agent, {"msg": payload})
+        assert output.stdout == payload
+        assert output.stdin_bytes == len(payload.encode("utf-8"))
+        # Byte length exceeds character length for multi-byte code points.
+        assert output.stdin_bytes > len(payload)


### PR DESCRIPTION
## Summary

Closes #18.

Adds a first-class, cross-platform **`stdin:`** field to `type: script` steps — a raw Jinja2 string template rendered against the workflow context and piped to the child process's stdin as UTF-8. This is the clean, argument-name-agnostic fix for the command-line-length fragility (notably Windows `ARG_MAX`) that previously forced workflow authors into per-flag temp-file workarounds (`--evaluations-file`).

```yaml
- name: summarize
  type: script
  command: python3
  args: ["scripts/analyze.py"]
  stdin: "{{ evaluator.output.evaluations | tojson }}"   # JSON via the tojson filter
```

## Why stdin (vs. temp files / arg-spillover)

- No temp-file lifecycle to manage — nothing to clean up.
- `process.communicate(input=...)` streams stdin in the background while draining stdout/stderr, so multi-MB payloads can't deadlock the pipe or hit `ARG_MAX`.
- A raw string template is strictly more general than a dedicated `stdin_json`: JSON is `{{ x | tojson }}`, arbitrary text (diffs, CSV, prompts) is `{{ x }}`. Matches how `command`/`args` already work.

## Behavior contract

- **Omitted** (`stdin: None`) → child inherits the parent's stdin (unchanged legacy behavior).
- **Present** (any string, including `""`) → stdin is piped; an explicit empty string sends immediate EOF.
- **`stdin` ⟂ `args`** — both are passed when set; no precedence conflict.
- Encoding is UTF-8 (consistent with `PYTHONUTF8=1` and the existing stdout/stderr decode).

## Changes

- **`config/schema.py`** — new `stdin` field + a single script-exclusive validation guard (mirrors the `status`/`output_template` pattern; rejects `stdin` on all six non-script step types, including `agent`/`human_gate`).
- **`executor/script.py`** — render + pipe stdin; new `ScriptOutput.stdin_bytes`.
- **`engine/workflow.py`** — `script_completed` event carries `stdin_bytes` for dashboard/JSONL observability (never the payload itself).
- **Docs/example** — `docs/workflow-syntax.md`, authoring skill reference, NG1 note in the original design doc; new `examples/script-stdin.yaml` registered in `examples/README.md`.

## Acceptance criteria

- [x] Works uniformly on Windows/macOS/Linux (stdin pipe via asyncio `communicate`).
- [x] No dependency on argument names.
- [x] Clear precedence when both `args` and `stdin` are configured (orthogonal, documented).
- [x] Temp artifact lifecycle deterministic / cleaned up (N/A — no temp files).
- [x] Tests covering large payloads + length behavior.

## Tests

- 8 executor unit tests (round-trip, 2 MB payload, empty, omitted back-compat, Jinja render, `tojson` JSON handoff, `stdin`+`args` coexistence, UTF-8 byte count).
- 9 schema tests (accepted on `script`; rejected on all 6 non-script types).
- 2 engine integration tests (structured payload handoff; 1 MB payload + `stdin_bytes` event).
- Full sweep: **1811 passed**. Lint ✅, typecheck ✅, `validate-examples` ✅ (23 examples).