### PR TITLE
feat(providers): force emit_output tool choice in Claude provider when no MCP tools

### DIFF
--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -11,6 +11,7 @@ The Claude provider enables Conductor workflows to use Anthropic's Claude models
 - [System Prompt](#system-prompt)
 - [Streaming Limitations](#streaming-limitations)
 - [Extended Thinking](#extended-thinking)
+- [Structured Output](#structured-output)
 - [Troubleshooting](#troubleshooting)
 - [Cost Optimization](#cost-optimization)
 
@@ -374,6 +375,34 @@ emits the same event shape so workflows that mix providers render consistently.
 
 See [`examples/reasoning-effort.yaml`](../../examples/reasoning-effort.yaml) for
 a runnable end-to-end example.
+
+## Structured Output
+
+The Claude provider enforces structured outputs natively by converting the `output` schema into an Anthropic tool definition.
+
+### Forced Tool Choice
+
+When you configure an agent with a defined `output` schema and don't declare any MCP tools, Conductor uses Anthropic's forced tool choice parameter. It sends the following configuration in the API request:
+
+```json
+{
+  "tool_choice": {
+    "type": "tool",
+    "name": "emit_output",
+    "disable_parallel_tool_use": true
+  }
+}
+```
+
+This forces the model to call the synthetic `emit_output` tool, which prevents the model from returning unstructured prose. Such enforcement aligns with the provider's capability contract declared as `CAPABILITIES.structured_output = "native"`.
+
+### Coexistence with MCP Tools
+
+If the agent has registered MCP tools, forced tool choice is disabled. The model needs to remain free to call any of the available MCP tools multiple times before concluding. In this case, Conductor instructs the model to return its final answer through the `emit_output` tool, but doesn't enforce it at the API parameter level.
+
+### Interaction with Extended Thinking
+
+Combining forced tool choice with Anthropic's extended thinking is not fully verified across all models. API support depends on Anthropic's backend validation rules. If the API rejects the request with a `400 BadRequestError` due to this combination, Conductor catches the error and raises a clear `ValidationError`. The error message will suggest adjusting the `reasoning.effort` setting or using a different model.
 
 ## Troubleshooting
 

--- a/docs/providers/comparison.md
+++ b/docs/providers/comparison.md
@@ -20,7 +20,7 @@ This guide helps you choose between GitHub Copilot, Anthropic Claude, Claude Age
 | **Cost Predictability** | High (flat rate) | Variable (usage-based) | Variable | Variable (usage-based) |
 | **Multi-provider** | No | Yes (via Conductor) | No | Yes (native) |
 | **Agentic Loop** | SDK-managed | Manual (provider code) | SDK-managed (delegated to CLI) | SDK-managed (delegated to hermes) |
-| **Structured Output** | Prompt injection | Native | Prompt injection | Prompt injection |
+| **Structured Output** | Prompt injection | Native (forced tool call) | Prompt injection | Prompt injection |
 | **Session Resume** | Yes | No | No | Yes |
 
 > **About the experimental tier.** `claude-agent-sdk` and `hermes` declare
@@ -78,7 +78,7 @@ agents:
 2. **You want fine-grained cost control** — Pay only for what you use; scale to zero when idle
 3. **You value reasoning quality** — Claude excels at analysis, synthesis, and following complex instructions
 4. **Light/intermittent usage** — Pay-per-use is cheaper than a subscription at low volumes
-5. **You need reliable structured output** — Native schema enforcement more robust than prompt injection
+5. **You need reliable structured output**: Conductor enforces native schemas via a forced tool call, making it more reliable than prompt injection.
 
 ### Example Claude Workflow
 

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -1170,11 +1170,16 @@ class ClaudeProvider(AgentProvider):
             )
 
         # Add MCP tools if available
+        mcp_tools: list[dict[str, Any]] = []
         if mcp_manager and mcp_manager.has_servers():
             mcp_tools = self._convert_mcp_tools_to_claude(tools, mcp_manager)  # tools is the filter
             all_tools.extend(mcp_tools)
             if mcp_tools:
                 logger.debug(f"Added {len(mcp_tools)} MCP tools to request")
+
+        # Force the emit_output tool call when the request carries no MCP
+        # tools; with MCP tools present the model must stay free to call them.
+        force_emit_output = has_output_schema and not mcp_tools
 
         # Use tools if any are defined
         request_tools: list[dict[str, Any]] | None = all_tools if all_tools else None
@@ -1198,6 +1203,7 @@ class ClaudeProvider(AgentProvider):
                     max_parse_recovery_attempts=config.max_parse_recovery_attempts,
                     system_prompt=system_prompt,
                     mcp_manager=mcp_manager,
+                    force_emit_output=force_emit_output,
                 )
 
                 # Handle partial output from mid-agent interrupt
@@ -1268,14 +1274,35 @@ class ClaudeProvider(AgentProvider):
                     try:
                         has_attr = hasattr(anthropic, "BadRequestError")
                         is_bad_request = has_attr and isinstance(e, anthropic.BadRequestError)
-                        if is_bad_request and "temperature" in str(e).lower():
-                            raise ValidationError(
-                                f"Temperature validation failed: {e}",
-                                suggestion=(
-                                    "Temperature must be between 0.0 and 1.0 "
-                                    "(enforced by Claude SDK)"
-                                ),
-                            ) from e
+                        if is_bad_request:
+                            error_text = str(e).lower()
+                            if "temperature" in error_text:
+                                raise ValidationError(
+                                    f"Temperature validation failed: {e}",
+                                    suggestion=(
+                                        "Temperature must be between 0.0 and 1.0 "
+                                        "(enforced by Claude SDK)"
+                                    ),
+                                ) from e
+                            # A 400 rejecting the forced emit_output tool_choice
+                            # (e.g. forced tool use is incompatible with extended
+                            # thinking on the selected model) only applies when
+                            # the flag actually sent tool_choice. Match both the
+                            # "tool_choice" and "tool choice" phrasings.
+                            if force_emit_output and (
+                                "tool_choice" in error_text or "tool choice" in error_text
+                            ):
+                                raise ValidationError(
+                                    f"The model rejected the forced tool_choice "
+                                    f"('emit_output'): {e}",
+                                    suggestion=(
+                                        "The selected model does not support forced "
+                                        "tool choice (possibly because extended "
+                                        "thinking is enabled). Remove "
+                                        "reasoning.effort or switch to a model that "
+                                        "supports forced tool_choice."
+                                    ),
+                                ) from e
                     except TypeError:
                         # isinstance can fail if BadRequestError is not a proper type
                         pass
@@ -1473,6 +1500,7 @@ class ClaudeProvider(AgentProvider):
         tools: list[dict[str, Any]] | None = None,
         thinking: dict[str, Any] | None = None,
         system_prompt: str | None = None,
+        force_emit_output: bool = False,
     ) -> ClaudeResponse:
         """Execute non-streaming Claude API call using AsyncAnthropic.
 
@@ -1491,6 +1519,11 @@ class ClaudeProvider(AgentProvider):
                 ``max_tokens > budget_tokens``.
             system_prompt: Optional rendered system prompt passed as the
                 top-level Anthropic ``system`` parameter.
+            force_emit_output: When True, force the model to call the
+                ``emit_output`` tool by sending
+                ``tool_choice={"type": "tool", "name": "emit_output",
+                "disable_parallel_tool_use": True}``. Used when the request
+                carries no MCP tools.
 
         Returns:
             Claude API response object with content blocks and usage metadata.
@@ -1528,6 +1561,13 @@ class ClaudeProvider(AgentProvider):
         if system_prompt:
             kwargs["system"] = system_prompt
 
+        if force_emit_output:
+            kwargs["tool_choice"] = {
+                "type": "tool",
+                "name": "emit_output",
+                "disable_parallel_tool_use": True,
+            }
+
         # Execute non-streaming API call (async)
         logger.debug(
             f"Executing non-streaming Claude API call: model={model}, "
@@ -1555,6 +1595,7 @@ class ClaudeProvider(AgentProvider):
         max_parse_recovery_attempts: int | None = None,
         system_prompt: str | None = None,
         mcp_manager: MCPManager | None = None,
+        force_emit_output: bool = False,
     ) -> tuple[ClaudeResponse, int | None, bool]:
         """Execute an agentic loop that handles MCP tool calls.
 
@@ -1589,6 +1630,9 @@ class ClaudeProvider(AgentProvider):
                 Passed explicitly (never read from shared provider state) so
                 parallel agents with different cwds execute their tool calls
                 against the correct per-cwd connection pool.
+            force_emit_output: When True, force the model to call the
+                ``emit_output`` tool via the Anthropic ``tool_choice``
+                parameter. Forwarded to every API call in the loop.
 
         Returns:
             Tuple of (final_response, total_tokens_used, is_partial).
@@ -1638,6 +1682,7 @@ class ClaudeProvider(AgentProvider):
                     has_output_schema=has_output_schema,
                     thinking=thinking,
                     system_prompt=system_prompt,
+                    force_emit_output=force_emit_output,
                 )
                 total_tokens += interrupt_tokens
                 return interrupt_response, total_tokens, True
@@ -1666,6 +1711,7 @@ class ClaudeProvider(AgentProvider):
                             thinking=thinking,
                             max_parse_recovery_attempts=max_parse_recovery_attempts,
                             system_prompt=system_prompt,
+                            force_emit_output=force_emit_output,
                         )
                     )
                 else:
