### PR TITLE
fix(copilot): capture resolved model for auto-routed runs

### DIFF
--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -2471,6 +2471,7 @@ class WorkflowEngine:
                     session,
                     interrupt_result.guidance,
                     agent_name=agent.name,
+                    agent_model=agent.model,
                 )
 
         # Fallback: re-execute the agent with guidance appended to prompt

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -121,8 +121,9 @@ class SDKResponse:
         cache_read_tokens: Tokens read from cache (if available).
         cache_write_tokens: Tokens written to cache (if available).
         partial: Whether this response is partial (from a mid-agent interrupt).
-        resolved_model: Actual model name reported by the SDK in the assistant.usage
-            event. None if the event was not emitted (e.g., error paths).
+        resolved_model: Model name the SDK reported in the assistant.usage event's
+            model field. None when that event is absent (error or interrupt paths)
+            or carries no usable model name (the model field is missing or empty).
     """
 
     content: str
@@ -576,8 +577,11 @@ class CopilotProvider(AgentProvider):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     cache_read_tokens=cache_read,
-                    cache_write_tokens=cache_write,
-                    model=(sdk_response.resolved_model if sdk_response else None)
+                    model=(
+                        sdk_response.resolved_model
+                        if sdk_response and agent.model in (None, "auto")
+                        else None
+                    )
                     or agent.model
                     or self._default_model,
                     partial=is_partial,
@@ -1240,6 +1244,7 @@ class CopilotProvider(AgentProvider):
         session: Any,
         guidance: str,
         agent_name: str | None = None,
+        agent_model: str | None = None,
     ) -> AgentOutput:
         """Send follow-up guidance to an interrupted session.
 
@@ -1256,6 +1261,8 @@ class CopilotProvider(AgentProvider):
                 interrupts only fire on sequential agents (for-each iterations
                 do not forward ``interrupt_signal`` to the executor), so the
                 tag, when supplied, is the unqualified agent name.
+            agent_model: Optional configured model for the interrupted agent,
+                used when the follow-up response does not report a resolved model.
 
         Returns:
             AgentOutput with the follow-up response content.
@@ -1292,7 +1299,13 @@ class CopilotProvider(AgentProvider):
                 output_tokens=sdk_response.output_tokens,
                 cache_read_tokens=sdk_response.cache_read_tokens,
                 cache_write_tokens=sdk_response.cache_write_tokens,
-                model=sdk_response.resolved_model or self._default_model,
+                model=(
+                    sdk_response.resolved_model
+                    if agent_model in (None, "auto")
+                    else None
+                )
+                or agent_model
+                or self._default_model,
             )
         finally:
             await session.disconnect()

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -577,6 +577,7 @@ class CopilotProvider(AgentProvider):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     cache_read_tokens=cache_read,
+                    cache_write_tokens=cache_write,
                     model=(
                         sdk_response.resolved_model
                         if sdk_response and agent.model in (None, "auto")
@@ -1299,11 +1300,7 @@ class CopilotProvider(AgentProvider):
                 output_tokens=sdk_response.output_tokens,
                 cache_read_tokens=sdk_response.cache_read_tokens,
                 cache_write_tokens=sdk_response.cache_write_tokens,
-                model=(
-                    sdk_response.resolved_model
-                    if agent_model in (None, "auto")
-                    else None
-                )
+                model=(sdk_response.resolved_model if agent_model in (None, "auto") else None)
                 or agent_model
                 or self._default_model,
             )

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -121,6 +121,8 @@ class SDKResponse:
         cache_read_tokens: Tokens read from cache (if available).
         cache_write_tokens: Tokens written to cache (if available).
         partial: Whether this response is partial (from a mid-agent interrupt).
