### PR TITLE
fix(doctor): render optional provider credentials neutrally (#319)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -453,6 +453,7 @@ values are never read or printed. Detected variables per provider:
 | `claude` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` | required (direct Anthropic API) |
 | `claude-agent-sdk` | `ANTHROPIC_API_KEY` | optional override — authenticates via `claude login` |
 | `hermes` | *(none — endpoint / API key are passed explicitly)* | — |
+| `openai-agents` | *(none — not yet implemented)* | — |
 
 For **`copilot`** and **`claude-agent-sdk`**, these env vars are *optional
 overrides*: both providers authenticate primarily via an on-disk CLI login
@@ -460,9 +461,9 @@ overrides*: both providers authenticate primarily via an on-disk CLI login
 credentials cell for them is expected — **not** a misconfiguration. Each
 absent optional variable renders as a neutral `○` (with a short note in the
 **Notes** column) rather than the red `✗` used for a genuinely missing
-*required* credential. To confirm a provider is actually ready, run a live
-connection probe with `--check` — the offline credentials view alone does
-not determine readiness for CLI-login providers.
+*required* credential. The offline view only ever reports env-var
+*presence*, never validity, for **any** provider — run a live connection
+probe with `--check` to confirm a provider is actually ready.
 
 ### Exit codes
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -447,12 +447,22 @@ id strings):
 Only the **presence** of credential environment variables is reported —
 values are never read or printed. Detected variables per provider:
 
-| Provider | Environment variables |
-|----------|-----------------------|
-| `copilot` | `GITHUB_TOKEN`, `GH_TOKEN`, `COPILOT_PROVIDER_API_KEY`, `COPILOT_PROVIDER_BEARER_TOKEN`, `COPILOT_PROVIDER_RUNTIME_TOKEN` |
-| `claude` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` |
-| `claude-agent-sdk` | `ANTHROPIC_API_KEY` |
-| `hermes` | *(none — endpoint / API key are passed explicitly)* |
+| Provider | Environment variables | Requirement |
+|----------|-----------------------|-------------|
+| `copilot` | `GITHUB_TOKEN`, `GH_TOKEN`, `COPILOT_PROVIDER_API_KEY`, `COPILOT_PROVIDER_BEARER_TOKEN`, `COPILOT_PROVIDER_RUNTIME_TOKEN` | optional overrides — authenticates via the GitHub/Copilot CLI login on disk |
+| `claude` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` | required (direct Anthropic API) |
+| `claude-agent-sdk` | `ANTHROPIC_API_KEY` | optional override — authenticates via `claude login` |
+| `hermes` | *(none — endpoint / API key are passed explicitly)* | — |
+
+For **`copilot`** and **`claude-agent-sdk`**, these env vars are *optional
+overrides*: both providers authenticate primarily via an on-disk CLI login
+(the GitHub/Copilot CLI and `claude login`, respectively), so an all-absent
+credentials cell for them is expected — **not** a misconfiguration. Each
+absent optional variable renders as a neutral `○` (with a short note in the
+**Notes** column) rather than the red `✗` used for a genuinely missing
+*required* credential. To confirm a provider is actually ready, run a live
+connection probe with `--check` — the offline credentials view alone does
+not determine readiness for CLI-login providers.
 
 ### Exit codes
 

--- a/src/conductor/cli/doctor.py
+++ b/src/conductor/cli/doctor.py
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
 _CHECK = "[green]✓[/green]"
 _CROSS = "[red]✗[/red]"
 _DASH = "[dim]—[/dim]"
+_OPTIONAL_MARK = "○"
+"""Neutral glyph for an absent *optional* credential — deliberately not the
+red ``✗`` used for a genuinely missing required credential (issue #319)."""
 
 
 def run_doctor(
@@ -229,13 +232,25 @@ def _tier_cell(tier: str | None) -> str:
 
 
 def _credentials_cell(diag: ProviderDiagnostic) -> str:
-    """Format credential env-var presence (presence only, never values)."""
+    """Format credential env-var presence (presence only, never values).
+
+    A present credential is a green ``✓``. An absent credential renders as a
+    red ``✗`` only when it is a genuine requirement; for providers whose env
+    vars are optional overrides (they authenticate via a CLI login on disk —
+    ``diag.credentials_optional``), an absent credential renders as a neutral
+    dim ``○`` instead, so an all-absent cell does not read as "broken". The
+    accompanying auth-path note is surfaced in the Notes column (issue #319).
+    """
     if not diag.credential_env_vars:
         return _DASH
-    lines = [
-        f"{_CHECK} {cred.name}" if cred.present else f"[dim]{_CROSS} {cred.name}[/dim]"
-        for cred in diag.credential_env_vars
-    ]
+    lines: list[str] = []
+    for cred in diag.credential_env_vars:
+        if cred.present:
+            lines.append(f"{_CHECK} {cred.name}")
+        elif diag.credentials_optional:
+            lines.append(f"[dim]{_OPTIONAL_MARK} {cred.name}[/dim]")
+        else:
+            lines.append(f"[dim]{_CROSS} {cred.name}[/dim]")
     return "\n".join(lines)
 
 

--- a/src/conductor/providers/diagnostics.py
+++ b/src/conductor/providers/diagnostics.py
@@ -51,22 +51,50 @@ ALL_SECTIONS: tuple[Section, ...] = ("env", "providers", "registries")
 # Surfaced as an informational note, not an error.
 _NOT_IMPLEMENTED: frozenset[str] = frozenset({"openai-agents"})
 
-# Per-provider credential environment variables whose *presence* (never
-# value) is reported in the offline diagnostic. Copilot authenticates via
-# the GitHub/Copilot CLI login on disk, so its GitHub-token vars are
-# best-effort hints rather than hard requirements.
-_CREDENTIAL_ENV_VARS: dict[str, tuple[str, ...]] = {
-    "copilot": (
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
-        "COPILOT_PROVIDER_API_KEY",
-        "COPILOT_PROVIDER_BEARER_TOKEN",
-        "COPILOT_PROVIDER_RUNTIME_TOKEN",
+
+@dataclass(frozen=True)
+class _CredentialSpec:
+    """Static credential metadata for a provider's offline diagnostic.
+
+    Only the *presence* of each var in ``env_vars`` is ever reported (never
+    its value). ``optional`` marks providers that authenticate primarily via
+    an on-disk CLI login — the GitHub/Copilot CLI for ``copilot`` and
+    ``claude login`` for ``claude-agent-sdk`` — so their env vars are
+    best-effort overrides rather than hard requirements: an all-absent
+    credentials cell for them is expected, not a misconfiguration. ``note``
+    surfaces that auth path in the rendered report so the absence of every
+    credential does not read as "provider is broken" (issue #319).
+    """
+
+    env_vars: tuple[str, ...] = ()
+    optional: bool = False
+    note: str | None = None
+
+
+# Per-provider credential environment variables and their offline-diagnostic
+# semantics. Copilot and claude-agent-sdk authenticate via a CLI login on
+# disk, so their tokens are optional overrides; claude (direct API) genuinely
+# requires one of its keys.
+_CREDENTIAL_SPECS: dict[str, _CredentialSpec] = {
+    "copilot": _CredentialSpec(
+        env_vars=(
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+            "COPILOT_PROVIDER_API_KEY",
+            "COPILOT_PROVIDER_BEARER_TOKEN",
+            "COPILOT_PROVIDER_RUNTIME_TOKEN",
+        ),
+        optional=True,
+        note="authenticates via GitHub/Copilot CLI login; env vars are optional overrides",
     ),
-    "claude": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
-    "claude-agent-sdk": ("ANTHROPIC_API_KEY",),
-    "hermes": (),
-    "openai-agents": (),
+    "claude": _CredentialSpec(env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")),
+    "claude-agent-sdk": _CredentialSpec(
+        env_vars=("ANTHROPIC_API_KEY",),
+        optional=True,
+        note="authenticates via `claude login`; ANTHROPIC_API_KEY is an optional override",
+    ),
+    "hermes": _CredentialSpec(),
+    "openai-agents": _CredentialSpec(),
 }
 
 # Update-check opt-out env var (mirrors cli/update.py so diagnostics does not
@@ -137,6 +165,7 @@ class ProviderDiagnostic:
     implemented: bool
     tier: str | None
     credential_env_vars: list[CredentialEnvVar] = field(default_factory=list)
+    credentials_optional: bool = False
     checked: bool = False
     connection_ok: bool | None = None
     connection_error: str | None = None
@@ -152,6 +181,7 @@ class ProviderDiagnostic:
             "implemented": self.implemented,
             "tier": self.tier,
             "credential_env_vars": [c.to_dict() for c in self.credential_env_vars],
+            "credentials_optional": self.credentials_optional,
             "checked": self.checked,
             "connection_ok": self.connection_ok,
             "connection_error": self.connection_error,
@@ -288,10 +318,10 @@ def _provider_tier(name: str) -> str | None:
 
 def _credential_env_vars(name: str) -> list[CredentialEnvVar]:
     """Return presence flags for the provider's credential env vars."""
-    return [
-        CredentialEnvVar(var, bool(os.environ.get(var)))
-        for var in _CREDENTIAL_ENV_VARS.get(name, ())
-    ]
+    spec = _CREDENTIAL_SPECS.get(name)
+    if spec is None:
+        return []
+    return [CredentialEnvVar(var, bool(os.environ.get(var))) for var in spec.env_vars]
 
 
 def _update_check_disabled() -> bool:
@@ -439,6 +469,7 @@ async def gather_provider(
     """
     implemented = name not in _NOT_IMPLEMENTED
     installed = _sdk_available(name) if implemented else False
+    spec = _CREDENTIAL_SPECS.get(name, _CredentialSpec())
 
     diag = ProviderDiagnostic(
         name=name,
@@ -446,7 +477,8 @@ async def gather_provider(
         implemented=implemented,
         tier=_provider_tier(name),
         credential_env_vars=_credential_env_vars(name),
-        note=None if implemented else "not yet implemented",
+        credentials_optional=spec.optional,
+        note="not yet implemented" if not implemented else spec.note,
     )
 
     do_check = check or list_models

--- a/src/conductor/providers/diagnostics.py
+++ b/src/conductor/providers/diagnostics.py
@@ -57,24 +57,28 @@ class _CredentialSpec:
     """Static credential metadata for a provider's offline diagnostic.
 
     Only the *presence* of each var in ``env_vars`` is ever reported (never
-    its value). ``optional`` marks providers that authenticate primarily via
-    an on-disk CLI login — the GitHub/Copilot CLI for ``copilot`` and
-    ``claude login`` for ``claude-agent-sdk`` — so their env vars are
-    best-effort overrides rather than hard requirements: an all-absent
-    credentials cell for them is expected, not a misconfiguration. ``note``
-    surfaces that auth path in the rendered report so the absence of every
-    credential does not read as "provider is broken" (issue #319).
+    its value). ``optional_auth_note`` collapses two related facts into one
+    field so they can't drift apart: ``None`` means the provider genuinely
+    requires one of ``env_vars``; a non-``None`` string means the provider
+    has a credential path outside these env vars (e.g. an on-disk CLI
+    login), so an all-absent credentials cell for it is expected — not a
+    misconfiguration — and the string is that path, surfaced in the
+    rendered report so the absence doesn't read as "provider is broken"
+    (issue #319). See ``optional`` for the derived boolean.
     """
 
     env_vars: tuple[str, ...] = ()
-    optional: bool = False
-    note: str | None = None
+    optional_auth_note: str | None = None
+
+    @property
+    def optional(self) -> bool:
+        """Whether every var in ``env_vars`` is an optional override."""
+        return self.optional_auth_note is not None
 
 
 # Per-provider credential environment variables and their offline-diagnostic
-# semantics. Copilot and claude-agent-sdk authenticate via a CLI login on
-# disk, so their tokens are optional overrides; claude (direct API) genuinely
-# requires one of its keys.
+# semantics. See each entry's ``optional_auth_note`` for *why* that provider's
+# vars are optional overrides rather than hard requirements.
 _CREDENTIAL_SPECS: dict[str, _CredentialSpec] = {
     "copilot": _CredentialSpec(
         env_vars=(
@@ -84,14 +88,16 @@ _CREDENTIAL_SPECS: dict[str, _CredentialSpec] = {
             "COPILOT_PROVIDER_BEARER_TOKEN",
             "COPILOT_PROVIDER_RUNTIME_TOKEN",
         ),
-        optional=True,
-        note="authenticates via GitHub/Copilot CLI login; env vars are optional overrides",
+        optional_auth_note=(
+            "authenticates via GitHub/Copilot CLI login; env vars are optional overrides"
+        ),
     ),
     "claude": _CredentialSpec(env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")),
     "claude-agent-sdk": _CredentialSpec(
         env_vars=("ANTHROPIC_API_KEY",),
-        optional=True,
-        note="authenticates via `claude login`; ANTHROPIC_API_KEY is an optional override",
+        optional_auth_note=(
+            "authenticates via `claude login`; ANTHROPIC_API_KEY is an optional override"
+        ),
     ),
     "hermes": _CredentialSpec(),
     "openai-agents": _CredentialSpec(),
@@ -316,11 +322,8 @@ def _provider_tier(name: str) -> str | None:
         return None
 
 
-def _credential_env_vars(name: str) -> list[CredentialEnvVar]:
+def _credential_env_vars(spec: _CredentialSpec) -> list[CredentialEnvVar]:
     """Return presence flags for the provider's credential env vars."""
-    spec = _CREDENTIAL_SPECS.get(name)
-    if spec is None:
-        return []
     return [CredentialEnvVar(var, bool(os.environ.get(var))) for var in spec.env_vars]
 
 
@@ -476,9 +479,12 @@ async def gather_provider(
         installed=installed,
         implemented=implemented,
         tier=_provider_tier(name),
-        credential_env_vars=_credential_env_vars(name),
+        credential_env_vars=_credential_env_vars(spec),
         credentials_optional=spec.optional,
-        note="not yet implemented" if not implemented else spec.note,
+        # "not yet implemented" always wins over a provider's own credential
+        # note — there is nothing useful to say about a provider's auth path
+        # when it can't be instantiated at all.
+        note="not yet implemented" if not implemented else spec.optional_auth_note,
     )
 
     do_check = check or list_models

--- a/tests/test_cli/test_doctor.py
+++ b/tests/test_cli/test_doctor.py
@@ -59,6 +59,7 @@ def _prov(
     implemented: bool = True,
     tier: str | None = "stable",
     creds: list[CredentialEnvVar] | None = None,
+    credentials_optional: bool = False,
     checked: bool = False,
     connection_ok: bool | None = None,
     connection_error: str | None = None,
@@ -85,6 +86,7 @@ def _prov(
         implemented=implemented,
         tier=tier,
         credential_env_vars=creds or [],
+        credentials_optional=credentials_optional,
         checked=checked,
         connection_ok=connection_ok,
         connection_error=connection_error,
@@ -152,6 +154,70 @@ class TestDoctorOffline:
         result = runner.invoke(app, ["doctor", "registries"])
         assert result.exit_code == 0
         assert captured["sections"] == ("registries",)
+
+
+# ---------------------------------------------------------------------------
+# Credential rendering — optional vs. required (issue #319)
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorCredentialRendering:
+    """Absent *optional* credentials render neutrally, not as an alarming ✗."""
+
+    def test_optional_absent_credentials_render_neutral_with_note(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # copilot authenticates via the CLI login on disk, so an all-absent
+        # credentials cell must NOT read as a misconfiguration.
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    creds=[
+                        CredentialEnvVar("GITHUB_TOKEN", True),
+                        CredentialEnvVar("GH_TOKEN", False),
+                        CredentialEnvVar("COPILOT_PROVIDER_API_KEY", False),
+                    ],
+                    credentials_optional=True,
+                    note="CLI login; env vars optional",
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "providers"])
+        assert result.exit_code == 0
+        # A present credential is still a ✓ regardless of optionality.
+        assert "✓ GITHUB_TOKEN" in result.output
+        # Absent optional credentials use the neutral ○, never the red ✗.
+        assert "○ GH_TOKEN" in result.output
+        assert "○ COPILOT_PROVIDER_API_KEY" in result.output
+        assert "✗ GH_TOKEN" not in result.output
+        assert "✗ COPILOT_PROVIDER_API_KEY" not in result.output
+        # The auth-path note explains why an all-absent cell is expected.
+        assert "optional" in result.output
+
+    def test_required_absent_credentials_still_render_cross(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # claude (direct API) genuinely requires a key — an absent required
+        # credential must keep the ✗ so a real misconfiguration stays visible.
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "claude",
+                    creds=[
+                        CredentialEnvVar("ANTHROPIC_API_KEY", False),
+                        CredentialEnvVar("ANTHROPIC_AUTH_TOKEN", False),
+                    ],
+                    credentials_optional=False,
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "providers"])
+        assert result.exit_code == 0
+        assert "✗ ANTHROPIC_API_KEY" in result.output
+        assert "○ ANTHROPIC_API_KEY" not in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_doctor.py
+++ b/tests/test_cli/test_doctor.py
@@ -155,6 +155,26 @@ class TestDoctorOffline:
         assert result.exit_code == 0
         assert captured["sections"] == ("registries",)
 
+    def test_copilot_absent_creds_render_neutral_end_to_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Real gather (NOT patched) reproducing issue #319 exactly as filed:
+        # with every copilot credential env var cleared, the offline view
+        # must render the neutral ○ (never the alarming ✗) plus its note.
+        for var in (
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+            "COPILOT_PROVIDER_API_KEY",
+            "COPILOT_PROVIDER_BEARER_TOKEN",
+            "COPILOT_PROVIDER_RUNTIME_TOKEN",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        result = runner.invoke(app, ["doctor", "providers", "--provider", "copilot"])
+        assert result.exit_code == 0
+        assert "✗" not in result.output
+        assert "○ GITHUB_TOKEN" in result.output
+        assert "optional" in result.output
+
 
 # ---------------------------------------------------------------------------
 # Credential rendering — optional vs. required (issue #319)
@@ -194,7 +214,7 @@ class TestDoctorCredentialRendering:
         assert "✗ GH_TOKEN" not in result.output
         assert "✗ COPILOT_PROVIDER_API_KEY" not in result.output
         # The auth-path note explains why an all-absent cell is expected.
-        assert "optional" in result.output
+        assert "CLI login; env vars optional" in result.output
 
     def test_required_absent_credentials_still_render_cross(
         self, monkeypatch: pytest.MonkeyPatch
@@ -244,6 +264,22 @@ class TestDoctorJson:
         data = json.loads(result.stdout)
         assert data["env"]["conductor_version"] == "1.2.3"
         assert data["providers"][0]["name"] == "copilot"
+
+    def test_json_includes_credentials_optional(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # credentials_optional must survive the full report -> to_dict ->
+        # print_json round trip, not just direct-construct unit tests.
+        report = DoctorReport(
+            providers=[
+                _prov("copilot", credentials_optional=True),
+                _prov("claude", credentials_optional=False),
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        by_name = {p["name"]: p["credentials_optional"] for p in data["providers"]}
+        assert by_name == {"copilot": True, "claude": False}
 
     def test_json_never_leaks_secret_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
         report = DoctorReport(

--- a/tests/test_providers/test_diagnostics.py
+++ b/tests/test_providers/test_diagnostics.py
@@ -178,6 +178,33 @@ class TestGatherProviderOffline:
         by_name = {c.name: c.present for c in diag.credential_env_vars}
         assert by_name["COPILOT_PROVIDER_RUNTIME_TOKEN"] is True
 
+    async def test_copilot_credentials_optional_with_note(self) -> None:
+        # copilot authenticates via the GitHub/Copilot CLI login on disk, so
+        # its env vars are optional overrides — flagged for a neutral render
+        # plus an explanatory note (issue #319).
+        diag = await d.gather_provider("copilot")
+        assert diag.credentials_optional is True
+        assert diag.note is not None
+        assert "optional" in diag.note.lower()
+
+    async def test_claude_agent_sdk_credentials_optional_with_note(self) -> None:
+        # claude-agent-sdk delegates to the `claude` CLI, which authenticates
+        # via `claude login`, so ANTHROPIC_API_KEY is likewise optional.
+        diag = await d.gather_provider("claude-agent-sdk")
+        assert diag.credentials_optional is True
+        assert diag.note is not None
+        assert "optional" in diag.note.lower()
+
+    async def test_claude_credentials_required_no_note(self) -> None:
+        # The direct Anthropic API has no on-disk login — its key is required.
+        diag = await d.gather_provider("claude")
+        assert diag.credentials_optional is False
+        assert diag.note is None
+
+    async def test_credentials_optional_serialized_in_to_dict(self) -> None:
+        diag = await d.gather_provider("copilot")
+        assert diag.to_dict()["credentials_optional"] is True
+
     async def test_credential_values_never_stored(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-super-secret")
         diag = await d.gather_provider("claude")

--- a/tests/test_providers/test_diagnostics.py
+++ b/tests/test_providers/test_diagnostics.py
@@ -205,6 +205,23 @@ class TestGatherProviderOffline:
         diag = await d.gather_provider("copilot")
         assert diag.to_dict()["credentials_optional"] is True
 
+    async def test_required_credentials_optional_false_in_to_dict(self) -> None:
+        # Symmetric check: a required provider's dataclass default must also
+        # come through the JSON boundary, not just the optional-True case.
+        diag = await d.gather_provider("claude")
+        assert diag.to_dict()["credentials_optional"] is False
+
+    async def test_unregistered_provider_name_never_raises(self) -> None:
+        # Defends the null-object fallback (`_CREDENTIAL_SPECS.get(name,
+        # _CredentialSpec())`) for a name present in known_provider_names()
+        # but not yet given a _CREDENTIAL_SPECS entry — a realistic
+        # future-onboarding mistake this fallback specifically guards
+        # against (diagnostics.py never raises).
+        diag = await d.gather_provider("not-a-real-provider")
+        assert diag.credential_env_vars == []
+        assert diag.credentials_optional is False
+        assert diag.note is None
+
     async def test_credential_values_never_stored(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-super-secret")
         diag = await d.gather_provider("claude")


### PR DESCRIPTION
Fixes #319.

## Problem

The default (offline) `conductor doctor` output made the **copilot** provider look unconfigured/not-ready even when fully authenticated. Every credential env var rendered as a red ✗ with an empty Notes column, so new users reasonably read it as "copilot is broken." In reality copilot authenticates via the **GitHub/Copilot CLI login on disk**, so those env vars are optional overrides — a fact documented only in a code comment that never reached the rendered report.

## Fix

Combines options (1) and (2) from the issue — the principled version:

1. **Model credential optionality per provider.** New `_CredentialSpec` (`env_vars` / `optional` / `note`) replaces the bare env-var tuple map in `diagnostics.py`. `ProviderDiagnostic` gains a `credentials_optional` field (serialized in `--json`).
2. **Render optional creds neutrally.** In `doctor.py`, an absent credential for an optional-auth provider renders as a neutral dim `○` (not red `✗`), and the provider's auth-path note surfaces in the **Notes** column. Present creds still show `✓`; genuinely **required** creds (claude / direct Anthropic API) keep the `✗` so real misconfigurations stay visible.

`claude-agent-sdk` gets the same treatment for parity — it delegates to the `claude` CLI (`claude login`), so its `ANTHROPIC_API_KEY` is likewise an optional override.

## Before / After (no credential env vars set)

**Before** — every copilot row is red ✗, Notes empty (looks broken):

```
│ copilot │ ✓ │ stable │ ✗ GITHUB_TOKEN ...              │ — │
```

**After** — neutral ○ + explanatory note:

```
│ copilot │ ✓ │ stable │ ○ GITHUB_TOKEN ...              │ authenticates via GitHub/Copilot CLI login; env vars are optional overrides │
│ claude  │ ✓ │ stable │ ✗ ANTHROPIC_API_KEY ...         │ —                                                                           │
```

## Changes

- `src/conductor/providers/diagnostics.py` — `_CredentialSpec`, `_CREDENTIAL_SPECS`, `ProviderDiagnostic.credentials_optional` (+ JSON key), auth notes
- `src/conductor/cli/doctor.py` — neutral `○` marker for absent optional credentials
- `docs/cli-reference.md` — document optional vs required credentials and the `--check` readiness hint
- tests — diagnostics optionality/note + JSON key; render `○` vs `✗`

## Verification

- `make format` / `make lint` — clean
- `make typecheck` — clean (1 pre-existing unrelated `dialog_evaluator.py` warning)
- `tests/test_cli/` + `tests/test_providers/test_diagnostics.py` — **511 passed, 3 skipped**
- Eyeballed live `conductor doctor providers` with all credential env vars unset

## Note / secret safety

Unchanged: only credential env-var **presence** is ever reported — values are never read or printed.