### PR TITLE
fix(install): don't let install-script tests pollute shell profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.21...HEAD)
 
+### Fixed
+
+- **Install-script tests no longer pollute the developer's shell profile** — the
+  install scripts ran `uv tool update-shell` unconditionally, so the
+  `-m install_scripts` integration tests appended each run's throwaway
+  `UV_TOOL_BIN_DIR` to the real `~/.zshenv` (and shell equivalents). Those stale
+  entries shadowed the user's actual `conductor` install with an old `v0.0.2`
+  test fixture, so `conductor` reported the wrong version and `conductor update`
+  appeared to do nothing. `install.sh` / `install.ps1` now honor
+  `CONDUCTOR_INSTALL_SKIP_PATH_UPDATE=1` (and a matching
+  `--skip-path-update` / `-SkipPathUpdate` flag) — set by default in the test
+  harness — and a regression test asserts the scripts never touch shell
+  profiles.
+
 ## [0.1.21](https://github.com/microsoft/conductor/compare/v0.1.20...v0.1.21) - 2026-07-13
 
 ### Added

--- a/install.ps1
+++ b/install.ps1
@@ -26,12 +26,19 @@
 #       available, or aborts when running non-interactively.
 #   -Force                    OR   $env:CONDUCTOR_INSTALL_FORCE = '1'
 #       Skip the running-process check entirely.
+#   -SkipPathUpdate           OR   $env:CONDUCTOR_INSTALL_SKIP_PATH_UPDATE = '1'
+#       Skip the `uv tool update-shell` step so the install never edits the
+#       user's PATH registry / profiles. The install-script tests install into
+#       a throwaway UV_TOOL_BIN_DIR that must never leak into the real
+#       environment (note: `uv tool update-shell` intentionally modifies the
+#       shell and so ignores UV_NO_MODIFY_PATH).
 
 [CmdletBinding()]
 param(
     [string]$Source,
     [switch]$AutoStop,
-    [switch]$Force
+    [switch]$Force,
+    [switch]$SkipPathUpdate
 )
 
 $ErrorActionPreference = 'Stop'
@@ -44,6 +51,7 @@ $GitHubDL  = "https://github.com/$Repo/releases/download"
 if (-not $Source   -and $env:CONDUCTOR_INSTALL_SOURCE)               { $Source   = $env:CONDUCTOR_INSTALL_SOURCE }
 if (-not $AutoStop -and $env:CONDUCTOR_INSTALL_AUTO_STOP -eq '1')    { $AutoStop = $true }
 if (-not $Force    -and $env:CONDUCTOR_INSTALL_FORCE     -eq '1')    { $Force    = $true }