+        resolved_model: Actual model name reported by the SDK in the assistant.usage
+            event. None if the event was not emitted (e.g., error paths).
     """
 
     content: str
@@ -129,6 +131,7 @@ class SDKResponse:
     cache_read_tokens: int | None = None
     cache_write_tokens: int | None = None
     partial: bool = False
+    resolved_model: str | None = None
 
 
 class CopilotProvider(AgentProvider):
@@ -574,7 +577,9 @@ class CopilotProvider(AgentProvider):
                     output_tokens=output_tokens,
                     cache_read_tokens=cache_read,
                     cache_write_tokens=cache_write,
-                    model=agent.model or self._default_model,
+                    model=(sdk_response.resolved_model if sdk_response else None)
+                    or agent.model
+                    or self._default_model,
                     partial=is_partial,
                 )
             except ProviderError as e:
@@ -888,6 +893,7 @@ class CopilotProvider(AgentProvider):
                         cache_read_tokens=sdk_response.cache_read_tokens,
                         cache_write_tokens=sdk_response.cache_write_tokens,
                         partial=True,
+                        resolved_model=sdk_response.resolved_model,
                     )
                     return partial_content, partial_usage
 
@@ -896,6 +902,7 @@ class CopilotProvider(AgentProvider):
                 total_output_tokens = sdk_response.output_tokens
                 cache_read_tokens = sdk_response.cache_read_tokens
                 cache_write_tokens = sdk_response.cache_write_tokens
+                current_resolved_model = sdk_response.resolved_model
 
                 # If no output schema (or output_mode is raw), we're done
                 if output_schema is None:
@@ -905,6 +912,7 @@ class CopilotProvider(AgentProvider):
                         output_tokens=total_output_tokens,
                         cache_read_tokens=cache_read_tokens,
                         cache_write_tokens=cache_write_tokens,
+                        resolved_model=current_resolved_model,
                     )
                     return {"result": response_content}, final_usage
 
@@ -921,6 +929,7 @@ class CopilotProvider(AgentProvider):
                             output_tokens=total_output_tokens,
                             cache_read_tokens=cache_read_tokens,
                             cache_write_tokens=cache_write_tokens,
+                            resolved_model=current_resolved_model,
                         )
                         return parsed_content, final_usage
                     except (json.JSONDecodeError, ValueError) as e:
@@ -965,6 +974,9 @@ class CopilotProvider(AgentProvider):
                             total_output_tokens = (
                                 total_output_tokens or 0
                             ) + recovery_response.output_tokens
+                        # Keep the latest resolved model (recovery uses the same session/model)
+                        if recovery_response.resolved_model:
+                            current_resolved_model = recovery_response.resolved_model
 
                 # All recovery attempts exhausted
                 expected_fields = list(output_schema.keys())
@@ -1049,6 +1061,9 @@ class CopilotProvider(AgentProvider):
         # Mutable container for usage data: [input_tokens, output_tokens, cache_read, cache_write]
         usage_ref: list[int | None] = [None, None, None, None]
 
+        # Mutable container for the resolved model name (from assistant.usage event)
+        resolved_model_ref: list[str | None] = [None]
+
         # Mutable container for tool iteration counting
         tool_iteration_ref: list[int] = [0]
 
@@ -1093,6 +1108,10 @@ class CopilotProvider(AgentProvider):
                     usage_ref[2] = int(cache_read)
                 if cache_write is not None:
                     usage_ref[3] = int(cache_write)
+                # Capture the actual model resolved by the SDK (e.g., when model="auto")
+                sdk_model = getattr(event.data, "model", None)
+                if sdk_model:
+                    resolved_model_ref[0] = sdk_model
             elif event_type == "session.idle":
                 done.set()
             elif event_type == "error" or event_type == "session.error":
@@ -1148,6 +1167,7 @@ class CopilotProvider(AgentProvider):
                 cache_read_tokens=usage_ref[2],
                 cache_write_tokens=usage_ref[3],
                 partial=True,
+                resolved_model=resolved_model_ref[0],
             )
 
         if error_message:
@@ -1162,6 +1182,7 @@ class CopilotProvider(AgentProvider):
             output_tokens=usage_ref[1],
             cache_read_tokens=usage_ref[2],
             cache_write_tokens=usage_ref[3],
+            resolved_model=resolved_model_ref[0],
         )
 
     async def _abort_session(self, session: Any, done: asyncio.Event) -> None:
@@ -1271,7 +1292,7 @@ class CopilotProvider(AgentProvider):
                 output_tokens=sdk_response.output_tokens,
                 cache_read_tokens=sdk_response.cache_read_tokens,
                 cache_write_tokens=sdk_response.cache_write_tokens,
-                model=self._default_model,
+                model=sdk_response.resolved_model or self._default_model,
             )
         finally:
             await session.disconnect()

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -1756,7 +1756,8 @@ class TestCopilotProviderResolvedModel:
     # claude-sonnet-4 is used in pricing/usage tests as the canonical model and exists in the
     # Conductor pricing table, so it satisfies both propagation and cost-calculation tests.
     _RESOLVED_MODEL_FROM_SDK = "claude-sonnet-4"
-    _PRICEABLE_MODEL = "claude-sonnet-4"
+    _PRICEABLE_MODEL = "gpt-4o"
+    _UNPRICEABLE_RESOLVED_MODEL = "claude-sonnet-4.5"
 
     class _FakeSession:
         session_id = "session-fake"
@@ -1812,22 +1813,141 @@ class TestCopilotProviderResolvedModel:
         result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
         assert result.model == "auto"
 
-    def test_resolved_model_enables_cost_calculation(self) -> None:
-        """AgentOutput with a resolved priceable model produces non-null cost_usd."""
+    @pytest.mark.asyncio
+    async def test_resolved_model_enables_auto_model_cost_calculation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A resolved priceable model from execute() produces non-null cost_usd."""
         from conductor.engine.usage import UsageTracker
