### PR TITLE
feat(doctor): surface per-model reasoning-effort support and context-window limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provider implements the hook fully via `client.list_models()`; the Claude
   provider derives reasoning-effort support from the existing thinking-model
   heuristic and reports prompt tokens only (the Anthropic SDK exposes no
-  output/total-context split); other providers degrade to `n/a`/`—` for every
-  field. See the "Per-model capabilities" section in
+  output/total-context split); other providers (`claude-agent-sdk`, `hermes`,
+  `openai-agents`) don't implement model enumeration at all, so they show
+  `n/a` in the Providers table and get no Models detail table. See the
+  "Per-model capabilities" section in
   [`docs/cli-reference.md`](docs/cli-reference.md#per-model-capabilities---models).
   ([#301](https://github.com/microsoft/conductor/issues/301))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`conductor doctor --models` surfaces per-model reasoning-effort support and
+  context-window limits** — a new optional `AgentProvider.get_model_capabilities`
+  hook (alongside the existing `get_max_prompt_tokens` / `get_model_pricing`
+  hooks) reports, per model: which `reasoning.effort` levels it accepts, its
+  default effort, and its prompt/output/context-window token limits. `--models`
+  now renders a separate per-provider **Models** detail table with this data
+  (the Providers table's Models column shows a count); the JSON `models` field
+  is now a list of capability objects rather than plain id strings. The Copilot
+  provider implements the hook fully via `client.list_models()`; the Claude
+  provider derives reasoning-effort support from the existing thinking-model
+  heuristic and reports prompt tokens only (the Anthropic SDK exposes no
+  output/total-context split); other providers degrade to `n/a`/`—` for every
+  field. See the "Per-model capabilities" section in
+  [`docs/cli-reference.md`](docs/cli-reference.md#per-model-capabilities---models).
+  ([#301](https://github.com/microsoft/conductor/issues/301))
+
 - **`max` reasoning-effort level** — the unified reasoning scale is now
   `low | medium | high | xhigh | max`, unifying it with the GitHub Copilot CLI.
   On the Copilot provider `max` is forwarded to the SDK and still validated
@@ -24,6 +40,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#299](https://github.com/microsoft/conductor/issues/299))
 
 ### Fixed
+
+- **Copilot per-model `reasoning_effort` validation was a silent no-op** —
+  `_validate_reasoning_effort_for_model` read
+  `capabilities.supported_reasoning_efforts`, but the installed
+  `github-copilot-sdk` (>=1.0.0) exposes that field (and
+  `default_reasoning_effort`) at the top level of the `Model` object, not
+  nested under `capabilities`. The lookup always returned `None`, so the
+  per-model check (including the `max`-rejection behavior from #299) never
+  fired against the real SDK — a model without `max` support would only be
+  caught by the backend, not by Conductor's own validation. Fixed to read the
+  correct field; discovered and corrected while implementing #301, which
+  needed the same field for `doctor --models`.
 
 - **Install-script tests no longer pollute the developer's shell profile** — the
   install scripts ran `uv tool update-shell` unconditionally, so the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -415,15 +415,18 @@ support and context-window limits:
 Coverage varies by provider — every field degrades independently to `n/a` /
 `—` rather than failing the command:
 
-- **Copilot** reports all fields (reasoning-effort levels + default, and all
-  three token limits) from the SDK's per-model metadata.
+- **Copilot** reports reasoning-effort levels + default, and prompt/context
+  token limits, from the SDK's per-model metadata (`Output` is frequently
+  `—` — the live API does not currently populate it for most models).
 - **Claude** derives reasoning-effort support from a static heuristic
   (Claude 3.7+ / 4.x models support all five levels; older models support
   none) and reports only `Prompt` (via the Anthropic API's
   `max_input_tokens`) — `Output` and `Context` are always `—` and `Default`
   is always `—` (Anthropic has no per-model default-effort concept).
-- **`claude-agent-sdk`**, **`hermes`**, and **`openai-agents`** report every
-  field as `n/a` / `—` (no capability hook implemented).
+- **`claude-agent-sdk`**, **`hermes`**, and **`openai-agents`** don't
+  implement model enumeration (`list_models`) at all, so `--models` shows
+  `n/a` for them in the Providers table and they get **no** Models detail
+  table — there is nothing to detail.
 
 In `--json`, each provider's `models` field is a list of objects (not plain
 id strings):

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -395,9 +395,49 @@ in the `env` section (cache-first, short timeout, silent, and skipped when
   installed, the capability tier (`stable` / `experimental`), which
   credential environment variables are **present** (presence only — values
   are never printed), and — with `--check` / `--models` — connection status
-  and available models. `openai-agents` is surfaced as "not yet implemented".
+  and a model count. `openai-agents` is surfaced as "not yet implemented".
 - **registries** — configured workflow registries and which is the default
   (see [`conductor registry`](#conductor-registry)).
+
+### Per-model capabilities (`--models`)
+
+Beyond a model count in the Providers table, `--models` renders a separate
+**Models** detail table per provider with each model's reasoning-effort
+support and context-window limits:
+
+| Column | Description |
+|--------|--------------|
+| Model | The model identifier. |
+| Reasoning efforts | `reasoning.effort` levels the model accepts (e.g. `low, medium, high, xhigh`), `none` when the model definitively supports none (e.g. a non-thinking Claude model), or `n/a` when the provider can't determine support. |
+| Default | The model's default reasoning-effort level, or `—` when unknown/not applicable. |
+| Prompt / Output / Context | Maximum prompt (input), output (completion), and total context-window tokens, or `—` when the provider doesn't expose that limit. |
+
+Coverage varies by provider — every field degrades independently to `n/a` /
+`—` rather than failing the command:
+
+- **Copilot** reports all fields (reasoning-effort levels + default, and all
+  three token limits) from the SDK's per-model metadata.
+- **Claude** derives reasoning-effort support from a static heuristic
+  (Claude 3.7+ / 4.x models support all five levels; older models support
+  none) and reports only `Prompt` (via the Anthropic API's
+  `max_input_tokens`) — `Output` and `Context` are always `—` and `Default`
+  is always `—` (Anthropic has no per-model default-effort concept).
+- **`claude-agent-sdk`**, **`hermes`**, and **`openai-agents`** report every
+  field as `n/a` / `—` (no capability hook implemented).
+
+In `--json`, each provider's `models` field is a list of objects (not plain
+id strings):
+
+```json
+{
+  "id": "gpt-5.5",
+  "supported_reasoning_efforts": ["low", "medium", "high", "xhigh"],
+  "default_reasoning_effort": "medium",
+  "max_prompt_tokens": 128000,
+  "max_output_tokens": 64000,
+  "max_context_window_tokens": 192000
+}
+```
 
 ### Credential detection
 

--- a/src/conductor/cli/doctor.py
+++ b/src/conductor/cli/doctor.py
@@ -22,6 +22,7 @@ from conductor.providers.diagnostics import (
     ALL_SECTIONS,
     DoctorReport,
     EnvDiagnostic,
+    ModelDiagnostic,
     ProviderDiagnostic,
     RegistryDiagnostic,
     gather,
@@ -94,6 +95,8 @@ def run_doctor(
         _render_env(report.env, console)
     if report.providers is not None:
         _render_providers(report.providers, console, check=check, models=models)
+        if models:
+            _render_models(report.providers, console)
     if report.registries is not None:
         _render_registries(report.registries, console)
 
@@ -248,20 +251,80 @@ def _connection_cell(diag: ProviderDiagnostic) -> str:
 
 
 def _models_cell(diag: ProviderDiagnostic) -> str:
-    """Format the models cell.
+    """Format the models cell in the Providers summary table.
 
-    Lists every model id (comma-separated); Rich wraps the cell to the column
-    width. The leading count makes long lists scannable. ``n/a`` when models
-    is None (not enumerated), ``(none)`` for an empty list.
+    Shows a count/status only — per-model reasoning-effort and
+    context-window details are rendered in the separate Models detail table
+    (see :func:`_render_models`) below the Providers table. ``n/a`` when
+    models is ``None`` (not enumerated), ``(none)`` for an empty list.
     """
     if diag.models_error:
         return f"{_CROSS} [dim]{escape(diag.models_error)}[/dim]"
     if diag.models is None:
         return "[dim]n/a[/dim]"
-    if not diag.models:
+    count = len(diag.models)
+    if not count:
         return "[dim](none)[/dim]"
-    shown = ", ".join(escape(model) for model in diag.models)
-    return f"[dim]{len(diag.models)}:[/dim] {shown}"
+    return f"{_CHECK} {count} model{'s' if count != 1 else ''}"
+
+
+def _format_tokens(value: int | None) -> str:
+    """Format a token-limit value with grouped digits, or ``—`` when unknown."""
+    if value is None:
+        return _DASH
+    return f"{value:,}"
+
+
+def _efforts_cell(model: ModelDiagnostic) -> str:
+    """Format the supported-reasoning-efforts cell.
+
+    ``n/a`` when unknown (``None``), ``none`` for a definitive empty list
+    (e.g. a non-thinking Claude model), otherwise a comma-separated list.
+    """
+    if model.supported_reasoning_efforts is None:
+        return "[dim]n/a[/dim]"
+    if not model.supported_reasoning_efforts:
+        return "[dim]none[/dim]"
+    return ", ".join(escape(effort) for effort in model.supported_reasoning_efforts)
+
+
+def _default_effort_cell(model: ModelDiagnostic) -> str:
+    """Format the default-reasoning-effort cell."""
+    if model.default_reasoning_effort is None:
+        return _DASH
+    return escape(model.default_reasoning_effort)
+
+
+def _render_models(providers: list[ProviderDiagnostic], console: Console) -> None:
+    """Render a per-provider Models detail table (``--models`` only).
+
+    One table per provider that returned at least one model, with columns
+    for reasoning-effort support and prompt/output/context token limits.
+    Providers with no models (``None``/empty/error) are already summarized
+    in the Providers table and are skipped here — there is nothing to detail.
+    """
+    for diag in providers:
+        if not diag.models:
+            continue
+        table = Table(title=f"Models — {diag.name}", show_lines=True)
+        table.add_column("Model", style="cyan", no_wrap=True)
+        table.add_column("Reasoning efforts")
+        table.add_column("Default")
+        table.add_column("Prompt", justify="right")
+        table.add_column("Output", justify="right")
+        table.add_column("Context", justify="right")
+
+        for model in diag.models:
+            table.add_row(
+                escape(model.id),
+                _efforts_cell(model),
+                _default_effort_cell(model),
+                _format_tokens(model.max_prompt_tokens),
+                _format_tokens(model.max_output_tokens),
+                _format_tokens(model.max_context_window_tokens),
+            )
+
+        console.print(table)
 
 
 def _render_registries(registries: RegistryDiagnostic, console: Console) -> None:

--- a/src/conductor/providers/base.py
+++ b/src/conductor/providers/base.py
@@ -109,6 +109,52 @@ class AgentOutput:
     """Whether this output is partial (from a mid-agent interrupt)."""
 
 
+@dataclass(frozen=True)
+class ModelCapabilityInfo:
+    """Provider-reported reasoning-effort and context-window metadata for a model.
+
+    Returned by the optional :meth:`AgentProvider.get_model_capabilities` hook
+    (see issue #301) and surfaced by ``conductor doctor --models``. Every field
+    is best-effort and independently optional — a provider that can report
+    token limits but not reasoning-effort support (or vice versa) should
+    leave the unknown fields at their ``None`` default rather than omit the
+    whole object.
+    """
+
+    supported_reasoning_efforts: list[str] | None = None
+    """Reasoning-effort levels the model accepts, or ``None`` when unknown.
+
+    An empty list is a meaningful, distinct value: it means the provider
+    positively knows the model supports *no* reasoning-effort levels
+    (e.g. a non-thinking Claude model), whereas ``None`` means the provider
+    could not determine support either way.
+    """
+
+    default_reasoning_effort: str | None = None
+    """The model's default reasoning-effort level, or ``None`` when unknown
+    or not applicable."""
+
+    max_prompt_tokens: int | None = None
+    """Maximum prompt (input) tokens, or ``None`` when unknown."""
+
+    max_output_tokens: int | None = None
+    """Maximum output (completion) tokens, or ``None`` when unknown."""
+
+    max_context_window_tokens: int | None = None
+    """Maximum total context window (prompt + output) tokens, or ``None``
+    when unknown."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe representation."""
+        return {
+            "supported_reasoning_efforts": self.supported_reasoning_efforts,
+            "default_reasoning_effort": self.default_reasoning_effort,
+            "max_prompt_tokens": self.max_prompt_tokens,
+            "max_output_tokens": self.max_output_tokens,
+            "max_context_window_tokens": self.max_context_window_tokens,
+        }
+
+
 class AgentProvider(ABC):
     """Abstract base class for SDK providers.
 
@@ -359,5 +405,38 @@ class AgentProvider(ABC):
         Returns:
             A list of available model identifiers, or ``None`` when the
             provider does not enumerate models.
+        """
+        return None
+
+    async def get_model_capabilities(self, model: str) -> ModelCapabilityInfo | None:
+        """Return provider-supplied reasoning-effort and context-window metadata.
+
+        This is the provider hook behind ``conductor doctor --models`` (see
+        issue #301), alongside :meth:`get_max_prompt_tokens` and
+        :meth:`get_model_pricing`. A provider that knows which
+        ``reasoning.effort`` levels a model accepts (and its default), plus
+        its prompt/output/context token limits, should return a
+        :class:`ModelCapabilityInfo` populating whichever fields it can
+        determine — fields the provider can't determine should stay at their
+        ``None`` default rather than causing the whole call to fail.
+
+        Implementations must:
+
+        * Return ``None`` when the model is unknown to the provider, the SDK
+          exposes no usable capability metadata, or the SDK call fails.
+        * Never raise — capability metadata is best-effort and must not
+          interrupt workflow execution or the ``doctor`` command.
+
+        The default implementation returns ``None``, which causes ``doctor``
+        to render every capability column as "n/a" for this provider — a
+        safe degradation matching the sibling hooks above.
+
+        Args:
+            model: The model identifier as it would be sent to the SDK
+                (e.g. ``"gpt-5.2"``, ``"claude-sonnet-4-5-20250929"``).
+
+        Returns:
+            A :class:`ModelCapabilityInfo` when the provider can supply
+            capability metadata for ``model``, otherwise ``None``.
         """
         return None

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -24,7 +24,7 @@ import json
 import logging
 import random
 import time
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, get_args
 
 from pydantic import BaseModel
 
@@ -34,7 +34,13 @@ from conductor.providers._event_format import (
     extract_tool_result_text,
     format_tool_arguments,
 )
-from conductor.providers.base import AgentOutput, AgentProvider, EventCallback, match_model_id
+from conductor.providers.base import (
+    AgentOutput,
+    AgentProvider,
+    EventCallback,
+    ModelCapabilityInfo,
+    match_model_id,
+)
 from conductor.providers.capabilities import ProviderCapabilities
 from conductor.providers.reasoning import (
     CLAUDE_ANSWER_HEADROOM_TOKENS,
@@ -501,6 +507,51 @@ class ClaudeProvider(AgentProvider):
             logger.debug("Failed to list Anthropic models: %s", e)
             return None
         return [model.id for model in page.data]
+
+    async def get_model_capabilities(self, model: str) -> ModelCapabilityInfo | None:
+        """Return reasoning-effort support and prompt-token limits for ``model``.
+
+        Implements the :meth:`AgentProvider.get_model_capabilities` hook (see
+        #301).
+
+        Reasoning-effort support is derived from the same static heuristic
+        used to gate extended thinking (:func:`is_claude_thinking_model`):
+        thinking-capable models (Claude 3.7+ / 4.x) advertise all five
+        :data:`ReasoningEffort` levels; other models advertise an empty list
+        — a definitive "supports none", not "unknown". Anthropic has no
+        notion of a model-specific *default* effort (unlike the Copilot SDK),
+        so ``default_reasoning_effort`` is always ``None``.
+
+        ``max_prompt_tokens`` reuses :meth:`get_max_prompt_tokens` (the
+        Anthropic SDK's ``max_input_tokens``). ``max_output_tokens`` and
+        ``max_context_window_tokens`` are always ``None`` — the Anthropic
+        SDK's ``models.list()`` exposes no output/total-context split.
+
+        Unlike :meth:`get_max_prompt_tokens` (which deliberately lets
+        non-SDK exceptions bubble up for its dashboard use case), this hook
+        upholds the base class's stricter "never raise" contract: any
+        exception from the delegated call — SDK or otherwise — is swallowed
+        and treated as "prompt tokens unknown". The reasoning-effort fields
+        are populated even when the SDK is unavailable or ``model`` can't be
+        resolved (the heuristic is a pure name match), so this never returns
+        ``None`` outright.
+        """
+        if is_claude_thinking_model(model):
+            supported_reasoning_efforts = list(get_args(ReasoningEffort))
+        else:
+            supported_reasoning_efforts = []
+        try:
+            max_prompt_tokens = await self.get_max_prompt_tokens(model)
+        except Exception as e:  # noqa: BLE001 - diagnostics must never raise
+            logger.debug("Failed to resolve max_prompt_tokens for %r: %s", model, e)
+            max_prompt_tokens = None
+        return ModelCapabilityInfo(
+            supported_reasoning_efforts=supported_reasoning_efforts,
+            default_reasoning_effort=None,
+            max_prompt_tokens=max_prompt_tokens,
+            max_output_tokens=None,
+            max_context_window_tokens=None,
+        )
 
     async def _ensure_mcp_connected(self) -> None:
         """Connect to MCP servers if configured.

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -527,19 +527,26 @@ class ClaudeProvider(AgentProvider):
         ``max_context_window_tokens`` are always ``None`` — the Anthropic
         SDK's ``models.list()`` exposes no output/total-context split.
 
-        Unlike :meth:`get_max_prompt_tokens` (which deliberately lets
-        non-SDK exceptions bubble up for its dashboard use case), this hook
-        upholds the base class's stricter "never raise" contract: any
-        exception from the delegated call — SDK or otherwise — is swallowed
-        and treated as "prompt tokens unknown". The reasoning-effort fields
-        are populated even when the SDK is unavailable or ``model`` can't be
-        resolved (the heuristic is a pure name match), so this never returns
-        ``None`` outright.
+        Unlike :meth:`get_max_prompt_tokens` (which only catches its
+        documented ``(TimeoutError, AnthropicError, OSError)`` tuple and lets
+        anything else propagate, by design, for its own caller), this hook
+        upholds the base class's stricter "never raise" contract on its own:
+        each field is resolved behind its own guard, so a failure in one
+        (e.g. an unexpected exception from the delegated
+        ``get_max_prompt_tokens`` call, or a non-string ``model``) degrades
+        only that field rather than the whole result or the caller. The
+        reasoning-effort fields are populated even when the SDK is
+        unavailable, ``model`` can't be resolved, or the token-limit lookup
+        fails (the heuristic is a pure name match independent of the SDK
+        call), so this never returns ``None`` outright.
         """
-        if is_claude_thinking_model(model):
-            supported_reasoning_efforts = list(get_args(ReasoningEffort))
-        else:
-            supported_reasoning_efforts = []
+        try:
+            supported_reasoning_efforts = (
+                list(get_args(ReasoningEffort)) if is_claude_thinking_model(model) else []
+            )
+        except Exception as e:  # noqa: BLE001 - diagnostics must never raise
+            logger.debug("Failed to resolve reasoning-effort support for %r: %s", model, e)
+            supported_reasoning_efforts = None
         try:
             max_prompt_tokens = await self.get_max_prompt_tokens(model)
         except Exception as e:  # noqa: BLE001 - diagnostics must never raise

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -23,7 +23,13 @@ from conductor.providers._event_format import (
     extract_tool_result_text,
     format_tool_arguments,
 )
-from conductor.providers.base import AgentOutput, AgentProvider, EventCallback, match_model_id
+from conductor.providers.base import (
+    AgentOutput,
+    AgentProvider,
+    EventCallback,
+    ModelCapabilityInfo,
+    match_model_id,
+)
 from conductor.providers.capabilities import ProviderCapabilities
 from conductor.providers.context_tier import ContextTier, resolve_context_tier
 from conductor.providers.reasoning import ReasoningEffort, resolve_reasoning_effort
@@ -2464,9 +2470,11 @@ class CopilotProvider(AgentProvider):
         """Validate ``effort`` against the model's advertised capabilities.
 
         Looks up the model via ``client.list_models()`` (resolving aliases via
-        :func:`match_model_id`) and inspects
-        ``capabilities.supported_reasoning_efforts``. When that list is
-        present and ``effort`` is not in it, raises :class:`ValidationError`.
+        :func:`match_model_id`) and inspects the matched ``Model``'s
+        ``supported_reasoning_efforts`` (a top-level field on ``Model``, not
+        nested under ``capabilities`` — see :meth:`get_model_capabilities`).
+        When that list is present and ``effort`` is not in it, raises
+        :class:`ValidationError`.
 
         When the field is missing/``None`` (capability unknown), or when the
         model can't be matched, or when listing fails, validation is skipped
@@ -2502,7 +2510,7 @@ class CopilotProvider(AgentProvider):
         if matched_id is None:
             return
         info = by_id[matched_id]
-        supported = getattr(info.capabilities, "supported_reasoning_efforts", None)
+        supported = getattr(info, "supported_reasoning_efforts", None)
         if supported is None:
             return
         if effort not in supported:
@@ -2514,6 +2522,50 @@ class CopilotProvider(AgentProvider):
                     "or pick a different model."
                 ),
             )
+
+    async def get_model_capabilities(self, model: str) -> ModelCapabilityInfo | None:
+        """Return reasoning-effort support and context-window limits for ``model``.
+
+        Implements the :meth:`AgentProvider.get_model_capabilities` hook (see
+        #301). Queries ``client.list_models()`` (cached internally by the SDK),
+        resolves aliases via :func:`match_model_id`, and reads:
+
+        * ``supported_reasoning_efforts`` / ``default_reasoning_effort`` — both
+          top-level fields on the matched ``Model`` (not nested under
+          ``capabilities`` — see the fix in
+          :meth:`_validate_reasoning_effort_for_model`).
+        * ``capabilities.limits.max_prompt_tokens`` / ``max_output_tokens`` /
+          ``max_context_window_tokens``.
+
+        Returns ``None`` in mock-handler mode, when the SDK is unavailable,
+        when no match is found, or when the SDK call fails — capability
+        metadata must never block ``doctor`` or workflow execution.
+
+        Catches ``Exception`` (not ``BaseException``) at the SDK boundary so
+        ``asyncio.CancelledError``/``KeyboardInterrupt``/``SystemExit`` still
+        propagate, mirroring :meth:`get_max_prompt_tokens`.
+        """
+        if self._mock_handler is not None or not COPILOT_SDK_AVAILABLE:
+            return None
+        try:
+            await self._ensure_client_started()
+            models = await self._client.list_models()
+        except Exception as e:
+            logger.debug("Failed to list Copilot models for capabilities of %r: %s", model, e)
+            return None
+        by_id = {info.id: info for info in models}
+        matched_id = match_model_id(model, by_id.keys())
+        if matched_id is None:
+            return None
+        info = by_id[matched_id]
+        limits = getattr(info.capabilities, "limits", None)
+        return ModelCapabilityInfo(
+            supported_reasoning_efforts=getattr(info, "supported_reasoning_efforts", None),
+            default_reasoning_effort=getattr(info, "default_reasoning_effort", None),
+            max_prompt_tokens=getattr(limits, "max_prompt_tokens", None),
+            max_output_tokens=getattr(limits, "max_output_tokens", None),
+            max_context_window_tokens=getattr(limits, "max_context_window_tokens", None),
+        )
 
     def get_session_ids(self) -> dict[str, str]:
         """Get tracked session IDs for all executed agents.

--- a/src/conductor/providers/diagnostics.py
+++ b/src/conductor/providers/diagnostics.py
@@ -90,10 +90,15 @@ class CredentialEnvVar:
         return {"name": self.name, "present": self.present}
 
 
-@dataclass
+@dataclass(frozen=True)
 class ModelDiagnostic:
     """Diagnostic snapshot of a single model's reasoning-effort and
     context-window capabilities (issue #301).
+
+    Frozen to match its sibling value objects (:class:`CredentialEnvVar`,
+    :class:`~conductor.providers.base.ModelCapabilityInfo`) — every instance
+    is fully constructed in one step by :func:`_build_model_diagnostics` and
+    never mutated afterward.
 
     Every capability field mirrors :class:`~conductor.providers.base.ModelCapabilityInfo`
     and is independently optional — a provider may know a model's token
@@ -385,27 +390,27 @@ async def _build_model_diagnostics(provider: Any, model_ids: list[str]) -> list[
     per-model failure degrades that model to id-only (all capability fields
     ``None``) rather than dropping it from the list or failing the whole
     ``--models`` probe — one bad model must not hide the rest.
+
+    The ``try`` wraps both the call *and* the read of its result: a
+    misbehaving provider that returns something other than a genuine
+    ``ModelCapabilityInfo`` (or ``None``) must degrade only that one model,
+    not raise out of the loop and silently discard every already-built
+    entry for models processed earlier in this same list.
     """
     result: list[ModelDiagnostic] = []
     for model_id in model_ids:
-        caps = None
         try:
             caps = await provider.get_model_capabilities(model_id)
+            # ModelCapabilityInfo.to_dict() keys mirror ModelDiagnostic's
+            # capability fields exactly, so it doubles as the kwargs for
+            # constructing this model's diagnostic. A misbehaving provider
+            # whose return value lacks to_dict() (or isn't None) is caught
+            # below and degrades to id-only, same as any other failure.
+            fields = caps.to_dict() if caps is not None else {}
+            result.append(ModelDiagnostic(id=model_id, **fields))
         except Exception as e:  # noqa: BLE001 - diagnostics must never raise
             logger.debug("Failed to get model capabilities for %r: %s", model_id, e)
-        if caps is None:
             result.append(ModelDiagnostic(id=model_id))
-        else:
-            result.append(
-                ModelDiagnostic(
-                    id=model_id,
-                    supported_reasoning_efforts=caps.supported_reasoning_efforts,
-                    default_reasoning_effort=caps.default_reasoning_effort,
-                    max_prompt_tokens=caps.max_prompt_tokens,
-                    max_output_tokens=caps.max_output_tokens,
-                    max_context_window_tokens=caps.max_context_window_tokens,
-                )
-            )
     return result
 
 

--- a/src/conductor/providers/diagnostics.py
+++ b/src/conductor/providers/diagnostics.py
@@ -23,6 +23,7 @@ Design contract:
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import platform
 from dataclasses import dataclass, field
@@ -33,6 +34,8 @@ from conductor.providers.capabilities import get_capabilities, known_provider_na
 
 if TYPE_CHECKING:
     from conductor.providers.factory import ProviderType
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -88,6 +91,38 @@ class CredentialEnvVar:
 
 
 @dataclass
+class ModelDiagnostic:
+    """Diagnostic snapshot of a single model's reasoning-effort and
+    context-window capabilities (issue #301).
+
+    Every capability field mirrors :class:`~conductor.providers.base.ModelCapabilityInfo`
+    and is independently optional — a provider may know a model's token
+    limits but not its reasoning-effort support, or vice versa. ``None``
+    means "unknown"; an empty ``supported_reasoning_efforts`` list means
+    "known to support none" (e.g. a non-thinking Claude model) — the two
+    are deliberately distinct.
+    """
+
+    id: str
+    supported_reasoning_efforts: list[str] | None = None
+    default_reasoning_effort: str | None = None
+    max_prompt_tokens: int | None = None
+    max_output_tokens: int | None = None
+    max_context_window_tokens: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe representation."""
+        return {
+            "id": self.id,
+            "supported_reasoning_efforts": self.supported_reasoning_efforts,
+            "default_reasoning_effort": self.default_reasoning_effort,
+            "max_prompt_tokens": self.max_prompt_tokens,
+            "max_output_tokens": self.max_output_tokens,
+            "max_context_window_tokens": self.max_context_window_tokens,
+        }
+
+
+@dataclass
 class ProviderDiagnostic:
     """Diagnostic snapshot for a single provider."""
 
@@ -99,7 +134,7 @@ class ProviderDiagnostic:
     checked: bool = False
     connection_ok: bool | None = None
     connection_error: str | None = None
-    models: list[str] | None = None
+    models: list[ModelDiagnostic] | None = None
     models_error: str | None = None
     note: str | None = None
 
@@ -114,7 +149,7 @@ class ProviderDiagnostic:
             "checked": self.checked,
             "connection_ok": self.connection_ok,
             "connection_error": self.connection_error,
-            "models": self.models,
+            "models": [m.to_dict() for m in self.models] if self.models is not None else None,
             "models_error": self.models_error,
             "note": self.note,
         }
@@ -343,6 +378,37 @@ def gather_registries() -> RegistryDiagnostic:
     return RegistryDiagnostic(default=config.default, registries=registries)
 
 
+async def _build_model_diagnostics(provider: Any, model_ids: list[str]) -> list[ModelDiagnostic]:
+    """Build a :class:`ModelDiagnostic` per model id (never raises).
+
+    Calls ``provider.get_model_capabilities(model_id)`` for each id. A
+    per-model failure degrades that model to id-only (all capability fields
+    ``None``) rather than dropping it from the list or failing the whole
+    ``--models`` probe — one bad model must not hide the rest.
+    """
+    result: list[ModelDiagnostic] = []
+    for model_id in model_ids:
+        caps = None
+        try:
+            caps = await provider.get_model_capabilities(model_id)
+        except Exception as e:  # noqa: BLE001 - diagnostics must never raise
+            logger.debug("Failed to get model capabilities for %r: %s", model_id, e)
+        if caps is None:
+            result.append(ModelDiagnostic(id=model_id))
+        else:
+            result.append(
+                ModelDiagnostic(
+                    id=model_id,
+                    supported_reasoning_efforts=caps.supported_reasoning_efforts,
+                    default_reasoning_effort=caps.default_reasoning_effort,
+                    max_prompt_tokens=caps.max_prompt_tokens,
+                    max_output_tokens=caps.max_output_tokens,
+                    max_context_window_tokens=caps.max_context_window_tokens,
+                )
+            )
+    return result
+
+
 async def gather_provider(
     name: str,
     *,
@@ -406,8 +472,12 @@ async def gather_provider(
 
         if list_models and diag.connection_ok:
             try:
-                models = await provider.list_models()
-                diag.models = list(models) if models is not None else None
+                model_ids = await provider.list_models()
+                diag.models = (
+                    await _build_model_diagnostics(provider, model_ids)
+                    if model_ids is not None
+                    else None
+                )
             except Exception as e:  # noqa: BLE001 - diagnostics must never raise
                 diag.models_error = _format_error(e)
     finally:
@@ -457,6 +527,7 @@ __all__ = [
     "CredentialEnvVar",
     "DoctorReport",
     "EnvDiagnostic",
+    "ModelDiagnostic",
     "ProviderDiagnostic",
     "RegistryDiagnostic",
     "RegistryInfo",

--- a/tests/test_cli/test_doctor.py
+++ b/tests/test_cli/test_doctor.py
@@ -21,6 +21,7 @@ from conductor.providers.diagnostics import (
     CredentialEnvVar,
     DoctorReport,
     EnvDiagnostic,
+    ModelDiagnostic,
     ProviderDiagnostic,
     RegistryDiagnostic,
     RegistryInfo,
@@ -61,10 +62,23 @@ def _prov(
     checked: bool = False,
     connection_ok: bool | None = None,
     connection_error: str | None = None,
-    models: list[str] | None = None,
+    models: list[str] | list[ModelDiagnostic] | None = None,
     models_error: str | None = None,
     note: str | None = None,
 ) -> ProviderDiagnostic:
+    """Build a ``ProviderDiagnostic`` for tests.
+
+    ``models`` accepts either plain model-id strings (wrapped into id-only
+    ``ModelDiagnostic`` entries — the common case for tests that don't care
+    about per-model capability fields) or fully-populated ``ModelDiagnostic``
+    instances (for tests exercising reasoning-effort / token-limit
+    rendering).
+    """
+    model_diagnostics = None
+    if models is not None:
+        model_diagnostics = [
+            m if isinstance(m, ModelDiagnostic) else ModelDiagnostic(id=m) for m in models
+        ]
     return ProviderDiagnostic(
         name=name,
         installed=installed,
@@ -74,7 +88,7 @@ def _prov(
         checked=checked,
         connection_ok=connection_ok,
         connection_error=connection_error,
-        models=models,
+        models=model_diagnostics,
         models_error=models_error,
         note=note,
     )
@@ -322,6 +336,124 @@ class TestDoctorFlags:
         assert "more)" not in result.output
         for model in models:
             assert model in result.output
+
+    def test_models_summary_cell_shows_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The Providers table's Models column shows a count, not raw ids."""
+        report = DoctorReport(
+            providers=[
+                _prov("copilot", checked=True, connection_ok=True, models=["gpt-5", "gpt-4"])
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        assert "2 models" in result.output
+
+    def test_model_capabilities_rendered_in_detail_table(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Per-model reasoning-effort and token-limit fields render in the
+        separate Models detail table (#301)."""
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[
+                        ModelDiagnostic(
+                            id="gpt-5.5",
+                            supported_reasoning_efforts=["low", "medium", "high", "xhigh"],
+                            default_reasoning_effort="medium",
+                            max_prompt_tokens=128_000,
+                            max_output_tokens=64_000,
+                            max_context_window_tokens=192_000,
+                        )
+                    ],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        monkeypatch.setattr(_app_module, "output_console", Console(width=200))
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        assert "Models — copilot" in result.output
+        assert "low, medium, high, xhigh" in result.output
+        assert "medium" in result.output
+        assert "128,000" in result.output
+        assert "64,000" in result.output
+        assert "192,000" in result.output
+
+    def test_unknown_model_capabilities_render_as_dash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unknown capability fields degrade to n/a / — rather than crashing."""
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "claude",
+                    checked=True,
+                    connection_ok=True,
+                    models=[ModelDiagnostic(id="claude-3-opus-20240229")],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        assert "claude-3-opus-20240229" in result.output
+        assert "n/a" in result.output  # unknown reasoning-effort support
+
+    def test_no_detail_table_when_models_empty_or_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Providers with no enumerated models don't get an empty detail table."""
+        report = DoctorReport(
+            providers=[
+                _prov("copilot", checked=True, connection_ok=True, models=[]),
+                _prov("claude", checked=True, connection_ok=True, models=None),
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        assert "Models — copilot" not in result.output
+        assert "Models — claude" not in result.output
+
+    def test_json_includes_model_capability_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The JSON ``models`` field is a list of capability objects, not ids."""
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[
+                        ModelDiagnostic(
+                            id="gpt-5.5",
+                            supported_reasoning_efforts=["low", "medium"],
+                            default_reasoning_effort="low",
+                            max_prompt_tokens=128_000,
+                            max_output_tokens=64_000,
+                            max_context_window_tokens=192_000,
+                        )
+                    ],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "--models", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        model = data["providers"][0]["models"][0]
+        assert model == {
+            "id": "gpt-5.5",
+            "supported_reasoning_efforts": ["low", "medium"],
+            "default_reasoning_effort": "low",
+            "max_prompt_tokens": 128_000,
+            "max_output_tokens": 64_000,
+            "max_context_window_tokens": 192_000,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_doctor.py
+++ b/tests/test_cli/test_doctor.py
@@ -401,8 +401,37 @@ class TestDoctorFlags:
         _patch_gather(monkeypatch, report)
         result = runner.invoke(app, ["doctor", "--models"])
         assert result.exit_code == 0
-        assert "claude-3-opus-20240229" in result.output
-        assert "n/a" in result.output  # unknown reasoning-effort support
+        # Target the model's own row, not just "n/a" anywhere in the output.
+        model_lines = [line for line in result.output.splitlines() if "claude-3-opus" in line]
+        assert model_lines, "model row not found in output"
+        assert "n/a" in model_lines[0]
+
+    def test_empty_reasoning_efforts_renders_as_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty list (definitively 'supports none') renders as 'none',
+        distinct from the 'n/a' shown for unknown (None) support."""
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "claude",
+                    checked=True,
+                    connection_ok=True,
+                    models=[
+                        ModelDiagnostic(
+                            id="claude-3-5-sonnet-20241022",
+                            supported_reasoning_efforts=[],
+                            max_prompt_tokens=200_000,
+                        )
+                    ],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        model_lines = [line for line in result.output.splitlines() if "claude-3-5-sonnet" in line]
+        assert model_lines, "model row not found in output"
+        assert "none" in model_lines[0]
+        assert "n/a" not in model_lines[0]
 
     def test_no_detail_table_when_models_empty_or_none(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_providers/test_base.py
+++ b/tests/test_providers/test_base.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from conductor.providers.base import AgentOutput, match_model_id
+from conductor.providers.base import AgentOutput, ModelCapabilityInfo, match_model_id
 
 
 class TestAgentOutput:
@@ -141,3 +141,59 @@ class TestGetModelPricingDefault:
                 return None
 
         assert await _Fake().get_model_pricing("any-model") is None
+
+
+class TestGetModelCapabilitiesDefault:
+    """The base AgentProvider.get_model_capabilities default returns None (#301)."""
+
+    @pytest.mark.asyncio
+    async def test_base_default_returns_none(self) -> None:
+        """Providers that don't override the hook render every column as n/a."""
+        from conductor.providers.base import AgentProvider
+
+        class _Fake(AgentProvider, abstract=True):
+            async def execute(self, *args: object, **kwargs: object) -> AgentOutput:
+                raise NotImplementedError
+
+            async def validate_connection(self) -> bool:
+                return True
+
+            async def close(self) -> None:
+                return None
+
+        assert await _Fake().get_model_capabilities("any-model") is None
+
+
+class TestModelCapabilityInfo:
+    """Tests for the ModelCapabilityInfo dataclass's to_dict()."""
+
+    def test_to_dict_all_fields(self) -> None:
+        info = ModelCapabilityInfo(
+            supported_reasoning_efforts=["low", "medium"],
+            default_reasoning_effort="low",
+            max_prompt_tokens=128_000,
+            max_output_tokens=8_192,
+            max_context_window_tokens=136_192,
+        )
+        assert info.to_dict() == {
+            "supported_reasoning_efforts": ["low", "medium"],
+            "default_reasoning_effort": "low",
+            "max_prompt_tokens": 128_000,
+            "max_output_tokens": 8_192,
+            "max_context_window_tokens": 136_192,
+        }
+
+    def test_to_dict_all_none_defaults(self) -> None:
+        assert ModelCapabilityInfo().to_dict() == {
+            "supported_reasoning_efforts": None,
+            "default_reasoning_effort": None,
+            "max_prompt_tokens": None,
+            "max_output_tokens": None,
+            "max_context_window_tokens": None,
+        }
+
+    def test_empty_reasoning_efforts_list_is_distinct_from_none(self) -> None:
+        """An empty list means 'known to support none', distinct from unknown."""
+        info = ModelCapabilityInfo(supported_reasoning_efforts=[])
+        assert info.supported_reasoning_efforts == []
+        assert info.to_dict()["supported_reasoning_efforts"] == []

--- a/tests/test_providers/test_claude.py
+++ b/tests/test_providers/test_claude.py
@@ -2650,6 +2650,40 @@ class TestClaudeGetModelCapabilities:
         assert caps.supported_reasoning_efforts == []
         assert caps.max_prompt_tokens is None
 
+    @pytest.mark.asyncio
+    async def test_reasoning_fields_populated_when_sdk_unavailable(
+        self, mock_anthropic_class: Mock
+    ) -> None:
+        """The reasoning-effort heuristic is a pure name match independent of
+        the SDK, so it stays populated even when ANTHROPIC_SDK_AVAILABLE is
+        False (get_max_prompt_tokens's own early-return path)."""
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(return_value=Mock(data=[]))
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        with patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", False):
+            caps = await provider.get_model_capabilities("claude-sonnet-4-5")
+        assert caps is not None
+        assert caps.supported_reasoning_efforts == ["low", "medium", "high", "xhigh", "max"]
+        assert caps.max_prompt_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_never_raises_for_non_string_model(self, mock_anthropic_class: Mock) -> None:
+        """A non-string model (a hypothetical caller bug) must not escape the
+        method's own guard — the reasoning-effort field degrades to unknown
+        rather than propagating an AttributeError. Use a truthy non-string
+        value (an int) since ``is_claude_thinking_model`` already short-
+        circuits falsy input like ``None`` or ``""`` without erroring."""
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(return_value=Mock(data=[]))
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        caps = await provider.get_model_capabilities(12345)  # type: ignore[arg-type]
+        assert caps is not None
+        assert caps.supported_reasoning_efforts is None
+
 
 class TestClaudeReasoningEffort:
     """Tests for extended-thinking / reasoning effort plumbing."""

--- a/tests/test_providers/test_claude.py
+++ b/tests/test_providers/test_claude.py
@@ -2582,6 +2582,75 @@ class TestClaudeGetMaxPromptTokens:
             assert await provider.get_max_prompt_tokens("claude-sonnet-4-5") is None
 
 
+@patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+@patch("conductor.providers.claude.AsyncAnthropic")
+class TestClaudeGetModelCapabilities:
+    """Tests for ClaudeProvider.get_model_capabilities (#301)."""
+
+    @pytest.mark.asyncio
+    async def test_thinking_model_reports_all_five_levels(self, mock_anthropic_class: Mock) -> None:
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(
+            return_value=Mock(data=[Mock(id="claude-sonnet-4-5", max_input_tokens=200_000)])
+        )
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        caps = await provider.get_model_capabilities("claude-sonnet-4-5")
+        assert caps is not None
+        assert caps.supported_reasoning_efforts == ["low", "medium", "high", "xhigh", "max"]
+        assert caps.default_reasoning_effort is None
+        assert caps.max_prompt_tokens == 200_000
+        assert caps.max_output_tokens is None
+        assert caps.max_context_window_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_non_thinking_model_reports_empty_list(self, mock_anthropic_class: Mock) -> None:
+        """An empty list is a definitive 'supports none', not 'unknown'."""
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(
+            return_value=Mock(
+                data=[Mock(id="claude-3-5-sonnet-20241022", max_input_tokens=200_000)]
+            )
+        )
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        caps = await provider.get_model_capabilities("claude-3-5-sonnet-20241022")
+        assert caps is not None
+        assert caps.supported_reasoning_efforts == []
+        assert caps.max_prompt_tokens == 200_000
+
+    @pytest.mark.asyncio
+    async def test_reasoning_fields_populated_even_when_prompt_tokens_unknown(
+        self, mock_anthropic_class: Mock
+    ) -> None:
+        """The reasoning heuristic is name-based and doesn't need a model match."""
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(return_value=Mock(data=[]))
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        caps = await provider.get_model_capabilities("claude-opus-4-20250514")
+        assert caps is not None
+        assert caps.supported_reasoning_efforts == ["low", "medium", "high", "xhigh", "max"]
+        assert caps.max_prompt_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_reasoning_fields_populated_when_sdk_call_fails(
+        self, mock_anthropic_class: Mock
+    ) -> None:
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        caps = await provider.get_model_capabilities("claude-3-opus-20240229")
+        assert caps is not None
+        assert caps.supported_reasoning_efforts == []
+        assert caps.max_prompt_tokens is None
+
+
 class TestClaudeReasoningEffort:
     """Tests for extended-thinking / reasoning effort plumbing."""
 

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -1577,14 +1577,29 @@ class TestReasoningEffort:
     """Tests for reasoning_effort plumbing into create_session."""
 
     @staticmethod
-    def _make_model(model_id: str, supported: list[str] | None) -> Any:
+    def _make_model(
+        model_id: str,
+        supported: list[str] | None,
+        *,
+        default_effort: str | None = None,
+        max_output_tokens: int | None = None,
+        max_context_window_tokens: int | None = None,
+    ) -> Any:
         from types import SimpleNamespace
 
+        # Mirrors the real github-copilot-sdk ``Model`` shape: reasoning-effort
+        # fields are top level on ``Model``, NOT nested under ``capabilities``
+        # (see the fix for the #301 validation-read bug).
         return SimpleNamespace(
             id=model_id,
+            supported_reasoning_efforts=supported,
+            default_reasoning_effort=default_effort,
             capabilities=SimpleNamespace(
-                limits=SimpleNamespace(max_prompt_tokens=128_000),
-                supported_reasoning_efforts=supported,
+                limits=SimpleNamespace(
+                    max_prompt_tokens=128_000,
+                    max_output_tokens=max_output_tokens,
+                    max_context_window_tokens=max_context_window_tokens,
+                ),
             ),
         )
 
@@ -1949,6 +1964,124 @@ class TestReasoningEffort:
         assert len(provider.get_retry_history()) == 3
         # Two backoff sleeps between three attempts.
         assert len(sleep_calls) == 2
+
+
+class TestGetModelCapabilities:
+    """Tests for CopilotProvider.get_model_capabilities (#301)."""
+
+    @staticmethod
+    def _make_model(
+        model_id: str,
+        supported: list[str] | None,
+        *,
+        default_effort: str | None = None,
+        max_prompt_tokens: int | None = 128_000,
+        max_output_tokens: int | None = None,
+        max_context_window_tokens: int | None = None,
+    ) -> Any:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            id=model_id,
+            supported_reasoning_efforts=supported,
+            default_reasoning_effort=default_effort,
+            capabilities=SimpleNamespace(
+                limits=SimpleNamespace(
+                    max_prompt_tokens=max_prompt_tokens,
+                    max_output_tokens=max_output_tokens,
+                    max_context_window_tokens=max_context_window_tokens,
+                ),
+            ),
+        )
+
+    @staticmethod
+    def _provider_with_list_models(list_models_impl: Any) -> CopilotProvider:
+        class _FakeClient:
+            async def list_models(self) -> Any:
+                return await list_models_impl()
+
+        provider = CopilotProvider(mock_handler=stub_handler)
+        provider._mock_handler = None
+        provider._client = _FakeClient()
+        provider._started = True
+
+        async def _noop() -> None:
+            return None
+
+        provider._ensure_client_started = _noop  # type: ignore[method-assign]
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_full_capabilities_reported(self) -> None:
+        async def list_models() -> list[Any]:
+            return [
+                self._make_model(
+                    "gpt-5.5",
+                    supported=["low", "medium", "high", "xhigh"],
+                    default_effort="medium",
+                    max_prompt_tokens=128_000,
+                    max_output_tokens=64_000,
+                    max_context_window_tokens=192_000,
+                )
+            ]
+
+        provider = self._provider_with_list_models(list_models)
+        caps = await provider.get_model_capabilities("gpt-5.5")
+        assert caps is not None
+        assert caps.supported_reasoning_efforts == ["low", "medium", "high", "xhigh"]
+        assert caps.default_reasoning_effort == "medium"
+        assert caps.max_prompt_tokens == 128_000
+        assert caps.max_output_tokens == 64_000
+        assert caps.max_context_window_tokens == 192_000
+
+    @pytest.mark.asyncio
+    async def test_no_reasoning_support_reports_none_supported(self) -> None:
+        async def list_models() -> list[Any]:
+            return [self._make_model("gpt-4o", supported=None, max_prompt_tokens=128_000)]
+
+        provider = self._provider_with_list_models(list_models)
+        caps = await provider.get_model_capabilities("gpt-4o")
+        assert caps is not None
+        assert caps.supported_reasoning_efforts is None
+        assert caps.default_reasoning_effort is None
+        assert caps.max_prompt_tokens == 128_000
+
+    @pytest.mark.asyncio
+    async def test_unmatched_model_returns_none(self) -> None:
+        async def list_models() -> list[Any]:
+            return [self._make_model("gpt-4o", supported=["low"])]
+
+        provider = self._provider_with_list_models(list_models)
+        assert await provider.get_model_capabilities("totally-different") is None
+
+    @pytest.mark.asyncio
+    async def test_list_models_failure_returns_none(self) -> None:
+        async def list_models() -> list[Any]:
+            raise RuntimeError("boom")
+
+        provider = self._provider_with_list_models(list_models)
+        assert await provider.get_model_capabilities("gpt-4o") is None
+
+    @pytest.mark.asyncio
+    async def test_mock_handler_mode_returns_none(self) -> None:
+        provider = CopilotProvider(mock_handler=stub_handler)
+        assert await provider.get_model_capabilities("gpt-4o") is None
+
+    @pytest.mark.asyncio
+    async def test_alias_resolution_via_match_model_id(self) -> None:
+        """A dated/aliased requested name resolves against the SDK's base id."""
+
+        async def list_models() -> list[Any]:
+            return [
+                self._make_model(
+                    "claude-3-5-sonnet", supported=["low", "medium"], default_effort="low"
+                )
+            ]
+
+        provider = self._provider_with_list_models(list_models)
+        caps = await provider.get_model_capabilities("claude-3-5-sonnet-20241022")
+        assert caps is not None
+        assert caps.supported_reasoning_efforts == ["low", "medium"]
 
 
 class TestContextTier:

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -1577,14 +1577,7 @@ class TestReasoningEffort:
     """Tests for reasoning_effort plumbing into create_session."""
 
     @staticmethod
-    def _make_model(
-        model_id: str,
-        supported: list[str] | None,
-        *,
-        default_effort: str | None = None,
-        max_output_tokens: int | None = None,
-        max_context_window_tokens: int | None = None,
-    ) -> Any:
+    def _make_model(model_id: str, supported: list[str] | None) -> Any:
         from types import SimpleNamespace
 
         # Mirrors the real github-copilot-sdk ``Model`` shape: reasoning-effort
@@ -1593,13 +1586,8 @@ class TestReasoningEffort:
         return SimpleNamespace(
             id=model_id,
             supported_reasoning_efforts=supported,
-            default_reasoning_effort=default_effort,
             capabilities=SimpleNamespace(
-                limits=SimpleNamespace(
-                    max_prompt_tokens=128_000,
-                    max_output_tokens=max_output_tokens,
-                    max_context_window_tokens=max_context_window_tokens,
-                ),
+                limits=SimpleNamespace(max_prompt_tokens=128_000),
             ),
         )
 

--- a/tests/test_providers/test_diagnostics.py
+++ b/tests/test_providers/test_diagnostics.py
@@ -206,8 +206,15 @@ def _fake_provider(
     validate_error: Exception | None = None,
     models: list[str] | None = None,
     models_error: Exception | None = None,
+    capabilities: dict[str, Any] | None = None,
 ) -> Any:
-    """Build an AsyncMock provider for check/model probes."""
+    """Build an AsyncMock provider for check/model probes.
+
+    ``capabilities`` maps model id -> a ``ModelCapabilityInfo``-like object
+    (or ``None``) returned by ``get_model_capabilities`` for that id. Ids not
+    present in the mapping (or when ``capabilities`` is omitted) resolve to
+    ``None``, matching the base-hook default.
+    """
     provider = AsyncMock()
     if validate_error is not None:
         provider.validate_connection.side_effect = validate_error
@@ -218,6 +225,8 @@ def _fake_provider(
     else:
         provider.list_models.return_value = models
     provider.close.return_value = None
+    caps_map = capabilities or {}
+    provider.get_model_capabilities.side_effect = lambda model_id: caps_map.get(model_id)
     return provider
 
 
@@ -287,7 +296,8 @@ class TestGatherProviderCheck:
         )
         diag = await d.gather_provider("copilot", list_models=True)
         assert diag.checked is True
-        assert diag.models == ["gpt-5", "gpt-4"]
+        assert diag.models is not None
+        assert [m.id for m in diag.models] == ["gpt-5", "gpt-4"]
 
     async def test_models_none_is_na(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
@@ -309,6 +319,60 @@ class TestGatherProviderCheck:
         diag = await d.gather_provider("copilot", list_models=True)
         assert diag.models is None
         assert "list boom" in (diag.models_error or "")
+
+    async def test_model_capabilities_populated_per_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each listed model's capabilities are resolved via get_model_capabilities."""
+        from conductor.providers.base import ModelCapabilityInfo
+
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(
+            ok=True,
+            models=["gpt-5", "gpt-4"],
+            capabilities={
+                "gpt-5": ModelCapabilityInfo(
+                    supported_reasoning_efforts=["low", "medium"],
+                    default_reasoning_effort="low",
+                    max_prompt_tokens=128_000,
+                    max_output_tokens=64_000,
+                    max_context_window_tokens=192_000,
+                ),
+                # "gpt-4" intentionally omitted -> None (unknown capabilities).
+            },
+        )
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        by_id = {m.id: m for m in diag.models}
+        assert by_id["gpt-5"].supported_reasoning_efforts == ["low", "medium"]
+        assert by_id["gpt-5"].default_reasoning_effort == "low"
+        assert by_id["gpt-5"].max_prompt_tokens == 128_000
+        assert by_id["gpt-5"].max_output_tokens == 64_000
+        assert by_id["gpt-5"].max_context_window_tokens == 192_000
+        # Unknown capabilities degrade to id-only, not a dropped entry.
+        assert by_id["gpt-4"].supported_reasoning_efforts is None
+        assert by_id["gpt-4"].max_prompt_tokens is None
+
+    async def test_model_capabilities_failure_degrades_to_id_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A per-model get_model_capabilities exception must not drop the
+        model or fail the whole --models probe."""
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["gpt-5", "gpt-4"])
+        provider.get_model_capabilities.side_effect = RuntimeError("capabilities boom")
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        assert [m.id for m in diag.models] == ["gpt-5", "gpt-4"]
+        assert all(m.supported_reasoning_efforts is None for m in diag.models)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_providers/test_diagnostics.py
+++ b/tests/test_providers/test_diagnostics.py
@@ -374,6 +374,75 @@ class TestGatherProviderCheck:
         assert [m.id for m in diag.models] == ["gpt-5", "gpt-4"]
         assert all(m.supported_reasoning_efforts is None for m in diag.models)
 
+    async def test_mixed_success_and_failure_isolates_the_failing_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failure on one model (not first/only) must not discard results
+        already built for other models in the same list — regression guard
+        for a bug where an unguarded attribute read on a malformed
+        capabilities object escaped the per-model try/except and wiped the
+        whole batch."""
+        from conductor.providers.base import ModelCapabilityInfo
+
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["gpt-5", "gpt-4", "gpt-3"])
+
+        good_caps = ModelCapabilityInfo(
+            supported_reasoning_efforts=["low", "medium"],
+            max_prompt_tokens=128_000,
+        )
+
+        def _capabilities_for(model_id: str) -> ModelCapabilityInfo | None:
+            if model_id == "gpt-4":
+                raise RuntimeError("capabilities boom for gpt-4 only")
+            return good_caps
+
+        provider.get_model_capabilities.side_effect = _capabilities_for
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        by_id = {m.id: m for m in diag.models}
+        # Model before AND after the failing one must retain full data.
+        assert by_id["gpt-5"].supported_reasoning_efforts == ["low", "medium"]
+        assert by_id["gpt-5"].max_prompt_tokens == 128_000
+        assert by_id["gpt-3"].supported_reasoning_efforts == ["low", "medium"]
+        assert by_id["gpt-3"].max_prompt_tokens == 128_000
+        # The failing model degrades to id-only, isolated from its neighbors.
+        assert by_id["gpt-4"].supported_reasoning_efforts is None
+        assert by_id["gpt-4"].max_prompt_tokens is None
+
+    async def test_malformed_capabilities_object_degrades_to_id_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A get_model_capabilities call that *succeeds* but returns an
+        object missing the expected attributes must degrade that model to
+        id-only rather than raising out of the per-model try/except and
+        discarding every other model already built in this list."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["gpt-5", "gpt-4"])
+        malformed = SimpleNamespace()  # no capability attributes at all
+
+        def _capabilities_for(model_id: str) -> Any:
+            if model_id == "gpt-4":
+                return malformed
+            return None
+
+        provider.get_model_capabilities.side_effect = _capabilities_for
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        assert [m.id for m in diag.models] == ["gpt-5", "gpt-4"]
+        by_id = {m.id: m for m in diag.models}
+        assert by_id["gpt-4"].supported_reasoning_efforts is None
+
 
 # ---------------------------------------------------------------------------
 # Top-level gather


### PR DESCRIPTION
## Summary

Extends `conductor doctor --models` (and the underlying `ProviderDiagnostic` / `--json` output) to surface, per model:

1. **Reasoning-effort support** — which `reasoning.effort` levels a model accepts, plus its default.
2. **Context window** — the model's prompt / output / total token limits.

## Approach

- Added an optional `AgentProvider.get_model_capabilities(model)` hook (mirrors the existing `get_max_prompt_tokens` / `get_model_pricing` pattern in `providers/base.py`; base default returns `None`, never raises).
- **Copilot**: implemented via `client.list_models()` — reasoning fields live at the top level of `Model`, not nested under `capabilities`.
- **Claude**: implemented via the existing thinking-model heuristic (`is_claude_thinking_model`) plus `get_max_prompt_tokens`; Anthropic exposes no output/total-context split, so those fields stay `None`.
- **Claude Agent SDK / Hermes / openai-agents**: inherit the base `None` default, rendered as `n/a`.
- `ProviderDiagnostic.models` changed from `list[str]` to `list[ModelDiagnostic]` (id + capability fields), populated per-model with per-model failure isolation so one bad model does not drop the rest of the list.
- `conductor doctor --models` now renders a separate per-provider **Models** detail table (Model / Reasoning efforts / Default / Prompt / Output / Context); the Providers table's Models column shows a count instead of raw ids. The JSON `models` field is now a list of capability objects (not plain id strings — this is a breaking shape change for `--json` consumers).

## Bug fix (found while implementing)

`CopilotProvider._validate_reasoning_effort_for_model` read `capabilities.supported_reasoning_efforts`, but the installed SDK (`github-copilot-sdk>=1.0.0`) exposes that field at the top level of `Model`. The lookup always returned `None`, so per-model reasoning-effort validation (including the `max`-rejection behavior from #299) was silently a no-op against the real SDK. Fixed the read location; updated the test mock shape to match the real SDK.

## Testing

- `uv run ruff check src tests` / `ruff format --check` — clean.
- `uv run ty check src` — clean (one pre-existing, unrelated warning).
- `uv run pytest -m "not install_scripts"` — 3942 passed, 21 skipped, 1 pre-existing failure unrelated to this change (`test_copilot_large_write.py`, fails identically on `main` — hits a live backend that rejects an unavailable model).
- Added/updated tests in `test_base.py`, `test_copilot.py`, `test_claude.py`, `test_diagnostics.py`, `test_doctor.py`.

## Docs

Updated `docs/cli-reference.md` (new "Per-model capabilities" section) and `CHANGELOG.md` (Added + Fixed entries).

Closes #301
