### PR TITLE
[codex] Make env-var default hint copyable

### DIFF
--- a/src/conductor/config/loader.py
+++ b/src/conductor/config/loader.py
@@ -60,7 +60,7 @@ def resolve_env_vars(value: str, max_depth: int = 10) -> str:
             raise ConfigurationError(
                 f"Required environment variable '{var_name}' is not set",
                 suggestion=f"Set the environment variable '{var_name}' or provide a default "
-                f"value using the syntax: ${{{{{{var_name}}}}:-default_value}}",
+                "value using the syntax: " + "${" + var_name + ":-default_value}",
             )
 
     # Perform substitution

--- a/tests/test_config/test_loader.py
+++ b/tests/test_config/test_loader.py
@@ -58,6 +58,7 @@ class TestResolveEnvVars:
                 resolve_env_vars("${REQUIRED_VAR}")
             assert "REQUIRED_VAR" in str(exc_info.value)
             assert "not set" in str(exc_info.value)
+            assert "${REQUIRED_VAR:-default_value}" in str(exc_info.value)
 
     def test_resolve_empty_default(self) -> None:
         """Test that empty default is allowed."""


### PR DESCRIPTION
## Summary
- Fix the missing-environment-variable suggestion so it prints a copyable `${VAR:-default}` example.
- Add a regression assertion for the rendered suggestion.
- Leave environment variable resolution behavior unchanged.

## Test plan
- `uv run pytest tests/test_config/test_loader.py -q`
- `uv run ruff check src/conductor/config/loader.py tests/test_config/test_loader.py`