### PR TITLE
docs(readme): fix provider table and add Copilot section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Conductor makes multi-agent workflows — code review pipelines, research-then-s
 ## Features
 
 - **YAML-based workflows** - Define multi-agent workflows in readable YAML
-- **Multiple providers** - GitHub Copilot, Anthropic Claude, Claude Agent SDK, or NousResearch Hermes (experimental) with seamless switching
+- **Multiple providers** - GitHub Copilot, Anthropic Claude, Claude Agent SDK (experimental), or NousResearch Hermes (experimental) with seamless switching
 - **Parallel execution** - Run agents concurrently (static groups or dynamic for-each)
 - **Sub-workflow composition** - Reusable sub-workflows with templated `input_mapping`, usable inside `for_each` groups for dynamic fan-out
 - **Script steps** - Run shell commands and route on exit code or parsed JSON stdout
@@ -214,11 +214,22 @@ Conductor supports multiple AI providers. Choose based on your needs:
 | Feature | Copilot | Claude | Claude Agent SDK | Hermes |
 |---------|---------|--------|------------------|--------|
 | **Tier** | Stable | Stable | Experimental | Experimental |
-| **Pricing** | Subscription ($10-39/mo) | Pay-per-token | Via Claude Code CLI | Pay-per-token (via hermes) |
-| **Context Window** | 8K-128K tokens | 200K tokens | 200K tokens | Per-model |
+| **Pricing** | Subscription | Pay-per-token | Subscription | Pay-per-token (via hermes) |
+| **Context Window** | Per-model | Per-model | Per-model | Per-model |
 | **Tool Support (MCP)** | Yes | Planned | Yes (built-in) | No (hermes internal tools) |
 | **Streaming** | Yes | Planned | Yes | No |
 | **Best For** | Heavy usage, tools | Large context, pay-per-use | Full Claude Code toolset | Multi-provider model access |
+
+### Using Copilot
+
+```yaml
+workflow:
+  runtime:
+    provider: copilot
+    default_model: gpt-5.2
+```
+
+Copilot is the default provider — `runtime.provider` can be omitted entirely. Requires an active GitHub Copilot subscription and the GitHub CLI authenticated (`gh auth login`).
 
 ### Using Claude
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ workflow:
 
 agents:
   - name: answerer
-    model: gpt-5.2
+    model: gpt-5.5
     prompt: |
       Answer the following question:
       {{ workflow.input.question }}
@@ -226,7 +226,7 @@ Conductor supports multiple AI providers. Choose based on your needs:
 workflow:
   runtime:
     provider: copilot
-    default_model: gpt-5.2
+    default_model: gpt-5.5
 ```
 
 Copilot is the default provider — `runtime.provider` can be omitted entirely. Requires an active GitHub Copilot subscription and the GitHub CLI authenticated (`gh auth login`).
@@ -237,18 +237,18 @@ Copilot is the default provider — `runtime.provider` can be omitted entirely. 
 workflow:
   runtime:
     provider: claude
-    default_model: claude-sonnet-4.5
+    default_model: claude-sonnet-5
 ```
 
 Set your API key: `export ANTHROPIC_API_KEY=sk-ant-...`
 
-### Using Claude Agent SDK
+### Using Claude Agent SDK (Experimental)
 
 ```yaml
 workflow:
   runtime:
     provider: claude-agent-sdk
-    default_model: claude-sonnet-4-6
+    default_model: claude-sonnet-5
 ```
 
 Requires the `claude` CLI to be installed and authenticated. Install the SDK: `uv add 'claude-agent-sdk>=0.1.0'`
@@ -261,7 +261,7 @@ Requires the `claude` CLI to be installed and authenticated. Install the SDK: `u
 workflow:
   runtime:
     provider: hermes
-    default_model: anthropic/claude-sonnet-4
+    default_model: anthropic/claude-sonnet-5
 ```
 
 Install the library: `pip install hermes-agent`


### PR DESCRIPTION
## Summary
- Set Context Window to "Per-model" across all providers in the Providers comparison table
- Set Pricing to "Subscription" for Copilot and Claude Agent SDK
- Add a "Using Copilot" section with a config example and auth notes
- Label Claude Agent SDK as experimental in the top-level Features list, matching the Providers table's Tier column

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
