### PR TITLE
[codex] Reject non-finite duration values

### DIFF
--- a/src/conductor/duration.py
+++ b/src/conductor/duration.py
@@ -14,6 +14,7 @@ to callers so the same parser can be reused for different policies.
 
 from __future__ import annotations
 
+import math
 import re
 
 _DURATION_PATTERN = re.compile(r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ms|s|m|h)?\s*$")
@@ -64,6 +65,8 @@ def parse_duration(value: str | int | float) -> float:
         raise ValueError(f"duration must be a number or duration string, not boolean: {value!r}")
 
     if isinstance(value, (int, float)):
+        if not math.isfinite(value):
+            raise ValueError(f"duration must be finite, got {value!r}")
         return float(value)
 
     if not isinstance(value, str):
@@ -79,5 +82,7 @@ def parse_duration(value: str | int | float) -> float:
         )
 
     number = float(match.group("value"))
+    if not math.isfinite(number):
+        raise ValueError(f"duration must be finite, got {value!r}")
     unit = match.group("unit") or "s"
     return number * _UNIT_TO_SECONDS[unit]

--- a/tests/test_engine/test_duration.py
+++ b/tests/test_engine/test_duration.py
@@ -6,6 +6,8 @@ tolerance, and rejection of malformed / unsupported values.
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from conductor.duration import parse_duration
@@ -118,3 +120,12 @@ class TestParseDurationRejects:
     def test_number_then_garbage(self) -> None:
         with pytest.raises(ValueError):
             parse_duration("5 minutes")
+
+    @pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+    def test_nonfinite_number(self, value: float) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            parse_duration(value)
+
+    def test_overflowing_string_number(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            parse_duration("9" * 400)


### PR DESCRIPTION
## Summary
- Reject `NaN` and infinity values in `parse_duration()`.
- Also reject overflowing numeric strings that parse to infinity.
- Add regression tests while preserving existing duration syntax.

## Test plan
- `uv run pytest tests/test_engine/test_duration.py -q`
- `uv run ruff check src/conductor/duration.py tests/test_engine/test_duration.py`