+if (-not $SkipPathUpdate -and $env:CONDUCTOR_INSTALL_SKIP_PATH_UPDATE -eq '1') { $SkipPathUpdate = $true }
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -424,16 +432,20 @@ try {
     Write-Ok "Conductor $displayVersion installed"
 
     # --- Update PATH for new shells ---
-    Write-Info "Ensuring conductor is on PATH for new shells..."
-    try {
-        & uv tool update-shell 2>&1 | Out-Null
-        if ($LASTEXITCODE -eq 0) {
-            Write-Ok "PATH updated (restart your terminal to pick up the change)"
-        } else {
+    if ($SkipPathUpdate) {
+        Write-Info "Skipping shell PATH update (CONDUCTOR_INSTALL_SKIP_PATH_UPDATE=1)."
+    } else {
+        Write-Info "Ensuring conductor is on PATH for new shells..."
+        try {
+            & uv tool update-shell 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Ok "PATH updated (restart your terminal to pick up the change)"
+            } else {
+                Write-Warn "Could not update user PATH automatically. Run 'uv tool update-shell' manually."
+            }
+        } catch {
             Write-Warn "Could not update user PATH automatically. Run 'uv tool update-shell' manually."
         }
-    } catch {
-        Write-Warn "Could not update user PATH automatically. Run 'uv tool update-shell' manually."
     }
 
     # --- Verify ---

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,12 @@
 #       is available, or aborts when running non-interactively.
 #   --force                   OR   $CONDUCTOR_INSTALL_FORCE=1
 #       Skip the running-process check entirely.
+#   --skip-path-update        OR   $CONDUCTOR_INSTALL_SKIP_PATH_UPDATE=1
+#       Skip the `uv tool update-shell` step so the install never edits the
+#       user's shell profiles (.zshenv/.bashrc/…). The install-script tests
+#       install into a throwaway UV_TOOL_BIN_DIR that must never leak into the
+#       real environment (note: `uv tool update-shell` intentionally modifies
+#       the shell and so ignores UV_NO_MODIFY_PATH).
 
 set -eu
 
@@ -32,13 +38,15 @@ GITHUB_DL="https://github.com/${REPO}/releases/download"
 SOURCE="${CONDUCTOR_INSTALL_SOURCE:-}"
 AUTO_STOP="${CONDUCTOR_INSTALL_AUTO_STOP:-0}"
 FORCE_FLAG="${CONDUCTOR_INSTALL_FORCE:-0}"
+SKIP_PATH_UPDATE="${CONDUCTOR_INSTALL_SKIP_PATH_UPDATE:-0}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --source)        SOURCE="$2"; shift 2 ;;
-        --source=*)      SOURCE="${1#--source=}"; shift ;;
-        --auto-stop)     AUTO_STOP=1; shift ;;
-        --force)         FORCE_FLAG=1; shift ;;
+        --source)           SOURCE="$2"; shift 2 ;;
+        --source=*)         SOURCE="${1#--source=}"; shift ;;
+        --auto-stop)        AUTO_STOP=1; shift ;;
+        --force)            FORCE_FLAG=1; shift ;;
+        --skip-path-update) SKIP_PATH_UPDATE=1; shift ;;
         *) shift ;;
     esac
 done