@@ -1678,6 +1724,7 @@ class ClaudeProvider(AgentProvider):
                             tools=tools,
                             thinking=thinking,
                             system_prompt=system_prompt,
+                            force_emit_output=force_emit_output,
                         )
                     )
                 interrupt_task = asyncio.create_task(interrupt_signal.wait())
@@ -1710,6 +1757,7 @@ class ClaudeProvider(AgentProvider):
                         has_output_schema=has_output_schema,
                         thinking=thinking,
                         system_prompt=system_prompt,
+                        force_emit_output=force_emit_output,
                     )
                     total_tokens += partial_tokens
                     return partial_resp, total_tokens, True
@@ -1726,6 +1774,7 @@ class ClaudeProvider(AgentProvider):
                     thinking=thinking,
                     max_parse_recovery_attempts=max_parse_recovery_attempts,
                     system_prompt=system_prompt,
+                    force_emit_output=force_emit_output,
                 )
             else:
                 response = await self._execute_api_call(
@@ -1736,6 +1785,7 @@ class ClaudeProvider(AgentProvider):
                     tools=tools,
                     thinking=thinking,
                     system_prompt=system_prompt,
+                    force_emit_output=force_emit_output,
                 )
 
             # Accumulate token usage
@@ -1944,6 +1994,7 @@ class ClaudeProvider(AgentProvider):
         has_output_schema: bool,
         thinking: dict[str, Any] | None = None,
         system_prompt: str | None = None,
