### PR TITLE
chore(release): cut 0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.20...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.21...HEAD)
+
+## [0.1.21](https://github.com/microsoft/conductor/compare/v0.1.20...v0.1.21) - 2026-07-13
 
 ### Added
 
@@ -28,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the scoped provider (default `copilot`) fails to connect. Also adds a
   public `list_models()` method to the provider interface (implemented for
   Copilot and Claude). ([#274](https://github.com/microsoft/conductor/issues/274))
+- **Jinja `include`/`import`/`extends` in `!file`-loaded prompts** — prompt
+  templates loaded via `prompt: !file ...` (and `system_prompt: !file ...`) now
+  support loader-dependent Jinja constructs, resolved relative to the prompt
+  file's own directory, enabling reusable prompt partials across workflows.
+  Inline prompts that attempt these constructs get a clear error instead of a
+  confusing failure.
+  ([#291](https://github.com/microsoft/conductor/pull/291),
+  closes [#287](https://github.com/microsoft/conductor/issues/287))
 
 ### Fixed
 
@@ -69,6 +79,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or completed. The toggle and the dive-in control are now siblings, so dive-in
   stays clickable for running items too.
   ([#273](https://github.com/microsoft/conductor/pull/273))
+- **Custom `default` Jinja filter rejected the standard `boolean` argument** —
+  Conductor's override of Jinja2's built-in `default` filter only accepted two
+  parameters, so valid templates using the standard third `boolean` argument
+  raised a `TypeError`. The filter now matches Jinja's built-in signature
+  (`default(value, default_value="", boolean=False)`) while preserving
+  Conductor's existing two-argument behavior when `boolean` is omitted.
+  ([#292](https://github.com/microsoft/conductor/pull/292),
+  closes [#288](https://github.com/microsoft/conductor/issues/288))
+- **Claude provider silently dropped `agent.system_prompt`** — the native
+  `claude` provider (Anthropic Messages API) ignored `system_prompt` instead of
+  sending it. It is now passed as the native top-level `system` parameter on
+  every API call in the agent execution path (main loop, tool-use iterations,
+  parse recovery, interrupt partial output, retries), and the validator
+  rubric's system prompt now reaches the model the same way.
+  ([#293](https://github.com/microsoft/conductor/pull/293),
+  closes [#289](https://github.com/microsoft/conductor/issues/289))
 
 ## [0.1.20](https://github.com/microsoft/conductor/compare/v0.1.19...v0.1.20) - 2026-06-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.20"
+version = "0.1.21"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 0.1.21

Previous release: [v0.1.20](https://github.com/microsoft/conductor/releases/tag/v0.1.20)

### Commit audit (11 commits since v0.1.20)

| PR | Summary | Disposition |
|---|---|---|
| #273 | Fix for-each dive-in disabled while item running (web) | Fixed — already in changelog |
| #276 | Add missing `DEFAULT_PRICING` entries for current models | Fixed — already in changelog |
| #258 | Bump `cryptography` 46.0.7 → 48.0.1 | Internal (dependabot) |
| #260 | Bump `starlette` 1.0.1 → 1.3.1 | Internal (dependabot) |
| #264 | Bump `pydantic-settings` 2.12.0 → 2.14.2 | Internal (dependabot) |
| #278 | Extend provider-capability checks to `for_each` inline agents | Fixed — already in changelog |
| #279 | Surface unpriced models + provider pricing hook | Added/Fixed — already in changelog |
| #277 | Add `conductor doctor` diagnostics command | Added — already in changelog |
| #291 | Support Jinja `include`/`import`/`extends` in `!file` prompts | Added — added to changelog in this PR |
| #292 | Support `boolean` argument in Jinja `default` filter | Fixed — added to changelog in this PR |
| #293 | Pass `system_prompt` as native `system` param in Claude provider | Fixed — added to changelog in this PR |

### Changelog summary

- Finalized `## [Unreleased]` as `## [0.1.21]` and opened a fresh empty `## [Unreleased]` section.
- Added three missing entries that weren't yet reflected in `[Unreleased]`: #291 (Jinja include/import/extends for `!file` prompts), #292 (`default` filter `boolean` arg), #293 (Claude `system_prompt` fix).
- All other user-visible changes since v0.1.20 were already correctly documented.

### Version bump

`0.1.20` → `0.1.21` (patch, automatic default).

### Validation

- `make check` (ruff check, ruff format --check, ty check) — passed (one pre-existing `possibly-missing-attribute` warning in `dialog_evaluator.py`, unrelated to this release)
- `uv run pytest -m "not real_api and not performance"` — 3865 passed, 17 skipped
- No schema/example changes in this range, so `make validate-examples` was not required.

### Next steps

Merging this PR will be followed by tagging the merge commit as `v0.1.21` and pushing the tag, which triggers `.github/workflows/release.yml` to build and publish the GitHub Release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 48384799-f37a-4e2e-a50c-d4620ebfbd38
