### PR TITLE
fix(validate): extend per-agent capability checks to for_each inline agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sub-workflow usage under-reporting in the same issue was already fixed in
   [#212](https://github.com/microsoft/conductor/pull/212).)
   ([#266](https://github.com/microsoft/conductor/issues/266))
+- **`for_each` inline agents skipped most provider-capability checks** —
+  `conductor validate`'s provider-capability cross-check applied the full
+  per-agent matrix (reasoning effort, structured output, per-agent MCP provider
+  override, explicit `max_session_seconds`) only to top-level `agents:`. A
+  `for_each` group's inline agent — which runs at runtime exactly like a
+  top-level agent — was checked for tool allowlists only, so it could request a
+  capability its provider doesn't support (e.g. `reasoning.effort: high` on the
+  `claude-agent-sdk` provider), pass validation, then fail or silently degrade
+  mid-iteration. The per-agent checks are now shared and run over inline agents
+  too, and the workflow-level `mcp_servers` / `max_session_seconds` inheritance
+  checks now also account for inline agents on the default provider.
+  ([#270](https://github.com/microsoft/conductor/issues/270))
 - **For-each dive-in worked only for finished items** — in the web dashboard's
   for-each group detail panel, the per-item "Dive into subworkflow" control was
   nested inside the row's expand/collapse `<button>`, which is `disabled` while

--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -1579,6 +1579,13 @@ def _validate_provider_capabilities(
 
     default_provider = config.workflow.runtime.provider.name
     workflow_mcp_servers = config.workflow.runtime.mcp_servers
+    # Workflow-wide reasoning-effort / session-timeout defaults. Bound at the
+    # top of the function — above the nested helpers that consume them — so
+    # ``_check_agent_capabilities`` (which reads ``runtime_default_effort`` as a
+    # closure free-variable) can never be invoked before the name is assigned,
+    # no matter where future call sites are added.
+    runtime_default_effort = config.workflow.runtime.default_reasoning_effort
+    runtime_max_session_seconds = config.workflow.runtime.max_session_seconds
 
     # Cache per provider name so we don't re-resolve for every agent.
     cache: dict[str, ProviderCapabilities] = {}
@@ -1643,12 +1650,14 @@ def _validate_provider_capabilities(
         ``AgentDef`` — which is not in ``config.agents`` but runs identically at
         runtime — gets the same treatment as a top-level agent (#270).
 
-        Reads ``runtime_default_effort`` from the enclosing scope; only invoked
-        after it has been assigned.
+        Reads the workflow-wide ``runtime_default_effort`` from the enclosing
+        scope; it is bound at the top of the function, so every call site is safe.
         """
         # Per-agent override against workflow-level mcp_servers: if the
         # workflow declared mcp_servers but this agent's resolved provider
         # is different from the default, the override skips MCP entirely.
+        # (The workflow-level MCP check below only flags agents that resolve to
+        # the DEFAULT provider, so inherit vs. override never double-report.)
         if workflow_mcp_servers and provider_name != default_provider and not caps.mcp_tools:
             errors.append(
                 f"Agent '{agent.name}' overrides provider to '{provider_name}', which "
@@ -1730,7 +1739,9 @@ def _validate_provider_capabilities(
     # workflow-level ``mcp_servers`` / ``max_session_seconds`` and run with
     # ``workflow_tools`` exactly like top-level agents. The workflow-level
     # inheritance checks below iterate this combined list so an inline agent on
-    # an incapable default provider can't silently escape them (#270).
+    # an incapable default provider can't silently escape them (#270). (The
+    # workflow-wide default reasoning effort is inherited too, but it is checked
+    # per-agent inside ``_check_agent_capabilities``, not via this list.)
     all_llm_agents = [a for a in config.agents if _is_llm_agent(a)] + [
         fe.agent for fe in config.for_each if _is_llm_agent(fe.agent)
     ]
@@ -1759,12 +1770,6 @@ def _validate_provider_capabilities(
                     f"MCP support, or use an MCP-capable default provider."
                 )
 
-    # Per-agent default reasoning effort (workflow-wide). Pulled outside
-    # the per-agent loop because it applies to every LLM agent that does
-    # NOT override ``reasoning.effort`` explicitly.
-    runtime_default_effort = config.workflow.runtime.default_reasoning_effort
-    runtime_max_session_seconds = config.workflow.runtime.max_session_seconds
-
     # ----- Workflow-level: max_session_seconds -----
     # When the workflow sets a default session timeout, every LLM agent
     # inherits it. A provider that ignores max_session_seconds would
@@ -1775,7 +1780,8 @@ def _validate_provider_capabilities(
         for agent in all_llm_agents:
             # If the agent overrides max_session_seconds explicitly, the
             # workflow-level value does not reach the provider for this
-            # agent — its per-agent override is handled per-agent below.
+            # agent — its per-agent override is handled by
+            # ``_check_agent_capabilities`` instead.
             if agent.max_session_seconds is not None:
                 continue
             pname = _resolved_provider_name(agent, default_provider)

--- a/src/conductor/config/validator.py
+++ b/src/conductor/config/validator.py
@@ -1630,76 +1630,22 @@ def _validate_provider_capabilities(
                 f"'tools: []' to disable all tools."
             )
 
-    # ----- Workflow-level: MCP servers -----
-    # An mcp_servers block applies only to provider-backed agents that
-    # actually resolve to a provider lacking MCP support. If every LLM
-    # agent overrides to an MCP-capable provider, the workflow-level
-    # mcp_servers block is fine even when the default provider lacks MCP.
-    if workflow_mcp_servers:
-        agents_using_default = [
-            a
-            for a in config.agents
-            if _is_llm_agent(a) and _resolved_provider_name(a, default_provider) == default_provider
-        ]
-        if agents_using_default:
-            default_caps = _caps_for(default_provider)
-            if default_caps is not None and not default_caps.mcp_tools:
-                errors.append(
-                    f"Workflow declares 'runtime.mcp_servers' "
-                    f"({sorted(workflow_mcp_servers)!r}) but the default provider "
-                    f"'{default_provider}' does not support MCP servers "
-                    f"(capabilities.mcp_tools=False) and is used by agent(s): "
-                    f"{sorted(a.name for a in agents_using_default)!r}. "
-                    f"Remove mcp_servers, override these agents to a provider with "
-                    f"MCP support, or use an MCP-capable default provider."
-                )
+    def _check_agent_capabilities(
+        agent: AgentDef, provider_name: str, caps: ProviderCapabilities
+    ) -> None:
+        """Full per-agent capability cross-check shared by top-level and for_each agents.
 
-    # Per-agent default reasoning effort (workflow-wide). Pulled outside
-    # the per-agent loop because it applies to every LLM agent that does
-    # NOT override ``reasoning.effort`` explicitly.
-    runtime_default_effort = config.workflow.runtime.default_reasoning_effort
-    runtime_max_session_seconds = config.workflow.runtime.max_session_seconds
+        Runs every per-agent capability check against the agent's resolved
+        provider: per-agent MCP provider-override, tools allowlist (via
+        :func:`_check_agent_tools`), reasoning effort (per-agent override OR the
+        inherited workflow-wide default), structured output schema, and an
+        explicit ``max_session_seconds``. Shared so a ``for_each`` group's inline
+        ``AgentDef`` — which is not in ``config.agents`` but runs identically at
+        runtime — gets the same treatment as a top-level agent (#270).
 
-    # ----- Workflow-level: max_session_seconds -----
-    # When the workflow sets a default session timeout, every LLM agent
-    # inherits it. A provider that ignores max_session_seconds would
-    # silently violate the operator's intent, just like the mcp_servers
-    # case above. Check against every resolved provider in use.
-    if runtime_max_session_seconds is not None:
-        providers_using_default_timeout: dict[str, list[str]] = {}
-        for agent in config.agents:
-            if not _is_llm_agent(agent):
-                continue
-            # If the agent overrides max_session_seconds explicitly, the
-            # workflow-level value does not reach the provider for this
-            # agent — its per-agent override is handled in the loop below.
-            if agent.max_session_seconds is not None:
-                continue
-            pname = _resolved_provider_name(agent, default_provider)
-            providers_using_default_timeout.setdefault(pname, []).append(agent.name)
-        for pname, agent_names in providers_using_default_timeout.items():
-            pcaps = _caps_for(pname)
-            if pcaps is not None and not pcaps.max_session_seconds:
-                errors.append(
-                    f"Workflow declares 'runtime.max_session_seconds'="
-                    f"{runtime_max_session_seconds!r} but provider '{pname}' "
-                    f"does not enforce session timeouts "
-                    f"(capabilities.max_session_seconds=False) and is used by "
-                    f"agent(s): {sorted(agent_names)!r}. Override these agents "
-                    f"to a timeout-aware provider, or remove the workflow-level "
-                    f"max_session_seconds."
-                )
-
-    # ----- Per-agent checks -----
-    for agent in config.agents:
-        if not _is_llm_agent(agent):
-            continue
-
-        provider_name = _resolved_provider_name(agent, default_provider)
-        caps = _caps_for(provider_name)
-        if caps is None:
-            continue  # error already recorded by _caps_for
-
+        Reads ``runtime_default_effort`` from the enclosing scope; only invoked
+        after it has been assigned.
+        """
         # Per-agent override against workflow-level mcp_servers: if the
         # workflow declared mcp_servers but this agent's resolved provider
         # is different from the default, the override skips MCP entirely.
@@ -1711,8 +1657,7 @@ def _validate_provider_capabilities(
             )
 
         # tools allowlist (explicit non-empty list) and the omitted-tools
-        # inheritance footgun against non-passthrough providers. Shared with
-        # the for_each inline-agent pass below.
+        # inheritance footgun against non-passthrough providers.
         _check_agent_tools(agent, provider_name, caps)
 
         # reasoning.effort: validate per-agent override OR workflow-wide
@@ -1780,14 +1725,94 @@ def _validate_provider_capabilities(
                 f"(capabilities.max_session_seconds=False)."
             )
 
-    # ----- For-each inline agents: tools capability cross-check -----
+    # All provider-backed agents that run at workflow scope: top-level agents
+    # PLUS for_each inline agents (``ForEachDef.agent``), which inherit the
+    # workflow-level ``mcp_servers`` / ``max_session_seconds`` and run with
+    # ``workflow_tools`` exactly like top-level agents. The workflow-level
+    # inheritance checks below iterate this combined list so an inline agent on
+    # an incapable default provider can't silently escape them (#270).
+    all_llm_agents = [a for a in config.agents if _is_llm_agent(a)] + [
+        fe.agent for fe in config.for_each if _is_llm_agent(fe.agent)
+    ]
+
+    # ----- Workflow-level: MCP servers -----
+    # An mcp_servers block applies only to provider-backed agents that
+    # actually resolve to a provider lacking MCP support. If every LLM
+    # agent overrides to an MCP-capable provider, the workflow-level
+    # mcp_servers block is fine even when the default provider lacks MCP.
+    if workflow_mcp_servers:
+        agents_using_default = [
+            a
+            for a in all_llm_agents
+            if _resolved_provider_name(a, default_provider) == default_provider
+        ]
+        if agents_using_default:
+            default_caps = _caps_for(default_provider)
+            if default_caps is not None and not default_caps.mcp_tools:
+                errors.append(
+                    f"Workflow declares 'runtime.mcp_servers' "
+                    f"({sorted(workflow_mcp_servers)!r}) but the default provider "
+                    f"'{default_provider}' does not support MCP servers "
+                    f"(capabilities.mcp_tools=False) and is used by agent(s): "
+                    f"{sorted(a.name for a in agents_using_default)!r}. "
+                    f"Remove mcp_servers, override these agents to a provider with "
+                    f"MCP support, or use an MCP-capable default provider."
+                )
+
+    # Per-agent default reasoning effort (workflow-wide). Pulled outside
+    # the per-agent loop because it applies to every LLM agent that does
+    # NOT override ``reasoning.effort`` explicitly.
+    runtime_default_effort = config.workflow.runtime.default_reasoning_effort
+    runtime_max_session_seconds = config.workflow.runtime.max_session_seconds
+
+    # ----- Workflow-level: max_session_seconds -----
+    # When the workflow sets a default session timeout, every LLM agent
+    # inherits it. A provider that ignores max_session_seconds would
+    # silently violate the operator's intent, just like the mcp_servers
+    # case above. Check against every resolved provider in use.
+    if runtime_max_session_seconds is not None:
+        providers_using_default_timeout: dict[str, list[str]] = {}
+        for agent in all_llm_agents:
+            # If the agent overrides max_session_seconds explicitly, the
+            # workflow-level value does not reach the provider for this
+            # agent — its per-agent override is handled per-agent below.
+            if agent.max_session_seconds is not None:
+                continue
+            pname = _resolved_provider_name(agent, default_provider)
+            providers_using_default_timeout.setdefault(pname, []).append(agent.name)
+        for pname, agent_names in providers_using_default_timeout.items():
+            pcaps = _caps_for(pname)
+            if pcaps is not None and not pcaps.max_session_seconds:
+                errors.append(
+                    f"Workflow declares 'runtime.max_session_seconds'="
+                    f"{runtime_max_session_seconds!r} but provider '{pname}' "
+                    f"does not enforce session timeouts "
+                    f"(capabilities.max_session_seconds=False) and is used by "
+                    f"agent(s): {sorted(agent_names)!r}. Override these agents "
+                    f"to a timeout-aware provider, or remove the workflow-level "
+                    f"max_session_seconds."
+                )
+
+    # ----- Per-agent checks -----
+    for agent in config.agents:
+        if not _is_llm_agent(agent):
+            continue
+
+        provider_name = _resolved_provider_name(agent, default_provider)
+        caps = _caps_for(provider_name)
+        if caps is None:
+            continue  # error already recorded by _caps_for
+
+        _check_agent_capabilities(agent, provider_name, caps)
+
+    # ----- For-each inline agents: full per-agent capability cross-check -----
     # A for_each group carries an INLINE ``AgentDef`` (not in ``config.agents``)
     # that runs with ``workflow_tools=config.tools``, exactly like a top-level
-    # agent. The per-agent loop above skips it, so re-run the tools check here —
-    # otherwise an inline agent that omits ``tools:`` against a non-passthrough
-    # provider slips past ``validate`` and fails mid-iteration with the same
-    # confusing runtime error. (Extending the remaining per-agent capability
-    # checks to inline agents is tracked in #270.)
+    # agent. The per-agent loop above skips it, so re-run the SAME capability
+    # checks here (#270) — per-agent MCP override, tools allowlist, reasoning
+    # effort, structured output, and explicit max_session_seconds. Otherwise an
+    # inline agent could request a capability its provider lacks, slip past
+    # ``validate``, and fail or silently degrade mid-iteration.
     for fe in config.for_each:
         inline_agent = fe.agent
         if not _is_llm_agent(inline_agent):
@@ -1796,7 +1821,7 @@ def _validate_provider_capabilities(
         inline_caps = _caps_for(inline_provider)
         if inline_caps is None:
             continue  # error already recorded by _caps_for
-        _check_agent_tools(inline_agent, inline_provider, inline_caps)
+        _check_agent_capabilities(inline_agent, inline_provider, inline_caps)
 
     # ----- Concurrency safety in parallel / for_each groups -----
     agent_by_name = {a.name: a for a in config.agents}

--- a/tests/test_config/test_validator_capabilities.py
+++ b/tests/test_config/test_validator_capabilities.py
@@ -886,8 +886,8 @@ class TestForEachInlineCapabilityCrossCheck:
     remaining per-agent checks (reasoning effort, structured output, per-agent
     MCP override, explicit max_session_seconds) so an inline agent gets identical
     treatment to a top-level agent. In each test the entry agent is inert, so the
-    assertion isolates to the inline (``inner``) agent — without the fix the
-    inline agent is skipped and NO error is raised.
+    assertion isolates to the inline (``inner``) agent — without the fix these
+    per-agent checks are skipped for the inline agent and NO error is raised.
     """
 
     def test_inline_reasoning_unsupported_level_errors(self, patch_caps: Any) -> None:
@@ -1098,3 +1098,41 @@ class TestForEachInlineWorkflowLevelInheritance:
             ),
         )
         validate_workflow_config(config)  # no raise
+
+    def test_inline_non_llm_human_gate_skipped(self, patch_caps: Any) -> None:
+        """A non-LLM (human_gate) inline agent must be SKIPPED by the
+        ``_is_llm_agent`` filter — even on an incapable default provider that
+        declares ``mcp_servers``, ``max_session_seconds``, AND
+        ``default_reasoning_effort`` that an LLM inline agent WOULD inherit and
+        fail on. Guards the inline ``_is_llm_agent`` guard (feeding
+        ``all_llm_agents`` and the for_each per-agent loop) against a future
+        refactor that drops it and spuriously fail-validates the workflow.
+        """
+        from conductor.config.schema import GateOption
+
+        patch_caps(
+            {
+                # Default provider is incapable on all three inherited axes;
+                # only a non-skipped LLM agent on it would raise.
+                "copilot": _caps(mcp_tools=False, max_session_seconds=False, reasoning_effort=None),
+                "claude": _caps(),  # entry override → capable, so entry never trips
+            }
+        )
+        config = self._inheritance_config(
+            inline=AgentDef(
+                name="gate",
+                type="human_gate",
+                prompt="Approve {{ item }}?",
+                options=[
+                    GateOption(label="OK", value="ok", route="$end"),
+                    GateOption(label="No", value="no", route="$end"),
+                ],
+            ),
+            runtime=RuntimeConfig(
+                provider="copilot",
+                default_reasoning_effort="high",
+                max_session_seconds=120.0,
+                mcp_servers={"docs": MCPServerDef(command="docs-server")},
+            ),
+        )
+        validate_workflow_config(config)  # must not raise — human_gate is skipped

--- a/tests/test_config/test_validator_capabilities.py
+++ b/tests/test_config/test_validator_capabilities.py
@@ -69,6 +69,35 @@ def _build_workflow(
     )
 
 
+def _for_each_workflow(
+    *,
+    inline: AgentDef,
+    tools: list[str] | None = None,
+    mcp_servers: dict[str, MCPServerDef] | None = None,
+) -> WorkflowConfig:
+    """Build a workflow whose only for_each group carries ``inline``.
+
+    The entry agent opts out of tools (``tools: []``) and no workflow-wide
+    defaults are set, so — unless a test says otherwise — only the inline agent
+    can trip a per-agent capability check, isolating the assertion to the
+    for_each path (#270).
+    """
+    return _build_workflow(
+        agents=[AgentDef(name="entry", prompt="hi", tools=[])],
+        tools=tools,
+        mcp_servers=mcp_servers,
+        for_each=[
+            ForEachDef(
+                name="loop",
+                type="for_each",
+                source="entry.output.items",
+                **{"as": "item"},
+                agent=inline,
+            )
+        ],
+    )
+
+
 @pytest.fixture
 def patch_caps(monkeypatch: pytest.MonkeyPatch):
     """Replace ``get_capabilities`` with a controllable mapping.
@@ -848,3 +877,224 @@ class TestMultiErrorAggregation:
         # on the first error.
         assert "agent_a" in msg
         assert "agent_b" in msg
+
+
+class TestForEachInlineCapabilityCrossCheck:
+    """Per-agent capability checks must ALSO cover a for_each group's INLINE agent (#270).
+
+    #269 wired the *tools* check into the for_each inline pass; #270 extends the
+    remaining per-agent checks (reasoning effort, structured output, per-agent
+    MCP override, explicit max_session_seconds) so an inline agent gets identical
+    treatment to a top-level agent. In each test the entry agent is inert, so the
+    assertion isolates to the inline (``inner``) agent — without the fix the
+    inline agent is skipped and NO error is raised.
+    """
+
+    def test_inline_reasoning_unsupported_level_errors(self, patch_caps: Any) -> None:
+        patch_caps({"copilot": _caps(reasoning_effort=("low", "medium"))})
+        config = _for_each_workflow(
+            inline=AgentDef(
+                name="inner", prompt="{{ item }}", reasoning=ReasoningConfig(effort="high")
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="Agent 'inner'.*supports only.*low.*medium"):
+            validate_workflow_config(config)
+
+    def test_inline_reasoning_on_no_reasoning_provider_errors(self, patch_caps: Any) -> None:
+        """The confirmed #270 example: inline ``reasoning.effort`` on a provider
+        that ignores reasoning (e.g. claude-agent-sdk) must error, exactly like
+        the identical agent at top level."""
+        patch_caps({"copilot": _caps(reasoning_effort=None)})
+        config = _for_each_workflow(
+            inline=AgentDef(
+                name="inner", prompt="{{ item }}", reasoning=ReasoningConfig(effort="high")
+            ),
+        )
+        with pytest.raises(
+            ConfigurationError, match="Agent 'inner'.*does not support reasoning effort"
+        ):
+            validate_workflow_config(config)
+
+    def test_inline_reasoning_supported_level_passes(self, patch_caps: Any) -> None:
+        patch_caps({"copilot": _caps(reasoning_effort=("low", "medium", "high"))})
+        config = _for_each_workflow(
+            inline=AgentDef(
+                name="inner", prompt="{{ item }}", reasoning=ReasoningConfig(effort="medium")
+            ),
+        )
+        validate_workflow_config(config)  # no raise
+
+    def test_inline_structured_output_no_support_errors(self, patch_caps: Any) -> None:
+        patch_caps({"copilot": _caps(structured_output="none")})
+        config = _for_each_workflow(
+            inline=AgentDef(
+                name="inner", prompt="{{ item }}", output={"x": OutputField(type="string")}
+            ),
+        )
+        with pytest.raises(
+            ConfigurationError, match="Agent 'inner'.*does not support structured output"
+        ):
+            validate_workflow_config(config)
+
+    def test_inline_structured_output_experimental_prompt_injection_warns(
+        self, patch_caps: Any
+    ) -> None:
+        patch_caps({"copilot": _caps(tier="experimental", structured_output="prompt_injection")})
+        config = _for_each_workflow(
+            inline=AgentDef(
+                name="inner", prompt="{{ item }}", output={"x": OutputField(type="string")}
+            ),
+        )
+        warnings = validate_workflow_config(config)
+        assert any("inner" in w and "prompt injection" in w for w in warnings), warnings
+
+    def test_inline_explicit_max_session_seconds_on_unsupported_errors(
+        self, patch_caps: Any
+    ) -> None:
+        patch_caps({"copilot": _caps(max_session_seconds=False)})
+        config = _for_each_workflow(
+            inline=AgentDef(name="inner", prompt="{{ item }}", max_session_seconds=120.0),
+        )
+        with pytest.raises(
+            ConfigurationError, match="Agent 'inner'.*does not enforce session timeouts"
+        ):
+            validate_workflow_config(config)
+
+    def test_inline_provider_override_against_mcp_errors(self, patch_caps: Any) -> None:
+        """An inline agent overriding to a non-MCP provider while the workflow
+        declares mcp_servers must error (the entry agent stays on the MCP-capable
+        default, so only the inline override trips the check)."""
+        patch_caps(
+            {
+                "copilot": _caps(mcp_tools=True),  # default (entry uses this)
+                "claude": _caps(mcp_tools=False),  # inline override
+            }
+        )
+        config = _for_each_workflow(
+            inline=AgentDef(name="inner", prompt="{{ item }}", provider="claude"),
+            mcp_servers={"docs": MCPServerDef(command="docs-server")},
+        )
+        with pytest.raises(ConfigurationError, match="Agent 'inner'.*MCP servers"):
+            validate_workflow_config(config)
+
+    def test_inline_on_fully_capable_default_passes(self, patch_caps: Any) -> None:
+        """A fully-capable provider honors every declared capability → no error.
+
+        Guards against false positives from running the full check over inline
+        agents.
+        """
+        patch_caps({"copilot": _caps()})
+        config = _for_each_workflow(
+            inline=AgentDef(
+                name="inner",
+                prompt="{{ item }}",
+                reasoning=ReasoningConfig(effort="high"),
+                max_session_seconds=60.0,
+                output={"x": OutputField(type="string")},
+            ),
+        )
+        validate_workflow_config(config)  # no raise
+
+
+class TestForEachInlineWorkflowLevelInheritance:
+    """Workflow-level inheritance checks must ALSO cover for_each inline agents (#270).
+
+    When every top-level agent overrides to a capable provider but a for_each
+    inline agent runs on the incapable *default* provider, it INHERITS the
+    workflow-level ``mcp_servers`` / ``max_session_seconds`` / default reasoning
+    effort. Without inline coverage the workflow-level checks (which only scanned
+    ``config.agents``) find no offending agent and the inheritance silently
+    degrades at runtime.
+    """
+
+    def _inheritance_config(
+        self,
+        *,
+        inline: AgentDef,
+        runtime: RuntimeConfig,
+    ) -> WorkflowConfig:
+        # ``entry`` overrides to a capable provider so, WITHOUT the fix, the
+        # workflow-level check finds nothing to flag — the error can only come
+        # from the inline agent inheriting the workflow-level setting.
+        return WorkflowConfig(
+            workflow=WorkflowDef(name="t", entry_point="entry", runtime=runtime),
+            agents=[AgentDef(name="entry", prompt="hi", tools=[], provider="claude")],
+            for_each=[
+                ForEachDef(
+                    name="loop",
+                    type="for_each",
+                    source="entry.output.items",
+                    **{"as": "item"},
+                    agent=inline,
+                )
+            ],
+        )
+
+    def test_inline_inherits_workflow_default_reasoning_effort_on_no_reasoning_provider_errors(
+        self, patch_caps: Any
+    ) -> None:
+        patch_caps(
+            {
+                "copilot": _caps(reasoning_effort=None),  # default (inline inherits here)
+                "claude": _caps(reasoning_effort=("low", "medium", "high")),  # entry override
+            }
+        )
+        config = self._inheritance_config(
+            inline=AgentDef(name="inner", prompt="{{ item }}"),
+            runtime=RuntimeConfig(provider="copilot", default_reasoning_effort="high"),
+        )
+        with pytest.raises(
+            ConfigurationError,
+            match="Agent 'inner'.*runtime.default_reasoning_effort.*does not support reasoning",
+        ):
+            validate_workflow_config(config)
+
+    def test_inline_inherits_workflow_mcp_servers_on_incapable_default_errors(
+        self, patch_caps: Any
+    ) -> None:
+        patch_caps(
+            {
+                "copilot": _caps(mcp_tools=False),  # default (inline inherits here)
+                "claude": _caps(mcp_tools=True),  # entry override
+            }
+        )
+        config = self._inheritance_config(
+            inline=AgentDef(name="inner", prompt="{{ item }}"),
+            runtime=RuntimeConfig(
+                provider="copilot",
+                mcp_servers={"docs": MCPServerDef(command="docs-server")},
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="does not support MCP servers.*inner"):
+            validate_workflow_config(config)
+
+    def test_inline_inherits_workflow_max_session_seconds_on_incapable_default_errors(
+        self, patch_caps: Any
+    ) -> None:
+        patch_caps(
+            {
+                "copilot": _caps(max_session_seconds=False),  # default (inline inherits here)
+                "claude": _caps(max_session_seconds=True),  # entry override
+            }
+        )
+        config = self._inheritance_config(
+            inline=AgentDef(name="inner", prompt="{{ item }}"),
+            runtime=RuntimeConfig(provider="copilot", max_session_seconds=120.0),
+        )
+        with pytest.raises(ConfigurationError, match="does not enforce session timeouts.*inner"):
+            validate_workflow_config(config)
+
+    def test_inline_inherits_capable_default_passes(self, patch_caps: Any) -> None:
+        """A capable default provider honors the inherited workflow-level settings
+        → no error, even though the inline agent overrides nothing."""
+        patch_caps({"copilot": _caps(), "claude": _caps()})
+        config = self._inheritance_config(
+            inline=AgentDef(name="inner", prompt="{{ item }}"),
+            runtime=RuntimeConfig(
+                provider="copilot",
+                default_reasoning_effort="high",
+                max_session_seconds=120.0,
+                mcp_servers={"docs": MCPServerDef(command="docs-server")},
+            ),
+        )
+        validate_workflow_config(config)  # no raise


### PR DESCRIPTION
## Summary

Closes #270. Follow-up from #269.

`conductor validate`'s provider-capability cross-check (`_validate_provider_capabilities` in `src/conductor/config/validator.py`) applied the full **per-agent** matrix — reasoning effort, structured output, per-agent MCP provider override, and explicit `max_session_seconds` — only to top-level `agents:`. A `for_each` group's **inline** agent (`ForEachDef.agent`) runs at runtime exactly like a top-level agent but was checked for **tool allowlists only** (added in #269).

As a result an inline `for_each` agent could request a capability its provider doesn't support (the confirmed example: `reasoning.effort: high` on the `claude-agent-sdk` provider), pass validation, then fail or silently degrade mid-iteration — the same silent-degradation class #269 set out to close, on a different axis.

## Changes

- **`src/conductor/config/validator.py`**
  - Extracted the per-agent checks into a shared nested helper `_check_agent_capabilities` (mirroring the existing `_check_agent_tools` sharing pattern), and call it from **both** the top-level `config.agents` loop and the `for_each` inline pass.
  - Introduced a combined `all_llm_agents` list (top-level + inline) so the **workflow-level** `mcp_servers` and `max_session_seconds` inheritance checks also flag an inline agent that inherits those settings on an incapable default provider.
  - Top-level behavior is byte-for-byte identical (same checks, order, and messages). Override-vs-inherit sets are disjoint, so no double-reporting.
- **`tests/test_config/test_validator_capabilities.py`** — 12 new tests across two classes (`TestForEachInlineCapabilityCrossCheck`, `TestForEachInlineWorkflowLevelInheritance`): inline reasoning effort (incl. the confirmed claude-agent-sdk example), structured output, `max_session_seconds`, MCP override, the three workflow-level inheritance cases, and passing guards. Each isolates to the inline agent so it genuinely exercises the gap.
- **`CHANGELOG.md`** — `Fixed` entry under Unreleased.

Scope note: parallel-group members are referenced by name from `config.agents`, so they are already covered by the main loop — only `for_each` carries inline agents.

## Verification

- `uv run pytest tests/test_config/` → **884 passed**; full suite → **3683 passed** (1 unrelated failure: `test_copilot_large_write.py`, a live Copilot integration test needing the unavailable `claude-opus-4.7-1m-internal` model).
- `ruff check` + `ruff format --check` clean; `ty check src` clean (only the pre-existing `dialog_evaluator.py` warning).
- `make validate-examples` → all 30 examples pass.
- Real `conductor validate` on the confirmed example now correctly errors:
  > Agent 'worker' resolves to reasoning.effort='high' but provider 'claude-agent-sdk' does not support reasoning effort (capabilities.reasoning_effort=None).