+        force_emit_output: bool = False,
     ) -> tuple[Any, int]:
         """Send a final API call requesting partial output after interrupt.
 
@@ -1963,6 +2014,9 @@ class ClaudeProvider(AgentProvider):
             has_output_schema: Whether the agent defines an output schema.
             thinking: Optional extended-thinking kwarg forwarded to the API call.
             system_prompt: Optional rendered system prompt forwarded to the API call.
+            force_emit_output: When True, force the ``emit_output`` tool call
+                via the Anthropic ``tool_choice`` parameter on the partial
+                output request.
 
         Returns:
             Tuple of (response, tokens_used_in_this_call).
@@ -1991,6 +2045,7 @@ class ClaudeProvider(AgentProvider):
             tools=tools,
             thinking=thinking,
             system_prompt=system_prompt,
+            force_emit_output=force_emit_output,
         )
 
         call_tokens = 0
@@ -2012,6 +2067,7 @@ class ClaudeProvider(AgentProvider):
         thinking: dict[str, Any] | None = None,
         max_parse_recovery_attempts: int | None = None,
         system_prompt: str | None = None,
+        force_emit_output: bool = False,
     ) -> ClaudeResponse:
         """Execute API call with parse recovery for malformed JSON responses.
 
@@ -2030,6 +2086,9 @@ class ClaudeProvider(AgentProvider):
             max_parse_recovery_attempts: Resolved per-agent parse recovery limit.
                 None means use the provider-level default.
             system_prompt: Optional rendered system prompt forwarded to every API call.
+            force_emit_output: When True, force the ``emit_output`` tool call
+                via the Anthropic ``tool_choice`` parameter on every attempt
+                (initial call and each recovery retry).
 
         Returns:
             Claude API response.
