### PR TITLE
fix(web): arm --web-bg grace timer on root workflow completion (#318)

### DIFF
--- a/src/conductor/web/server.py
+++ b/src/conductor/web/server.py
@@ -473,8 +473,20 @@ class WebDashboard:
         self._event_history.append(event_dict)
         self._queue.put_nowait(event_dict)
 
-        if event.type in ("workflow_completed", "workflow_failed"):
+        # Arm the --web-bg auto-shutdown grace timer when the *root* workflow
+        # reaches a terminal event. Gating on the root event (sub-workflow
+        # terminal events carry a non-empty ``data.subworkflow_path``) avoids a
+        # premature shutdown while the root run is still executing. Arming here —
+        # not only from the WebSocket-disconnect paths — ensures an unwatched run
+        # (zero clients ever connected) still shuts down instead of blocking
+        # forever in ``wait_for_clients_disconnect()`` (issue #318).
+        # ``_maybe_start_grace_timer`` no-ops while clients are connected and
+        # when there is no running event loop (synchronous ``emit()`` in tests).
+        if event.type in ("workflow_completed", "workflow_failed") and self._is_root_event(
+            event_dict
+        ):
             self._workflow_completed = True
+            self._maybe_start_grace_timer()
 
     # ------------------------------------------------------------------
     # Replay support (used by ``resume_workflow_async``)
@@ -1010,7 +1022,12 @@ class WebDashboard:
     # ------------------------------------------------------------------
 
     def _maybe_start_grace_timer(self) -> None:
-        """Start the grace timer if conditions are met for auto-shutdown."""
+        """Start the grace timer if conditions are met for auto-shutdown.
+
+        Safe to call from any context: if there is no running event loop
+        (e.g. a synchronous ``emit()`` in a unit test with no server), this
+        no-ops rather than creating an orphan coroutine. See issue #318.
+        """
         if not self._bg:
             return
         if not self._workflow_completed:
@@ -1018,6 +1035,12 @@ class WebDashboard:
         if self._connections:
             return
         if self._grace_task is not None:
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running event loop — there is no server loop to shut down,
+            # so there is nothing to arm (and ``create_task`` would raise).
             return
         self._grace_task = asyncio.create_task(self._grace_countdown())
 

--- a/src/conductor/web/server.py
+++ b/src/conductor/web/server.py
@@ -473,18 +473,13 @@ class WebDashboard:
         self._event_history.append(event_dict)
         self._queue.put_nowait(event_dict)
 
-        # Arm the --web-bg auto-shutdown grace timer when the *root* workflow
-        # reaches a terminal event. Gating on the root event (sub-workflow
-        # terminal events carry a non-empty ``data.subworkflow_path``) avoids a
-        # premature shutdown while the root run is still executing. Arming here —
-        # not only from the WebSocket-disconnect paths — ensures an unwatched run
-        # (zero clients ever connected) still shuts down instead of blocking
-        # forever in ``wait_for_clients_disconnect()`` (issue #318).
-        # ``_maybe_start_grace_timer`` no-ops while clients are connected and
-        # when there is no running event loop (synchronous ``emit()`` in tests).
-        if event.type in ("workflow_completed", "workflow_failed") and self._is_root_event(
-            event_dict
-        ):
+        # Also arm the grace timer here (not only from the WebSocket-disconnect
+        # paths) so an unwatched run — zero clients ever connected — still
+        # shuts down instead of blocking forever in
+        # ``wait_for_clients_disconnect()`` (issue #318). See ``_is_root_event``
+        # and ``_maybe_start_grace_timer`` for the gating/no-op details.
+        is_terminal_event = event.type in ("workflow_completed", "workflow_failed")
+        if is_terminal_event and self._is_root_event(event_dict):
             self._workflow_completed = True
             self._maybe_start_grace_timer()
 
@@ -1039,8 +1034,12 @@ class WebDashboard:
         try:
             asyncio.get_running_loop()
         except RuntimeError:
-            # No running event loop — there is no server loop to shut down,
-            # so there is nothing to arm (and ``create_task`` would raise).
+            # No running loop to shut down; create_task() would raise. Log so
+            # an unexpected occurrence outside tests (which would silently
+            # reproduce the #318 hang) leaves a trace.
+            logger.debug(
+                "_maybe_start_grace_timer: no running event loop; skipping grace-timer arm"
+            )
             return
         self._grace_task = asyncio.create_task(self._grace_countdown())
 

--- a/tests/test_web/test_server.py
+++ b/tests/test_web/test_server.py
@@ -11,6 +11,7 @@ Tests cover:
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 import time
 import traceback
@@ -192,18 +193,38 @@ class TestLateJoiner:
 class TestAutoShutdown:
     """Tests for --web-bg auto-shutdown logic."""
 
-    def test_workflow_completed_sets_flag(self) -> None:
-        """Emitting workflow_completed sets the internal flag."""
+    def test_workflow_completed_sets_flag(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Emitting workflow_completed sets the internal flag.
+
+        Also asserts the grace timer stays unarmed *without* an exception
+        being swallowed by ``WorkflowEventEmitter.emit()``'s subscriber
+        catch-all: this synchronous ``emit()`` runs with no running event
+        loop, exercising the loop-safety guard in ``_maybe_start_grace_timer``
+        (issue #318). A bare ``_grace_task is None`` assertion alone can't
+        tell a guarded no-op apart from an unguarded ``RuntimeError`` from
+        ``asyncio.create_task()`` getting silently caught and logged by
+        ``emit()`` — so this also asserts nothing was logged there.
+        """
         emitter, dashboard = _make_dashboard(bg=True)
         assert dashboard._workflow_completed is False
-        emitter.emit(_make_event("workflow_completed", elapsed=5.0))
+        with caplog.at_level(logging.ERROR, logger="conductor.events"):
+            emitter.emit(_make_event("workflow_completed", elapsed=5.0))
         assert dashboard._workflow_completed is True
+        assert dashboard._grace_task is None
+        assert "Event subscriber raised an exception" not in caplog.text
 
-    def test_workflow_failed_sets_flag(self) -> None:
-        """Emitting workflow_failed sets the internal flag."""
+    def test_workflow_failed_sets_flag(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Emitting workflow_failed sets the internal flag.
+
+        Also asserts the grace timer stays unarmed with no swallowed exception
+        (see ``test_workflow_completed_sets_flag`` for why this matters).
+        """
         emitter, dashboard = _make_dashboard(bg=True)
-        emitter.emit(_make_event("workflow_failed", error_type="Error", message="boom"))
+        with caplog.at_level(logging.ERROR, logger="conductor.events"):
+            emitter.emit(_make_event("workflow_failed", error_type="Error", message="boom"))
         assert dashboard._workflow_completed is True
+        assert dashboard._grace_task is None
+        assert "Event subscriber raised an exception" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_wait_for_clients_disconnect_resolves(self) -> None:
@@ -324,6 +345,51 @@ class TestAutoShutdown:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
+
+    @pytest.mark.asyncio
+    async def test_unwatched_run_arms_grace_timer_on_failure(self) -> None:
+        """Root workflow_failed also arms the grace timer when unwatched.
+
+        Regression for issue #318: the arming call in ``_on_event`` covers both
+        terminal event types via one shared ``if``, but nothing previously
+        verified ``workflow_failed`` specifically — a future change that split
+        the conditional and only wired arming for ``workflow_completed`` would
+        otherwise go undetected.
+        """
+        emitter, dashboard = _make_dashboard(bg=True)
+        assert dashboard._grace_task is None
+
+        emitter.emit(_make_event("workflow_failed", error_type="Error", message="boom"))
+
+        assert dashboard._workflow_completed is True
+        assert dashboard._grace_task is not None
+
+        dashboard._grace_task.cancel()
+        dashboard._grace_task = asyncio.create_task(_short_grace(dashboard._bg_event, 0.05))
+        await asyncio.wait_for(dashboard.wait_for_clients_disconnect(), timeout=1.0)
+        assert dashboard._bg_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_connected_client_keeps_grace_timer_unarmed_on_completion(self) -> None:
+        """Root completion while a client is connected must not arm the timer.
+
+        Regression guard for issue #318: ``_on_event`` now calls
+        ``_maybe_start_grace_timer()`` unconditionally on the root terminal
+        event, relying entirely on the pre-existing ``if self._connections:
+        return`` guard to avoid cutting a *watched* run's post-run dashboard
+        window short. Nothing previously combined a connected client with a
+        completion event to prove that guard is actually exercised from this
+        new call site. This must run with a live event loop (``async def``)
+        so the connections check — not the loop-safety no-op — is what's
+        actually under test.
+        """
+        emitter, dashboard = _make_dashboard(bg=True)
+        dashboard._connections.add(MagicMock())
+
+        emitter.emit(_make_event("workflow_completed", elapsed=1.0))
+
+        assert dashboard._workflow_completed is True
+        assert dashboard._grace_task is None
 
 
 class TestBroadcastErrorIsolation:

--- a/tests/test_web/test_server.py
+++ b/tests/test_web/test_server.py
@@ -272,6 +272,59 @@ class TestAutoShutdown:
             with pytest.raises(asyncio.CancelledError):
                 await first
 
+    @pytest.mark.asyncio
+    async def test_unwatched_run_arms_grace_timer_on_completion(self) -> None:
+        """Root completion arms the grace timer even if no client ever connected.
+
+        Regression for issue #318: previously the grace timer was armed only from
+        WebSocket-disconnect paths, so an unwatched ``--web-bg`` run (nobody opens
+        the dashboard) blocked forever in ``wait_for_clients_disconnect()`` after
+        the workflow had already finished.
+        """
+        emitter, dashboard = _make_dashboard(bg=True)
+        assert dashboard._grace_task is None
+        assert not dashboard._connections
+
+        # No client ever connects; the root workflow simply finishes.
+        emitter.emit(_make_event("workflow_completed", elapsed=1.0))
+
+        assert dashboard._workflow_completed is True
+        assert dashboard._grace_task is not None  # armed without any disconnect
+
+        # Swap in a short grace so the post-run wait actually resolves.
+        dashboard._grace_task.cancel()
+        dashboard._grace_task = asyncio.create_task(_short_grace(dashboard._bg_event, 0.05))
+        await asyncio.wait_for(dashboard.wait_for_clients_disconnect(), timeout=1.0)
+        assert dashboard._bg_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_subworkflow_completion_does_not_arm_or_set_flag(self) -> None:
+        """Nested sub-workflow terminal events must not arm the timer or set the flag.
+
+        Regression for issue #318: the completion check is gated on the *root*
+        event (sub-workflow events carry a non-empty ``subworkflow_path``) so a
+        sub-workflow finishing mid-run cannot trigger a premature auto-shutdown.
+        """
+        emitter, dashboard = _make_dashboard(bg=True)
+
+        # A nested sub-workflow finishes while the root run is still executing.
+        emitter.emit(
+            _make_event("workflow_completed", subworkflow_path=["parent", "child"], elapsed=1.0)
+        )
+        assert dashboard._workflow_completed is False
+        assert dashboard._grace_task is None
+
+        # The root terminal event still arms the timer.
+        emitter.emit(_make_event("workflow_completed", elapsed=1.0))
+        assert dashboard._workflow_completed is True
+        assert dashboard._grace_task is not None
+
+        # Clean up the armed grace task.
+        task = dashboard._grace_task
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
 
 class TestBroadcastErrorIsolation:
     """Tests that broadcast errors don't crash the broadcaster."""


### PR DESCRIPTION
## Summary

Fixes #318.

In `--web-bg` mode (or `CONDUCTOR_WEB_BG=1`), the detached process is supposed to auto-shutdown after **workflow completes + all clients disconnect + 30s grace**. But the grace timer was only ever armed from **WebSocket-disconnect code paths**:

- the `/ws` endpoint's `finally` block on client disconnect, and
- the broadcaster's failed-send cleanup.

`_on_event` only set `self._workflow_completed = True` on a terminal event — it never armed the timer. So if **no dashboard client ever connected**, no disconnect fired, the timer was never started, `_bg_event` was never set, and `wait_for_clients_disconnect()` blocked forever after the workflow had already finished. The detached child became a zombie holding its port and PID file — making `--web-bg` unusable for headless/programmatic supervision.

## Fix

- **`_on_event`** now arms the grace timer on the workflow's **root** terminal event, gated on the existing `_is_root_event(event_dict)` helper. `_maybe_start_grace_timer()` already no-ops while clients are connected, so watched runs keep their current behavior (timer only arms once the last client disconnects).
- Gating on the **root** event also fixes a coupled latent bug: previously `_workflow_completed` was set on *any* terminal event, including nested **sub-workflow** ones (which carry `data.subworkflow_path`). Un-gated, arming from `_on_event` would let a sub-workflow finishing mid-run trigger a premature shutdown.
- **`_maybe_start_grace_timer`** is now loop-safe: it no-ops when there's no running event loop (a synchronous `emit()` in a unit test with no server) instead of leaking an orphan `_grace_countdown` coroutine.

## Tests

Added to `tests/test_web/test_server.py` (`TestAutoShutdown`):

- `test_unwatched_run_arms_grace_timer_on_completion` — root completion arms the timer with zero clients ever connected, and the post-run wait resolves.
- `test_subworkflow_completion_does_not_arm_or_set_flag` — a nested sub-workflow terminal event neither sets the flag nor arms the timer; the root event still does.

Both tests **fail on the pre-fix code** (verified by reverting), so they're non-tautological.

## Verification

- ✅ 133 passed (`tests/test_web` + `tests/test_cli/test_web_flags.py`)
- ✅ `make lint` clean
- ✅ `make typecheck` clean (the one remaining diagnostic is pre-existing in `engine/dialog_evaluator.py`, unrelated)

No CHANGELOG / docs / frontend changes needed.