### PR TITLE
chore(release): cut 0.1.19 changelog and bump copilot SDK floor to >=1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.18...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.19...HEAD)
+
+## [0.1.19](https://github.com/microsoft/conductor/compare/v0.1.18...v0.1.19) - 2026-06-16
 
 ### Added
 
@@ -20,6 +22,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `workflow` agents). See [`examples/context-tier.yaml`](examples/context-tier.yaml)
   and [Context Tier](docs/configuration.md#context-tier).
   ([#251](https://github.com/microsoft/conductor/issues/251))
+- **Validator block** — an optional `validator:` block on provider-backed
+  agents that runs a second LLM call to grade the agent's output against a
+  user-defined rubric. Distinct from `retry:` (transient failures, same
+  prompt) and `output:` (shape/type): it catches structurally valid but
+  semantically wrong, incomplete, or off-rubric output. Fields: `criteria`
+  (required), `model` (defaults to the agent's model), and `max_retries`
+  (`0` or `1`, default `1`, hard-capped at `1`). On `passed: false` the agent
+  re-runs **once** with the validator's issues appended under a
+  `## Validation feedback` section; the second output is final (no second
+  validation loop). Validation is **fail-open** — grader errors or unparseable
+  responses are logged and treated as a pass, so a hung or broken grader can't
+  block the workflow. Wired into the main loop, parallel groups, and for-each
+  loops; emits `agent_validator_start` / `agent_validator_complete` /
+  `agent_validation_failed` events surfaced in `--verbose` console output and
+  the web dashboard, and records the grading call (plus any discarded first
+  attempt) as a separate `<agent> (validator)` usage row. Rejected on
+  `script` / `human_gate` / `workflow` / `wait` / `set` / `terminate` steps.
+  See [`examples/validator.yaml`](examples/validator.yaml) and the
+  [Validator section](docs/workflow-syntax.md) of the workflow syntax docs.
+  ([#256](https://github.com/microsoft/conductor/pull/256),
+  closes [#220](https://github.com/microsoft/conductor/issues/220))
+- **Periodic / milestone checkpoints** — opt-in `runtime.checkpoint` block that
+  saves a resumable checkpoint at step boundaries so a long run that stalls or
+  is hard-killed stays recoverable (previously Conductor only checkpointed on
+  failure). Two OR-combined triggers — `every_agent: true` (save at every step
+  boundary) and `every_seconds: N` (a throttle: save at the first boundary once
+  `N` seconds have elapsed since the last checkpoint) — plus `keep_last`
+  (default `5`) to rotate older periodic checkpoints per run. Off by default, so
+  failure-only behaviour is preserved. Periodic checkpoints are scoped to their
+  own run and trigger, so failure checkpoints and other runs' files are never
+  rotated away, and they are cleaned up automatically on clean completion or an
+  explicit `terminate`. A failed periodic save emits a `checkpoint_save_failed`
+  event (console + JSONL + dashboard) so a recovery-reliant run is never left
+  silently without checkpoints, and `conductor checkpoints` gains a `Trigger`
+  column. See
+  [`examples/periodic-checkpoints.yaml`](examples/periodic-checkpoints.yaml)
+  and the [Periodic Checkpoints section](docs/workflow-syntax.md) of the
+  workflow syntax docs.
+  ([#255](https://github.com/microsoft/conductor/pull/255),
+  closes [#244](https://github.com/microsoft/conductor/issues/244))
+- **Script `stdin:` payload transport** — `type: script` steps accept a new
+  `stdin:` field: a Jinja2 string template rendered against the workflow
+  context and piped to the child process on stdin as UTF-8. Workflows can now
+  hand large or structured payloads to scripts without hitting command-line
+  length limits (notably Windows, which caps the command line at ~32 KB),
+  removing argument-name-specific temp-file workarounds. `stdin` and `args` are
+  orthogonal; an explicit empty string pipes an immediate EOF, and omitting it
+  preserves the legacy behaviour of inheriting the parent's stdin. The payload
+  is streamed in the background so multi-MB inputs can't deadlock, the submitted
+  byte count is surfaced as `stdin_bytes` on the `script_completed` event, and
+  an unencodable payload raises a named `ExecutionError`. Rejected on every
+  non-script step type. See
+  [`examples/script-stdin.yaml`](examples/script-stdin.yaml).
+  ([#253](https://github.com/microsoft/conductor/pull/253),
+  refs [#18](https://github.com/microsoft/conductor/issues/18))
+- **Experimental provider tier** — providers that delegate part of the agentic
+  loop to an upstream SDK can now declare an *experimental* stability tier with
+  explicit, allowed capability carve-outs instead of silently eroding provider
+  parity. Every provider declares a class-level `CAPABILITIES`
+  (`ProviderCapabilities`) descriptor, and `conductor validate` cross-checks
+  workflow features against each agent's resolved provider — surfacing silent
+  mismatches (unsupported `runtime.mcp_servers`, non-empty per-agent `tools:`
+  allowlists, `reasoning.effort`, structured `output:`, concurrent use in
+  parallel/for-each groups, `max_session_seconds`) at validate time rather than
+  at runtime. The `workflow_started` event gains a `providers` block (tier,
+  upstream pin, maintainer, full capability dump) plus a `provider_name` per
+  agent; the CLI prints a one-time banner per experimental provider per run, and
+  the web dashboard renders a yellow "exp" badge on affected agent nodes. See
+  [Experimental Providers](docs/providers/experimental.md).
+  ([#242](https://github.com/microsoft/conductor/pull/242),
+  closes [#241](https://github.com/microsoft/conductor/issues/241))
+- **`claude-agent-sdk` provider** — a new, experimental provider that delegates
+  the agentic loop, tool execution, and structured-output extraction to the
+  Claude Code CLI via the `claude-agent-sdk` package. Unlike the raw `claude`
+  provider it does not manage its own retry logic, MCP servers, or tool wiring —
+  the SDK runtime owns those. It achieves event and output parity
+  (`agent_turn_start`, `agent_message`, `agent_reasoning`,
+  `agent_tool_start` / `agent_tool_complete`, and the standard `AgentOutput`
+  shape), pairing real `ToolResultBlock` results rather than emitting nulls.
+  Workflow-level `runtime.mcp_servers`, non-empty per-agent `tools:` lists, and
+  `temperature` / `max_tokens` are rejected at the factory (the CLI controls
+  these). Install with the optional extra
+  (`pip install conductor[claude-agent-sdk]`) plus the `claude` CLI. See
+  [`examples/experimental-claude-agent-sdk.yaml`](examples/experimental-claude-agent-sdk.yaml).
+  ([#104](https://github.com/microsoft/conductor/pull/104))
 
 ### Fixed
 
@@ -46,6 +133,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the user typed). Collected values are now nested under an explicit
   `additional_input` key, matching the shape the `gate_resolved` event already
   used. ([#237](https://github.com/microsoft/conductor/pull/237))
+- `context: explicit` mode now supports **nested output projection** in
+  `input:` declarations. References of the form
+  `agent_name.output.field.subfield...` (and the
+  `agent_name.field.subfield...` shorthand) project arbitrarily deep into a
+  prior step's structured output, where previously only a single level
+  (`agent_name.output.field`) resolved and deeper paths silently failed.
+  Optional refs (`?`) skip missing intermediate paths, and projected leaves are
+  deep-copied to avoid mutation aliasing. Static validation in
+  `conductor validate` was aligned with the runtime so valid nested references
+  no longer fail validation.
+  ([#239](https://github.com/microsoft/conductor/pull/239))
 
 ### Changed
 
@@ -58,11 +156,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Templates that referenced the old flat path now raise `TemplateError`
     (`StrictUndefined`), so the migration fails loudly rather than rendering
     to empty strings.
-  - In `context: explicit` mode, `input:` declarations support
-    `<gate>.output.additional_input` (the parent dict) but not the dotted
-    shorthand `<gate>.output.additional_input.<field>`. Declare the parent
-    and read individual fields via Jinja2 in the consuming agent's prompt or
-    output template.
+  - In `context: explicit` mode, `input:` declarations can reference either
+    `<gate>.output.additional_input` (the whole dict) or an individual
+    `<gate>.output.additional_input.<field>`. Nested explicit-input projection
+    landed in this same release
+    ([#239](https://github.com/microsoft/conductor/pull/239)), so the dotted
+    field path now resolves directly; you can also still declare the parent and
+    read individual fields via Jinja2 in the consuming agent's prompt or output
+    template.
 
 ## [0.1.18](https://github.com/microsoft/conductor/compare/v0.1.17...v0.1.18) - 2026-05-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.18"
+version = "0.1.19"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -37,7 +37,7 @@ dependencies = [
     "ruamel.yaml>=0.18.0",
     "jinja2>=3.1.0",
     "simpleeval>=1.0.0",
-    "github-copilot-sdk>=0.3.0",
+    "github-copilot-sdk>=1.0.0",
     "anthropic>=0.77.0,<1.0.0",
     "mcp>=1.0.0",
     "fastapi>=0.115.0",

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -206,7 +206,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.77.0,<1.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'claude-agent-sdk'", specifier = ">=0.1.64" },
     { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "github-copilot-sdk", specifier = ">=0.3.0" },
+    { name = "github-copilot-sdk", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mcp", specifier = ">=1.0.0" },
@@ -393,19 +393,19 @@ wheels = [
 
 [[package]]
 name = "github-copilot-sdk"
-version = "0.3.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/d7/3d71064646a24d633c9dec035ff8b5b6d72c11d3aad765e54efd71737f0f/github_copilot_sdk-0.3.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:ed8f27989158824c754d7febb473bdf25744a1e6bc07a06f114f7e7deebd2c22", size = 58566984, upload-time = "2026-04-24T16:05:37.535Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/18/439854722b951a2f213c23cc731e9a31d46c8b1e2f1b1de080745c03c798/github_copilot_sdk-0.3.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7e241d9b00ebf8bb4d10b2d6101c75fcef38de04d144d729e07fa48394270ee1", size = 55318729, upload-time = "2026-04-24T16:05:41.734Z" },
-    { url = "https://files.pythonhosted.org/packages/11/56/931a65b17ad36d3b8987d8cb9bd2835f759c79ae1799fdc34d1252c38b6f/github_copilot_sdk-0.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:f4d98a67b8f038885ddd38bd7033d1ac20c3010f04c72ee0fc74ba4984b69ffa", size = 61452705, upload-time = "2026-04-24T16:05:45.225Z" },
-    { url = "https://files.pythonhosted.org/packages/00/e5/7e275fc76a7f9cc3240da393ed631d9647c346a36d6392ea4b0ed56326f6/github_copilot_sdk-0.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b591546d789f9f8243fb59ca71b08cb0bb1dbec818fbef060c3830c6787de2c8", size = 59646875, upload-time = "2026-04-24T16:05:48.832Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/67/00e3bf21842b0c418aad6ce233ec8cd7e8ca91859e4f7e571fc47c682ed9/github_copilot_sdk-0.3.0-py3-none-win_amd64.whl", hash = "sha256:c5712d57a2c6291b805c79e039c55c48d858034b1a37fc8e1653925403a028e9", size = 54165496, upload-time = "2026-04-24T16:05:52.712Z" },
-    { url = "https://files.pythonhosted.org/packages/91/1c/76bb5159018a1c0d44b17ded340c91085fb48dd3dc912eb349781c54c200/github_copilot_sdk-0.3.0-py3-none-win_arm64.whl", hash = "sha256:93b07c46f60cebbbb003d5bddba22eab886849b1d052b98037b52b6434a5bc07", size = 52103138, upload-time = "2026-04-24T16:05:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/89/22/d4d576becff84146501e043831bdd2ca5aee57fcfdfface4ee7db7883655/github_copilot_sdk-1.0.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d1ca7fff62b69f8c9aa24eb2d1f615195730d6b7297050e8e240aa38fbae5eba", size = 94824679, upload-time = "2026-06-10T16:54:17.004Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5f/f3d935b81f11930539cdf47a7e0dbd4d5ccaadba1f4daf0c64892421a81d/github_copilot_sdk-1.0.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dc4b59dfe034bec6a031b291dbe49de8a8558e42d28aee25213c680ab771d54e", size = 88837334, upload-time = "2026-06-10T16:54:23.056Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/94/225ec0258e1630a81e13b193a9258d8c4550b552b6197f903b75002abf75/github_copilot_sdk-1.0.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:bedb442ee4dd40d43870719f91a9fb6e117ca5d76bbbf1807af80cc77ff64257", size = 97255205, upload-time = "2026-06-10T16:54:29.828Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/34/72fb3936e7e8a425f1498bd6693a4e7db678e43fc3912dc5ce9cecccfe23/github_copilot_sdk-1.0.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a498fffba3d8a521eb73f31d08fef9f534e7c57ae6d0a76fa1848beebb3fb6a9", size = 94572477, upload-time = "2026-06-10T16:54:37.253Z" },
+    { url = "https://files.pythonhosted.org/packages/df/95/34aa49c08033acabbe129acf83a2d71a382bd2977ce92f5114a299508a4e/github_copilot_sdk-1.0.1-py3-none-win_amd64.whl", hash = "sha256:29d850cf5cf2b85c0513b68cba112d4a7aba0a9a447893fc7cc69136dd4e6ac1", size = 91387201, upload-time = "2026-06-10T16:54:45.164Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/900b278e519442d4a5fc9dd070b9100f6f1e6b3c6af3b8642b0b3a65d2f5/github_copilot_sdk-1.0.1-py3-none-win_arm64.whl", hash = "sha256:5f69245b1cb2fc1054e78543ee5c10464b53ebbba11e749c7a42002b02ce6b13", size = 90455774, upload-time = "2026-06-10T16:54:53.093Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Release prep for **0.1.19** plus a dependency fix that unblocks the `context_tier` feature.

### Changelog — cut `[0.1.19]` (2026-06-16)
Documented the changes that landed since v0.1.18 but were missing from the changelog:

- **Added**: validator block (#220), periodic/milestone checkpoints (#255), script `stdin:` transport (#253), experimental provider tier (#241), `claude-agent-sdk` provider (#104).
- **Fixed**: nested explicit input projection (#239).
- **Corrected a stale note**: the human_gate entry claimed `<gate>.output.additional_input.<field>` was unsupported in `context: explicit` mode — #239 made it resolve (verified by `tests/test_engine/test_context.py:382`).
- Bumped version to `0.1.19`.

### Dependency — `github-copilot-sdk` floor `>=0.3.0` → `>=1.0.0` (re-locked to 1.0.1)
`create_session()` in SDK 0.3.0 has **no `context_tier` kwarg**, so setting `context_tier` (#251) raised a hard `ProviderError` on the pinned floor. The kwarg was added in 1.0.0 (`client.py:1566`).

## Verification (on SDK 1.0.1)

- `context_tier: long_context` probe → ✅ (was a hard error on 0.3.0)
- Smoke run: periodic checkpoints (3× `trigger=periodic`), validator (ran + passed), script stdin (correct aggregation) → ✅
- `#239` nested input, `#237` human_gate shape, `#245` dashboard-kill checkpoint, `#241`/`#104` experimental cross-check → ✅
- Copilot provider unit tests: **84 passed**
- Full suite (excl. `performance`/`real_api`): **3508 passed, 0 failed**
  - 1 `real_api` test fails on internal-model access (`claude-opus-4.7-1m-internal` not available) — environmental, not a regression.

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)