@@ -2054,6 +2113,7 @@ class ClaudeProvider(AgentProvider):
             tools=tools,
             thinking=thinking,
             system_prompt=system_prompt,
+            force_emit_output=force_emit_output,
         )
 
         # If no output schema, return immediately (no recovery needed)
@@ -2120,6 +2180,7 @@ class ClaudeProvider(AgentProvider):
                 tools=tools,
                 thinking=thinking,
                 system_prompt=system_prompt,
+                force_emit_output=force_emit_output,
             )
 
             # Check if recovery succeeded (tool_use)

--- a/tests/test_providers/test_claude.py
+++ b/tests/test_providers/test_claude.py
@@ -3703,3 +3703,543 @@ class TestClaudeMCPManagerPool:
 
         assert manager is not None
         assert instances[0].connected[0]["cwd"] == os.getcwd()
+class TestClaudeToolChoice:
+    """Tests for forced ``tool_choice`` on the ``emit_output`` synthetic tool.
+
+    When an agent has an ``output:`` schema and the request carries no MCP
+    tools, the provider must force the model to call ``emit_output`` by
+    sending ``tool_choice={"type": "tool", "name": "emit_output",
+    "disable_parallel_tool_use": True}`` on every ``messages.create`` call.
+    This eliminates an entire failure class where the model answers in prose
+    and the provider falls into the expensive parse-recovery loop.
+
+    Negative guards (``test_tool_choice_absent_*``) already pass on current
+    code (which never sends ``tool_choice``) and act as regression guards
+    for the MCP-tools path.
+    """
+
+    @staticmethod
+    def _build_provider(
+        mock_anthropic_module: Mock,
+        mock_anthropic_class: Mock,
+        create_side_effect: list[object] | None = None,
+        create_return_value: Mock | None = None,
+    ) -> tuple[ClaudeProvider, Mock]:
+        """Build a ClaudeProvider with a mocked AsyncAnthropic client.
+
+        Mirrors the ``_build_provider_with_responses`` helper used by the
+        reasoning-effort regression suite.
+        """
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(return_value=Mock(data=[]))
+        if create_side_effect is not None:
+            mock_client.messages.create = AsyncMock(side_effect=create_side_effect)
+        else:
+            mock_client.messages.create = AsyncMock(return_value=create_return_value)
+        mock_anthropic_class.return_value = mock_client
+        provider = ClaudeProvider()
+        return provider, mock_client
+
+    @staticmethod
+    def _make_emit_output_response(input_payload: dict[str, object]) -> Mock:
+        """Build a mock messages.create response carrying an emit_output tool_use."""
+        emit_block = Mock(spec=["type", "name", "input", "id"])
+        emit_block.type = "tool_use"
+        emit_block.name = "emit_output"
+        emit_block.id = "toolu_emit"
+        emit_block.input = input_payload
+
+        response = Mock()
+        response.content = [emit_block]
+        response.usage = Mock(input_tokens=5, output_tokens=5)
+        return response
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_forced_on_emit_output_happy_path(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: forced tool_choice is sent when only emit_output is present.
+        """Happy path: agent with output schema and no MCP servers must send
+        tool_choice forcing the emit_output tool, and must NOT burn extra
+        parse-recovery API calls (call_count == 1)."""
+        response = self._make_emit_output_response({"answer": "42"})
+        provider, mock_client = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_return_value=response
+        )
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            output={"answer": OutputField(type="string")},
+        )
+        result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
+
+        assert result.content == {"answer": "42"}
+        assert mock_client.messages.create.await_count == 1
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["tool_choice"] == {
+            "type": "tool",
+            "name": "emit_output",
+            "disable_parallel_tool_use": True,
+        }
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_absent_when_mcp_tools_present(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: forced tool_choice is NOT sent when MCP tools are
+        # available (model must be able to call them).
+        """Negative guard: when MCP servers yield at least one tool, the
+        request must NOT carry tool_choice — the model needs the freedom to
+        call the MCP tool first."""
+        response = self._make_emit_output_response({"answer": "42"})
+        provider, mock_client = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_return_value=response
+        )
+
+        # Stub MCP manager: has_servers() True and get_all_tools() yields one tool.
+        mock_mcp = Mock()
+        mock_mcp.has_servers = Mock(return_value=True)
+        mock_mcp.get_all_tools = Mock(
+            return_value=[
+                {
+                    "name": "search",
+                    "description": "web search",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ]
+        )
+        provider._get_mcp_manager_for_cwd = AsyncMock(return_value=mock_mcp)
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            output={"answer": OutputField(type="string")},
+        )
+        await provider.execute(agent=agent, context={}, rendered_prompt="p")
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert "tool_choice" not in kwargs
+        # Sanity: the MCP tool was actually added alongside emit_output.
+        tool_names = [t["name"] for t in kwargs["tools"]]
+        assert "emit_output" in tool_names
+        assert "search" in tool_names
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_forced_when_mcp_filter_yields_no_tools(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: when MCP servers exist but yield no tools, forced
+        # tool_choice applies.
+        """Edge case: has_servers() is True but the agent's tool filter
+        excludes every MCP tool, so ``_convert_mcp_tools_to_claude`` returns
+        []. Forced tool_choice must still apply because the request carries
+        only emit_output."""
+        response = self._make_emit_output_response({"answer": "42"})
+        provider, mock_client = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_return_value=response
+        )
+
+        # MCP manager has a server and exposes one tool, but the agent's
+        # tools filter does not match it → converted list is empty.
+        mock_mcp = Mock()
+        mock_mcp.has_servers = Mock(return_value=True)
+        mock_mcp.get_all_tools = Mock(
+            return_value=[
+                {
+                    "name": "search",
+                    "description": "web search",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ]
+        )
+        provider._get_mcp_manager_for_cwd = AsyncMock(return_value=mock_mcp)
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            output={"answer": OutputField(type="string")},
+        )
+        # Pass a filter that matches nothing → mcp_tools == [] after conversion.
+        await provider.execute(
+            agent=agent, context={}, rendered_prompt="p", tools=["not-the-mcp-tool"]
+        )
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        tool_names = [t["name"] for t in kwargs["tools"]]
+        assert tool_names == ["emit_output"]
+        assert kwargs["tool_choice"] == {
+            "type": "tool",
+            "name": "emit_output",
+            "disable_parallel_tool_use": True,
+        }
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_absent_in_raw_output_mode(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: raw output mode never triggers forced tool_choice.
+        """Negative guard: agents with ``output_mode="raw"`` skip structured
+        output entirely — no emit_output tool, no tool_choice."""
+        text_block = Mock(spec=["type", "text"])
+        text_block.type = "text"
+        text_block.text = "raw prose answer"
+
+        response = Mock()
+        response.content = [text_block]
+        response.usage = Mock(input_tokens=5, output_tokens=5)
+
+        provider, mock_client = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_return_value=response
+        )
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            output_mode="raw",
+        )
+        await provider.execute(agent=agent, context={}, rendered_prompt="p")
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert "tool_choice" not in kwargs
+        assert "tools" not in kwargs or kwargs["tools"] is None
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_forced_on_interrupt_partial_output_path(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: forced tool_choice reaches the interrupt partial-output
+        # path.
+        """When an interrupt fires on the first iteration, the partial-output
+        recovery call (``_request_partial_output`` → ``_execute_api_call``)
+        must also carry the forced tool_choice."""
+        import asyncio
+
+        response = self._make_emit_output_response({"result": "partial data"})
+        provider, mock_client = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_return_value=response
+        )
+
+        interrupt = asyncio.Event()
+        interrupt.set()
+
+        tools = [
+            {
+                "name": "emit_output",
+                "description": "Emit output",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"result": {"type": "string"}},
+                },
+            }
+        ]
+
+        response_obj, _tokens, is_partial = await provider._execute_agentic_loop(
+            messages=[{"role": "user", "content": "test"}],
+            model="claude-3-5-sonnet-latest",
+            temperature=None,
+            max_tokens=8192,
+            tools=tools,
+            output_schema={"result": OutputField(type="string")},
+            has_output_schema=True,
+            interrupt_signal=interrupt,
+            force_emit_output=True,
+        )
+
+        assert is_partial is True
+        # _request_partial_output calls _execute_api_call once.
+        assert mock_client.messages.create.await_count == 1
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["tool_choice"] == {
+            "type": "tool",
+            "name": "emit_output",
+            "disable_parallel_tool_use": True,
+        }
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_forced_alongside_thinking_kwargs(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: forced tool_choice coexists with extended thinking
+        # kwargs.
+        """Combo test: with ``reasoning.effort`` set AND an output schema,
+        the API call must carry BOTH the ``thinking`` kwarg AND the forced
+        ``tool_choice`` kwarg."""
+        from conductor.config.schema import ReasoningConfig
+
+        response = self._make_emit_output_response({"answer": "42"})
+        provider, mock_client = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_return_value=response
+        )
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            model="claude-opus-4-20250514",
+            reasoning=ReasoningConfig(effort="medium"),
+            output={"answer": OutputField(type="string")},
+        )
+        await provider.execute(agent=agent, context={}, rendered_prompt="p")
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 8192}
+        assert kwargs["tool_choice"] == {
+            "type": "tool",
+            "name": "emit_output",
+            "disable_parallel_tool_use": True,
+        }
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_present_on_both_calls_across_retry(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: the flag survives retries (computed before the retry
+        # loop).
+        """Retry test: when the first attempt raises a retryable error and
+        the second succeeds, BOTH messages.create calls must include the
+        forced tool_choice — the flag is computed once before the retry
+        loop, not per attempt."""
+        mock_anthropic_module.__version__ = "0.77.0"
+
+        class MockRateLimitError(Exception):
+            def __init__(self) -> None:
+                self.response = Mock()
+                self.response.headers = {}
+                super().__init__("Rate limit exceeded")
+
+        mock_anthropic_module.RateLimitError = MockRateLimitError
+        mock_anthropic_module.BadRequestError = type("BadRequestError", (Exception,), {})
+
+        success_response = self._make_emit_output_response({"answer": "42"})
+        provider, mock_client = self._build_provider(
+            mock_anthropic_module,
+            mock_anthropic_class,
+            create_side_effect=[MockRateLimitError(), success_response],
+        )
+
+        from conductor.providers.claude import RetryConfig
+
+        # Re-bind provider with a fast retry config to keep the test snappy.
+        provider = ClaudeProvider(retry_config=RetryConfig(base_delay=0.01, max_delay=0.1))
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            output={"answer": OutputField(type="string")},
+        )
+        result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
+
+        assert result.content == {"answer": "42"}
+        assert mock_client.messages.create.await_count == 2
+        expected_tool_choice = {
+            "type": "tool",
+            "name": "emit_output",
+            "disable_parallel_tool_use": True,
+        }
+        first_kwargs = mock_client.messages.create.call_args_list[0].kwargs
+        second_kwargs = mock_client.messages.create.call_args_list[1].kwargs
+        assert first_kwargs["tool_choice"] == expected_tool_choice
+        assert second_kwargs["tool_choice"] == expected_tool_choice
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_forced_when_no_mcp_manager_at_all(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: forced tool_choice works when no MCP manager exists at
+        # all (catches the uninitialized mcp_tools regression).
+        """Regression: ``_mcp_manager is None`` (not just ``has_servers() ==
+        False``) must still produce forced tool_choice without raising
+        ``UnboundLocalError`` on an uninitialized ``mcp_tools`` local."""
+        response = self._make_emit_output_response({"answer": "42"})
+        provider, mock_client = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_return_value=response
+        )
+        # Explicitly guarantee the no-MCP-manager state.
+        provider._get_mcp_manager_for_cwd = AsyncMock(return_value=None)
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            output={"answer": OutputField(type="string")},
+        )
+        result = await provider.execute(agent=agent, context={}, rendered_prompt="p")
+
+        assert result.content == {"answer": "42"}
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["tool_choice"] == {
+            "type": "tool",
+            "name": "emit_output",
+            "disable_parallel_tool_use": True,
+        }
+
+
+class TestClaudeBadRequestToolChoice:
+    """Tests for the BadRequestError branch handling API rejections of forced
+    ``tool_choice``.
+
+    When the provider forces ``emit_output`` via ``tool_choice`` and the
+    Anthropic API rejects it (e.g. forced tool use is incompatible with
+    extended thinking on the selected model), the user must get a targeted
+    ``ValidationError`` naming the feature and suggesting the fix — not a
+    generic ``ProviderError``.
+    """
+
+    @staticmethod
+    def _build_provider(
+        mock_anthropic_module: Mock,
+        mock_anthropic_class: Mock,
+        create_side_effect: list[object],
+    ) -> tuple[ClaudeProvider, Mock]:
+        """Build a ClaudeProvider whose messages.create raises via side_effect."""
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(return_value=Mock(data=[]))
+        mock_client.messages.create = AsyncMock(side_effect=create_side_effect)
+        mock_anthropic_class.return_value = mock_client
+        provider = ClaudeProvider()
+        return provider, mock_client
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_rejection_raises_targeted_validation_error(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: an API rejection of forced tool_choice surfaces as a
+        # targeted ValidationError (not a generic ProviderError).
+        """Agent with output schema + reasoning effort → forced tool_choice is
+        sent → API answers 400 "tool_choice ... extended thinking" → the
+        provider must raise ValidationError whose message names both the
+        feature ("tool_choice") and the likely cause ("thinking")."""
+        mock_anthropic_module.BadRequestError = type("BadRequestError", (Exception,), {})
+        rejection = mock_anthropic_module.BadRequestError(
+            "tool_choice is not supported with extended thinking"
+        )
+        provider, _ = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_side_effect=[rejection]
+        )
+
+        from conductor.config.schema import ReasoningConfig
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            model="claude-opus-4-20250514",
+            reasoning=ReasoningConfig(effort="medium"),
+            output={"answer": OutputField(type="string")},
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            await provider.execute(agent=agent, context={}, rendered_prompt="p")
+
+        assert "tool_choice" in str(exc_info.value)
+        assert "thinking" in str(exc_info.value)
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_rejection_space_variant_also_matches(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: the "tool choice" wording variant (space instead of
+        # underscore) is also recognized as a forced-tool_choice rejection.
+        """Anthropic may phrase the rejection without the underscore
+        ("tool choice ... thinking"). The normalized substring check must
+        catch both spellings."""
+        mock_anthropic_module.BadRequestError = type("BadRequestError", (Exception,), {})
+        rejection = mock_anthropic_module.BadRequestError(
+            "Forced tool choice is not compatible with thinking on this model"
+        )
+        provider, _ = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_side_effect=[rejection]
+        )
+
+        from conductor.config.schema import ReasoningConfig
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            model="claude-opus-4-20250514",
+            reasoning=ReasoningConfig(effort="medium"),
+            output={"answer": OutputField(type="string")},
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            await provider.execute(agent=agent, context={}, rendered_prompt="p")
+
+        assert "tool_choice" in str(exc_info.value)
+        assert "thinking" in str(exc_info.value)
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_tool_choice_rejection_not_raised_without_forced_choice(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        # Requirement: a BadRequestError mentioning tool_choice must NOT be
+        # reclassified when forced tool_choice was never sent (MCP path).
+        """Negative guard: when MCP tools are present, no tool_choice is sent,
+        so a tool_choice-flavored 400 cannot be attributed to the forced
+        emit_output — the error must keep the generic ProviderError path."""
+        mock_anthropic_module.BadRequestError = type("BadRequestError", (Exception,), {})
+        rejection = mock_anthropic_module.BadRequestError(
+            "tool_choice is not supported with extended thinking"
+        )
+        provider, _ = self._build_provider(
+            mock_anthropic_module, mock_anthropic_class, create_side_effect=[rejection]
+        )
+
+        # MCP manager yields a tool → force_emit_output is False.
+        mock_mcp = Mock()
+        mock_mcp.has_servers = Mock(return_value=True)
+        mock_mcp.get_all_tools = Mock(
+            return_value=[
+                {
+                    "name": "search",
+                    "description": "web search",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ]
+        )
+        provider._get_mcp_manager_for_cwd = AsyncMock(return_value=mock_mcp)
+
+        from conductor.config.schema import ReasoningConfig
+
+        agent = AgentDef(
+            name="t",
+            prompt="p",
+            model="claude-opus-4-20250514",
+            reasoning=ReasoningConfig(effort="medium"),
+            output={"answer": OutputField(type="string")},
+        )
+
+        with pytest.raises(ProviderError):
+            await provider.execute(agent=agent, context={}, rendered_prompt="p")

--- a/tests/test_providers/test_claude.py
+++ b/tests/test_providers/test_claude.py
@@ -3703,6 +3703,8 @@ class TestClaudeMCPManagerPool:
 
         assert manager is not None
         assert instances[0].connected[0]["cwd"] == os.getcwd()
+
+
 class TestClaudeToolChoice:
     """Tests for forced ``tool_choice`` on the ``emit_output`` synthetic tool.
 


### PR DESCRIPTION
## Summary

When an agent has an `output:` schema and the request carries no MCP tools, the Claude provider now sends `tool_choice={"type": "tool", "name": "emit_output", "disable_parallel_tool_use": true}` on every `messages.create` call. This aligns the implementation with the declared `CAPABILITIES.structured_output = "native"` contract (*"schema is enforced via a forced tool call"*) and eliminates an entire failure class where the model answers in prose and the provider falls into the expensive parse-recovery loop.

When MCP tools ARE present, no `tool_choice` is sent — the model keeps the freedom to call MCP tools first (the existing `tool_choice=auto` default).

When the Anthropic API rejects a forced `tool_choice` request (e.g. forced tool use is incompatible with extended thinking on the selected model), the provider now raises a targeted `ValidationError` naming the feature and suggesting the fix (remove `reasoning.effort` or switch model), instead of a generic `ProviderError`.

## Changes

- **`src/conductor/providers/claude.py`**
  - Compute `force_emit_output = has_output_schema and not mcp_tools` in `execute()` (by-fact-of-added-MCP-tools criterion; `mcp_tools` is initialized to `[]` before the conditional block so the no-MCP-manager path cannot raise `UnboundLocalError`).
  - Thread `force_emit_output` (default `False`, backward compatible) through `_execute_agentic_loop`, `_execute_with_parse_recovery`, and `_request_partial_output` into `_execute_api_call` (10 call sites).
  - Set `kwargs["tool_choice"]` in `_execute_api_call` before `messages.create` when the flag is set.
  - Extend the `BadRequestError` branch: when `force_emit_output` actually sent `tool_choice` and the normalized (lowercased) API message matches `"tool_choice"` or `"tool choice"`, raise `ValidationError` with a suggestion mentioning extended thinking. The pre-existing temperature-validation branch is unchanged.

- **`tests/test_providers/test_claude.py`** — 11 new tests:
  - `TestClaudeToolChoice` (8): happy path, MCP present (negative guard), MCP filter yielding no tools, raw output mode (negative guard), interrupt partial-output path, extended-thinking combo, retry persistence (both calls), no-MCP-manager regression.
  - `TestClaudeBadRequestToolChoice` (3): targeted ValidationError on rejection, `"tool choice"` (space) wording variant, negative guard locking the MCP path on generic `ProviderError`.
  - Each test carries a `# Requirement:` comment.

- **`docs/providers/claude.md`** — new *Structured Output* section covering the forced tool choice mechanism, MCP coexistence rule, and the extended-thinking interaction caveat.
- **`docs/providers/comparison.md`** — comparison table and Claude strengths list note the forced tool call.

## Test plan

- `uv run pytest tests/test_providers/test_claude.py -k tool_choice -v` → 11 passed
- `uv run pytest tests/test_providers/test_claude.py -k BadRequest -v` → 3 passed
- `uv run pytest tests/test_providers/` → 658 passed, 7 skipped
- `make test` → 3956 passed (2 failures reproduced on clean `main` — pre-existing, unrelated: checkpoint contamination test + Copilot 403)
- `make validate-examples` → green
- `make check` → clean (1 pre-existing `ty` warning in `engine/dialog_evaluator.py:131`, present on `main` too)
- Manual smoke (real `ClaudeProvider.execute` with mocked transport): happy path sends forced `tool_choice` and extracts content; rejection path raises `ValidationError` with `tool_choice` + `thinking` in the message; MCP path sends no `tool_choice`.

## Scope

Out of scope (unchanged): `copilot.py`, `hermes.py`, `claude_agent_sdk.py` (`tool_choice` is an Anthropic-API concept — no Provider Parity violation), parse-recovery logic (kept as a safety net for the MCP path), `OutputField`, the `emit_output` schema, MCP-tools path behavior.

🤖 Generated with [OhMyOpenCode](https://github.com/oh-my-opencode) orchestration