-        from conductor.providers.base import AgentOutput
 
+        provider = CopilotProvider(retry_config=RetryConfig(max_attempts=1))
+        provider._client = self._FakeClient()
+        agent = AgentDef(name="a", model="auto", prompt="p")
+
+        async def fake_send(*args: Any, **kwargs: Any) -> SDKResponse:
+            return SDKResponse(
+                content='{"result":"ok"}',
+                input_tokens=1000,
+                output_tokens=500,
+                resolved_model=self._RESOLVED_MODEL_FROM_SDK,
+            )
+
+        async def noop() -> None:
+            return None
+
+        monkeypatch.setattr(provider, "_ensure_client_started", noop)
+        monkeypatch.setattr(provider, "_send_and_wait", fake_send)
+
+        result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
         tracker = UsageTracker()
-        output = AgentOutput(
-            content={},
-            raw_response="",
-            input_tokens=1000,
-            output_tokens=500,
-            model=self._PRICEABLE_MODEL,  # only needs to be in Conductor pricing table
-        )
-        usage = tracker.record("agent", output, elapsed=1.0)
+        usage = tracker.record("agent", result, elapsed=1.0)
         assert usage.cost_usd is not None
         assert usage.cost_usd > 0
+
+    @pytest.mark.asyncio
+    async def test_auto_model_without_resolved_model_remains_unpriced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """model='auto' remains unpriceable when the SDK does not report a model."""
+        from conductor.engine.usage import UsageTracker
+
+        provider = CopilotProvider(retry_config=RetryConfig(max_attempts=1))
+        provider._client = self._FakeClient()
+        agent = AgentDef(name="a", model="auto", prompt="p")
+
+        async def fake_send(*args: Any, **kwargs: Any) -> SDKResponse:
+            return SDKResponse(
+                content='{"result":"ok"}',
+                input_tokens=1000,
+                output_tokens=500,
+                resolved_model=None,
+            )
+
+        async def noop() -> None:
+            return None
+
+        monkeypatch.setattr(provider, "_ensure_client_started", noop)
+        monkeypatch.setattr(provider, "_send_and_wait", fake_send)
+
+        result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
+        usage = UsageTracker().record("agent", result, elapsed=1.0)
+        assert result.model == "auto"
+        assert usage.cost_usd is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_priceable_model_ignores_unpriceable_resolved_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit configured models keep their pricing name over SDK aliases."""
+        from conductor.engine.usage import UsageTracker
+
+        provider = CopilotProvider(retry_config=RetryConfig(max_attempts=1))
+        provider._client = self._FakeClient()
+        agent = AgentDef(name="a", model=self._PRICEABLE_MODEL, prompt="p")
+
+        async def fake_send(*args: Any, **kwargs: Any) -> SDKResponse:
+            return SDKResponse(
+                content='{"result":"ok"}',
+                input_tokens=1000,
+                output_tokens=500,
+                resolved_model=self._UNPRICEABLE_RESOLVED_MODEL,
+            )
+
+        async def noop() -> None:
+            return None
+
+        monkeypatch.setattr(provider, "_ensure_client_started", noop)
+        monkeypatch.setattr(provider, "_send_and_wait", fake_send)
+
+        result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
+        usage = UsageTracker().record("agent", result, elapsed=1.0)
+        assert result.model == self._PRICEABLE_MODEL
+        assert usage.cost_usd is not None
+        assert usage.cost_usd > 0
+
+    @pytest.mark.asyncio
+    async def test_followup_preserves_explicit_model_over_unpriceable_resolved_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Follow-up turns keep explicit pricing names over SDK aliases."""
+        provider = CopilotProvider(retry_config=RetryConfig(max_attempts=1))
+
+        async def fake_send(*args: Any, **kwargs: Any) -> SDKResponse:
+            return SDKResponse(
+                content='{"result":"ok"}',
+                resolved_model=self._UNPRICEABLE_RESOLVED_MODEL,
+            )
+
+        monkeypatch.setattr(provider, "_send_and_wait", fake_send)
+
+        result = await provider.send_followup(
+            self._FakeSession(),
+            guidance="continue",
+            agent_model=self._PRICEABLE_MODEL,
+        )
+        assert result.model == self._PRICEABLE_MODEL
+
+    @pytest.mark.asyncio
+    async def test_followup_uses_resolved_model_for_auto_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Follow-up turns use SDK resolved model for auto-routed agents."""
+        provider = CopilotProvider(retry_config=RetryConfig(max_attempts=1))
+
+        async def fake_send(*args: Any, **kwargs: Any) -> SDKResponse:
+            return SDKResponse(
+                content='{"result":"ok"}',
+                resolved_model=self._RESOLVED_MODEL_FROM_SDK,
+            )
+
+        monkeypatch.setattr(provider, "_send_and_wait", fake_send)
+
+        result = await provider.send_followup(
+            self._FakeSession(),
+            guidance="continue",
+            agent_model="auto",
+        )
+        assert result.model == self._RESOLVED_MODEL_FROM_SDK
 
     @pytest.mark.asyncio
     async def test_send_and_wait_captures_model_from_usage_event(self) -> None:

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -1747,3 +1747,127 @@ class TestContextTier:
         await provider.execute(agent=agent, context={}, rendered_prompt="Analyze")
         assert captured["create_session_kwargs"]["context_tier"] == "long_context"
         assert captured["create_session_kwargs"]["reasoning_effort"] == "high"
+
+
+class TestCopilotProviderResolvedModel:
+    """Tests for SDKResponse.resolved_model propagation into AgentOutput.model."""
+
+    # These are mocked tests; model availability in the live Copilot environment is not required.
+    # claude-sonnet-4 is used in pricing/usage tests as the canonical model and exists in the
+    # Conductor pricing table, so it satisfies both propagation and cost-calculation tests.
+    _RESOLVED_MODEL_FROM_SDK = "claude-sonnet-4"
+    _PRICEABLE_MODEL = "claude-sonnet-4"
+
+    class _FakeSession:
+        session_id = "session-fake"
+
+        async def disconnect(self) -> None:
+            return None
+
+    class _FakeClient:
+        async def create_session(self, **kwargs: Any) -> Any:
+            return TestCopilotProviderResolvedModel._FakeSession()
+
+    @pytest.mark.asyncio
+    async def test_resolved_model_from_sdk_overrides_auto(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SDKResponse.resolved_model propagates into AgentOutput.model for model='auto'."""
+        provider = CopilotProvider(retry_config=RetryConfig(max_attempts=1))
+        provider._client = self._FakeClient()
+        agent = AgentDef(name="a", model="auto", prompt="p")
+
+        async def fake_send(*args: Any, **kwargs: Any) -> SDKResponse:
+            return SDKResponse(
+                content='{"result":"ok"}', resolved_model=self._RESOLVED_MODEL_FROM_SDK
+            )
+
+        async def noop() -> None:
+            return None
+
+        monkeypatch.setattr(provider, "_ensure_client_started", noop)
+        monkeypatch.setattr(provider, "_send_and_wait", fake_send)
+
+        result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
+        assert result.model == self._RESOLVED_MODEL_FROM_SDK
+
+    @pytest.mark.asyncio
+    async def test_resolved_model_fallback_when_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When resolved_model is None, AgentOutput.model falls back to agent.model."""
+        provider = CopilotProvider(retry_config=RetryConfig(max_attempts=1))
+        provider._client = self._FakeClient()
+        agent = AgentDef(name="a", model="auto", prompt="p")
+
+        async def fake_send(*args: Any, **kwargs: Any) -> SDKResponse:
+            return SDKResponse(content='{"result":"ok"}', resolved_model=None)
+
+        async def noop() -> None:
+            return None
+
+        monkeypatch.setattr(provider, "_ensure_client_started", noop)
+        monkeypatch.setattr(provider, "_send_and_wait", fake_send)
+
+        result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
+        assert result.model == "auto"
+
+    def test_resolved_model_enables_cost_calculation(self) -> None:
+        """AgentOutput with a resolved priceable model produces non-null cost_usd."""
+        from conductor.engine.usage import UsageTracker
+        from conductor.providers.base import AgentOutput
+
+        tracker = UsageTracker()
+        output = AgentOutput(
+            content={},
+            raw_response="",
+            input_tokens=1000,
+            output_tokens=500,
+            model=self._PRICEABLE_MODEL,  # only needs to be in Conductor pricing table
+        )
+        usage = tracker.record("agent", output, elapsed=1.0)
+        assert usage.cost_usd is not None
+        assert usage.cost_usd > 0
+
+    @pytest.mark.asyncio
+    async def test_send_and_wait_captures_model_from_usage_event(self) -> None:
+        """_send_and_wait extracts event.data.model from assistant.usage into resolved_model."""
+        from unittest.mock import Mock as _Mock
+
+        provider = CopilotProvider(retry_config=RetryConfig(max_attempts=1))
+        captured_cb: list[Any] = []
+
+        # Build assistant.usage event with explicit token counts and model name.
+        usage_ev = _Mock()
+        usage_ev.type.value = "assistant.usage"
+        usage_ev.data.input_tokens = 100
+        usage_ev.data.output_tokens = 50
+        usage_ev.data.cache_read_tokens = None
+        usage_ev.data.cache_write_tokens = None
+        usage_ev.data.model = self._RESOLVED_MODEL_FROM_SDK
+
+        # session.idle tells _send_and_wait the turn is complete.
+        idle_ev = _Mock()
+        idle_ev.type.value = "session.idle"
+
+        def on_event(callback: Any) -> None:
+            captured_cb.append(callback)
+
+        session = _Mock()
+        session.on = on_event
+
+        async def fake_send(prompt: str) -> None:
+            assert captured_cb, "Expected _send_and_wait to register a session event callback"
+            callback = captured_cb[0]
+            for ev in (usage_ev, idle_ev):
+                callback(ev)
+
+        session.send = fake_send
+
+        result = await provider._send_and_wait(
+            session=session,
+            prompt="hello",
+            verbose_enabled=False,
+            full_enabled=False,
+        )
+        assert result.resolved_model == self._RESOLVED_MODEL_FROM_SDK


### PR DESCRIPTION
## Summary

This PR captures the concrete model resolved by the Copilot SDK for auto-routed runs.

Previously, when an agent was configured with `model: auto`, Conductor recorded `AgentOutput.model` as `"auto"` even though the Copilot SDK had resolved the request to a concrete model. Token usage was available, but downstream accounting could not attribute that usage to the actual model.

This change captures `event.data.model` from the SDK `assistant.usage` event, stores it as `SDKResponse.resolved_model`, preserves it through response reconstruction paths, and uses it for `AgentOutput.model` when available.

## What changed

- Add `resolved_model` to `SDKResponse`.
- Capture the resolved model from `assistant.usage`.
- Preserve `resolved_model` through `_execute_sdk_call`.
- Use the resolved model when constructing `AgentOutput`.
- Keep existing fallback behavior when no resolved model is available.
- Add tests for:
  - resolved model propagation;
  - fallback behavior;
  - cost calculation when the resolved model is priceable;
  - SDK `assistant.usage` event extraction.

## Validation

Unit tests:

- `uv run pytest tests/test_providers/test_copilot.py::TestCopilotProviderResolvedModel -v` — passed
- `uv run pytest tests/test_providers/test_copilot.py -v` — passed

Local smoke tests with Copilot:

- `model: auto` structured-output run resolved to a concrete model instead of `"auto"`.
- explicit resolved-model run succeeded.
- `model: auto` no-schema/raw-output run resolved to a concrete model instead of `"auto"`.

Observed resolved models included `gpt-5.3-codex` / `gpt-5.4-mini` depending on the run.

## Notes

This PR does not attempt to calculate GitHub Copilot credit or USD cost. Copilot pricing/accounting is plan and policy dependent and may change independently from the SDK. The change records the concrete resolved model so downstream pricing or accounting logic can make an informed decision instead of receiving `"auto"`.