### PR TITLE
chore(release): cut 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.21...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.22...HEAD)
+
+## [0.1.22](https://github.com/microsoft/conductor/compare/v0.1.21...v0.1.22) - 2026-07-15
 
 ### Added
 
@@ -66,6 +68,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--skip-path-update` / `-SkipPathUpdate` flag) — set by default in the test
   harness — and a regression test asserts the scripts never touch shell
   profiles.
+
+### Documentation
+
+- **README provider comparison table corrected** — set Context Window to
+  "Per-model" across all providers, set Pricing to "Subscription" for Copilot
+  and Claude Agent SDK, labeled Claude Agent SDK as experimental in the
+  top-level Features list (matching the Providers table's Tier column), and
+  added a "Using Copilot" section with a config example and auth notes.
+  ([#296](https://github.com/microsoft/conductor/pull/296))
 
 ## [0.1.21](https://github.com/microsoft/conductor/compare/v0.1.20...v0.1.21) - 2026-07-13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.21"
+version = "0.1.22"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.21"
+version = "0.1.22"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 0.1.22

Previous tag: `v0.1.21`

### Commit audit (5 commits since v0.1.21)

| PR | Subject | Disposition |
|---|---|---|
| #285 | docs(cli): document --quiet/--silent as global options | Already covered - retroactively amended the published `[0.1.21]` changelog section |
| #296 | docs(readme): fix provider table and add Copilot section | Added new Documentation entry to `[0.1.22]` |
| #298 | fix(install): install-script tests polluting shell profiles | Already covered in Unreleased -> Fixed |
| #300 | feat(providers): add max reasoning-effort level | Already covered in Unreleased -> Added |
| #302 | feat(doctor): per-model reasoning-effort/context-window limits | Already covered in Unreleased -> Added + Fixed |

### Changelog summary

- Added: `conductor doctor --models` per-model reasoning-effort/context-window support (#301); unified `max` reasoning-effort level (#299)
- Fixed: Copilot per-model `reasoning_effort` validation silent no-op; install-script tests no longer pollute shell profiles (#298)
- Documentation: README provider comparison table corrections (#296)

### Version bump

Patch: `0.1.21` -> `0.1.22` (default bump; no explicit minor/major request).

### Validation

- `make check` passed (ruff check, ruff format --check, ty check - only pre-existing dialog_evaluator.py warning)
- `make test` - 3946 passed, 21 skipped, 2 failed; both failures confirmed pre-existing/unrelated to this release:
  - `test_copilot_large_write.py::test_large_create_tool_call_does_not_truncate` - fails identically on unmodified origin/main (live backend rejects an unavailable model)
  - `test_performance.py::TestStartupTime::test_cli_import_time` - flaky timing threshold; passed on the same commit in a clean worktree
- `git diff --check` clean; diff limited to CHANGELOG.md, pyproject.toml, uv.lock

### Next steps

Merging this PR will be followed by tagging the merge commit `v0.1.22` and pushing it, which triggers `.github/workflows/release.yml` to build and publish the GitHub Release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