@@ -310,11 +318,15 @@ main() {
     success "Conductor ${display_version} installed"
 
     # --- Update shell PATH ---
-    info "Ensuring conductor is on PATH for new shells…"
-    if uv tool update-shell >/dev/null 2>&1; then
-        success "PATH updated (restart your shell to pick up the change)"
+    if [ "$SKIP_PATH_UPDATE" = "1" ]; then
+        info "Skipping shell PATH update (CONDUCTOR_INSTALL_SKIP_PATH_UPDATE=1)."
     else
-        warn "Could not update shell PATH automatically. Run 'uv tool update-shell' manually."
+        info "Ensuring conductor is on PATH for new shells…"
+        if uv tool update-shell >/dev/null 2>&1; then
+            success "PATH updated (restart your shell to pick up the change)"
+        else
+            warn "Could not update shell PATH automatically. Run 'uv tool update-shell' manually."
+        fi
     fi
 
     # --- Verify ---

--- a/tests/test_integration/install_scripts_helpers.py
+++ b/tests/test_integration/install_scripts_helpers.py
@@ -188,9 +188,12 @@ def run_install_script(
     leaves behind gets reaped automatically.
     """
     extra_env = dict(extra_env or {})
-    # Optional belt-and-braces: tests can opt-out of `uv tool update-shell`
-    # to avoid touching the user's profile. The script itself respects
-    # UV_NO_MODIFY_PATH=1 set in Sandbox.env(), but we also support a hook.
+    # Prevent the install scripts from running `uv tool update-shell`, which
+    # would append this test's throwaway UV_TOOL_BIN_DIR to the *real* user
+    # shell profiles (.zshenv/.bashrc/…) and shadow the user's actual install.
+    # `uv tool update-shell` deliberately edits the shell and so ignores
+    # UV_NO_MODIFY_PATH; install.sh / install.ps1 honor
+    # CONDUCTOR_INSTALL_SKIP_PATH_UPDATE=1 to skip that step under test.
     extra_env.setdefault("CONDUCTOR_INSTALL_SKIP_PATH_UPDATE", "1")
 
     if IS_WINDOWS:

--- a/tests/test_integration/test_install_scripts.py
+++ b/tests/test_integration/test_install_scripts.py
@@ -162,6 +162,38 @@ def test_fresh_install(sandbox: Sandbox, wheels: WheelPair) -> None:
     assert version == "0.0.2", f"expected 0.0.2, got {version!r}\n{result.combined}"
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="POSIX shell-profile isolation check")
+def test_install_does_not_touch_shell_profiles(
+    sandbox: Sandbox, wheels: WheelPair, tmp_path: Path
+) -> None:
+    """The install script must not edit the user's shell profiles under test.
+
+    Regression guard: ``install.sh`` once ran ``uv tool update-shell``
+    unconditionally, which appended each test's throwaway
+    ``UV_TOOL_BIN_DIR`` to the developer's real ``~/.zshenv`` and shadowed
+    their actual conductor install with a stale ``v0.0.2`` test fixture
+    (``uv tool update-shell`` deliberately edits the shell and ignores
+    ``UV_NO_MODIFY_PATH``). The install scripts now honor
+    ``CONDUCTOR_INSTALL_SKIP_PATH_UPDATE=1`` — set by default in
+    :func:`run_install_script` — to skip that step.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    result = run_install_script(sandbox, source=wheels.new, extra_env={"HOME": str(fake_home)})
+    _assert_install_ok(result, "0.0.2")
+
+    assert "Skipping shell PATH update" in result.combined, (
+        f"install script did not honor CONDUCTOR_INSTALL_SKIP_PATH_UPDATE:\n{result.combined}"
+    )
+
+    profiles = (".zshenv", ".zshrc", ".zprofile", ".bashrc", ".bash_profile", ".profile")
+    touched = [name for name in profiles if (fake_home / name).exists()]
+    assert not touched, (
+        f"install script modified shell profiles {touched} despite skip hook:\n{result.combined}"
+    )
+
+
 def test_upgrade_clean(sandbox: Sandbox, wheels: WheelPair) -> None:
     """Seed an old install; upgrade via the install script; verify new version."""
     seed_install(sandbox, wheels.old)


### PR DESCRIPTION
## Problem

`install.sh` / `install.ps1` call `uv tool update-shell` **unconditionally** after installing. That command deliberately edits the user's shell configs (`~/.zshenv`, `~/.bashrc`, PATH registry) and intentionally ignores `UV_NO_MODIFY_PATH`.

The `-m install_scripts` integration tests drive the real install scripts against throwaway `UV_TOOL_BIN_DIR` sandboxes. Because `update-shell` ran anyway, **every test run appended its temp `uv-bin` dir to the developer's real `~/.zshenv`**. Those dirs contain stale `v0.0.2` fixture binaries that shadow the user's actual `uv tool` install ahead of `~/.local/bin` — so `conductor` reported the wrong version and `conductor update` appeared to do nothing (it updated the real install, but PATH still resolved to the fixture).

Observed locally: ~147 leaked `export PATH=".../pytest-of-jason/.../uv-bin:$PATH"` lines in `~/.zshenv`.

## Fix

- `install.sh` / `install.ps1` now honor `CONDUCTOR_INSTALL_SKIP_PATH_UPDATE=1` (plus a matching `--skip-path-update` / `-SkipPathUpdate` flag) to skip the `uv tool update-shell` step.
- `run_install_script` in the test helper sets this by default, so the install-script tests can no longer touch the developer's shell profiles. Corrected the helper's stale comment that claimed the scripts respected `UV_NO_MODIFY_PATH`.
- Added a hermetic regression test (`test_install_does_not_touch_shell_profiles`) that runs an install into an isolated `HOME` and asserts no shell profile is created/modified.
- CHANGELOG entry under Unreleased → Fixed.

## Testing

```
uv run pytest tests/test_integration/test_install_scripts.py -m install_scripts -q
# 4 passed, 4 skipped (Windows-only); ~/.zshenv byte-identical before/after
```

`sh -n install.sh` passes; `ruff check` / `ruff format --check` clean on changed files.

> Note: this only prevents *future* leakage. Existing pollution in a developer's `~/.zshenv` from prior test runs must be cleaned up separately.