### PR TITLE
fix(engine,cli): resolve human gates from dashboard in --web-bg

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -130,18 +130,20 @@ The `--web-bg` flag is a convenience shortcut: it forks a background process run
 
 `--web` and `--web-bg` are mutually exclusive.
 
-**`--web-bg` and `human_gate`** — `--web-bg` is incompatible with workflows
-that contain `human_gate` agents (unless `--skip-gates` is also passed),
-because the detached background process has no stdin to prompt on and the
-child would crash with `EOFError` mid-run. Conductor detects this at
-load time and aborts before forking, with a message listing the options:
+**`--web-bg` and `human_gate`** — background runs support human gates through
+the dashboard. When the workflow reaches a `human_gate`, the detached process
+waits for a response from the web dashboard (the gate modal) or the
+`conductor gate-respond` CLI, rather than trying to prompt on the (absent)
+stdin. At launch, when the workflow contains a `human_gate` (and `--skip-gates`
+is not set), Conductor prints a notice with the dashboard URL and the
+`conductor gate-respond` command so a parked run doesn't look stuck:
 
-1. Use `--web` (foreground) instead of `--web-bg`
-2. Add `--skip-gates` to auto-select the first option at every gate
-3. Remove `human_gate` steps from the workflow
-4. Use `conductor gate-respond --port <port> --choice <value>` to resolve from CLI
+- Resolve each gate from the dashboard's decision modal, or
+- Run `conductor gate-respond --port <port> --choice <value>` (optionally
+  `--agent <name>` and `--input "<text>"`), or
+- Pass `--skip-gates` to auto-select the first option at every gate.
 
-The same check applies to `conductor resume --web-bg`.
+The same behavior applies to `conductor resume --web-bg`.
 
 Background workflows can be stopped with `conductor stop` (see below) or via the stop button in the web dashboard.
 

--- a/plugins/conductor/skills/conductor/references/execution.md
+++ b/plugins/conductor/skills/conductor/references/execution.md
@@ -511,6 +511,17 @@ conductor run workflow.yaml --skip-gates
 
 Auto-selects the first option at each gate.
 
+### Resolving Gates in the Dashboard
+
+With `--web` or `--web-bg`, gates are also resolvable from the browser
+dashboard's decision modal or the `conductor gate-respond` CLI — no terminal
+prompt required. This makes `--web-bg` (detached background) fully compatible
+with `human_gate` workflows: the launch prints the dashboard URL plus a
+`conductor gate-respond --port <port> --choice <value>` hint, and the run waits
+for a web/CLI response instead of aborting. Foreground `--web` from a real
+terminal still accepts either the terminal prompt or the dashboard, whichever
+responds first.
+
 ## Interactive Interrupt
 
 During execution, press **Esc** or **Ctrl+G** to pause the workflow. An interactive menu appears with these actions:

--- a/plugins/conductor/skills/conductor/references/execution.md
+++ b/plugins/conductor/skills/conductor/references/execution.md
@@ -515,12 +515,14 @@ Auto-selects the first option at each gate.
 
 With `--web` or `--web-bg`, gates are also resolvable from the browser
 dashboard's decision modal or the `conductor gate-respond` CLI — no terminal
-prompt required. This makes `--web-bg` (detached background) fully compatible
-with `human_gate` workflows: the launch prints the dashboard URL plus a
-`conductor gate-respond --port <port> --choice <value>` hint, and the run waits
-for a web/CLI response instead of aborting. Foreground `--web` from a real
-terminal still accepts either the terminal prompt or the dashboard, whichever
-responds first.
+prompt required. This makes `--web-bg` (detached background) compatible with
+`human_gate` workflows whenever the dashboard starts successfully: the launch
+prints the dashboard URL plus a `conductor gate-respond --port <port> --choice
+<value>` hint, and the run waits for a web/CLI response instead of aborting.
+If the dashboard itself fails to start (e.g. a port conflict), a gate reached
+in background mode raises a clear error rather than silently hanging or
+crashing. Foreground `--web` from a real terminal still accepts either the
+terminal prompt or the dashboard, whichever responds first.
 
 ## Interactive Interrupt
 

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -156,46 +156,44 @@ def print_error(error: Exception) -> None:
         console.print(panel)
 
 
-def _abort_web_bg_if_human_gate(workflow_path: Path, *, skip_gates: bool) -> None:
-    """Reject ``--web-bg`` when the workflow has a ``human_gate`` agent.
+def _workflow_has_human_gate(workflow_path: Path) -> bool:
+    """Return True if the workflow defines any ``human_gate`` agent.
 
-    Without this check, ``--web-bg`` forks a detached child whose stdin is
-    redirected to ``DEVNULL``; ``Prompt.ask`` then raises ``EOFError`` and
-    the parent only reports ``"Background process exited immediately"``,
-    which never mentions ``human_gate`` or ``--skip-gates``. Failing fast
-    in the parent process produces a single visible error on the user's
-    terminal. ``--skip-gates`` is a documented escape hatch and is honored.
+    Used to decide whether to print the ``--web-bg`` gate-resolution notice
+    after forking the background child (issue #286). Config-load failures
+    return ``False`` so the normal run path surfaces the real error instead
+    of this best-effort probe.
     """
-    if skip_gates:
-        return
     try:
         from conductor.config.loader import load_config
 
         config = load_config(workflow_path)
     except Exception:  # noqa: BLE001 — defer real validation to the loader path
-        # If config fails to load, let the normal run path surface the error.
-        return
-    has_gate = any(getattr(a, "type", None) == "human_gate" for a in config.agents) or any(
+        return False
+    return any(getattr(a, "type", None) == "human_gate" for a in config.agents) or any(
         getattr(getattr(fe, "agent", None), "type", None) == "human_gate" for fe in config.for_each
     )
-    if not has_gate:
-        return
-    # Emit via plain typer.echo (not typer.BadParameter) so the message renders
-    # verbatim — BadParameter is rendered as a Rich panel whose text wrapping
-    # can split long flag names like ``--skip-gates`` across border lines in
-    # narrow terminals (e.g. CI runners), hiding the remediation hint.
-    message = (
-        "Error: --web-bg is incompatible with workflows that contain human_gate "
-        "steps because the detached process has no stdin to prompt on.\n"
-        "\n"
-        "Options:\n"
-        "  1. Use --web (foreground) instead of --web-bg\n"
-        "  2. Add --skip-gates to auto-accept the first option\n"
-        "  3. Remove human_gate steps from the workflow\n"
-        "  4. Use `conductor gate-respond --port <port> --choice <value>` to resolve from CLI"
+
+
+def _print_web_bg_human_gate_notice(url: str) -> None:
+    """Tell the user how to resolve human gates in a ``--web-bg`` run.
+
+    Background human gates used to abort the launch (the detached child has
+    no stdin to prompt on). They are now resolvable from the dashboard or the
+    ``conductor gate-respond`` CLI (issue #286), so instead of blocking we
+    point at both so a parked run doesn't look stuck. Printed only in verbose
+    mode — ``--silent`` suppresses all bg output, including the dashboard URL
+    on the line above this notice.
+    """
+    from urllib.parse import urlparse
+
+    port = urlparse(url).port
+    port_hint = str(port) if port is not None else "<port>"
+    console.print(
+        "[yellow]This workflow contains human_gate steps.[/yellow] Resolve them from "
+        "the dashboard above, or run "
+        f"[bold]conductor gate-respond --port {port_hint} --choice <value>[/bold]."
     )
-    typer.echo(message, err=True)
-    raise typer.Exit(code=2)
 
 
 def version_callback(value: bool) -> None:
@@ -477,7 +475,10 @@ def run(
 
     # Handle --web-bg: fork a background process and exit immediately
     if web_bg:
-        _abort_web_bg_if_human_gate(workflow_path, skip_gates=skip_gates)
+        # Background human gates are now resolvable from the dashboard /
+        # ``conductor gate-respond`` (issue #286), so we no longer abort the
+        # launch — we just note how to resolve them once the URL is known.
+        notify_gate = not skip_gates and _workflow_has_human_gate(workflow_path)
         from conductor.cli.bg_runner import launch_background
 
         try:
@@ -501,6 +502,8 @@ def run(
                     "[dim]Workflow running in background. Dashboard auto-shuts down after "
                     "workflow completes and all clients disconnect.[/dim]"
                 )
+                if notify_gate:
+                    _print_web_bg_human_gate_notice(launch.url)
         except Exception as e:
             print_error(e)
             raise typer.Exit(code=1) from None
@@ -917,9 +920,8 @@ def resume(
     if web_bg:
         # When the user resumes via --from <checkpoint> alone (no workflow
         # argument), resolved_workflow is None but the checkpoint records the
-        # original workflow path. Read it so the human_gate guard still fires
-        # and the user gets a single visible error instead of a silent crash
-        # in the detached child.
+        # original workflow path. Read it so the human_gate notice can still
+        # fire for the detached child (issue #286).
         gate_check_workflow: Path | None = resolved_workflow
         if gate_check_workflow is None and resolved_checkpoint is not None:
             try:
@@ -932,8 +934,13 @@ def resume(
             except (OSError, json.JSONDecodeError):
                 # Checkpoint unreadable — let the normal resume path surface it.
                 pass
-        if gate_check_workflow is not None:
-            _abort_web_bg_if_human_gate(gate_check_workflow, skip_gates=skip_gates)
+        # Background human gates are now resolvable from the dashboard /
+        # ``conductor gate-respond`` (issue #286); note how instead of aborting.
+        notify_gate = (
+            not skip_gates
+            and gate_check_workflow is not None
+            and _workflow_has_human_gate(gate_check_workflow)
+        )
         from conductor.cli.bg_runner import launch_background_resume
 
         try:
@@ -953,6 +960,8 @@ def resume(
                     "[dim]Resumed workflow running in background. Dashboard auto-shuts down "
                     "after workflow completes and all clients disconnect.[/dim]"
                 )
+                if notify_gate:
+                    _print_web_bg_human_gate_notice(launch.url)
         except Exception as e:
             print_error(e)
             raise typer.Exit(code=1) from None

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -169,6 +169,7 @@ def _workflow_has_human_gate(workflow_path: Path) -> bool:
 
         config = load_config(workflow_path)
     except Exception:  # noqa: BLE001 — defer real validation to the loader path
+        logger.debug("Best-effort human_gate probe failed to load %s", workflow_path, exc_info=True)
         return False
     return any(getattr(a, "type", None) == "human_gate" for a in config.agents) or any(
         getattr(getattr(fe, "agent", None), "type", None) == "human_gate" for fe in config.for_each
@@ -187,6 +188,11 @@ def _print_web_bg_human_gate_notice(url: str) -> None:
     """
     from urllib.parse import urlparse
 
+    # ``url`` is always a live, bound ``http://127.0.0.1:<port>`` by the time
+    # this runs — ``_finalize_background_launch`` in bg_runner.py confirms the
+    # child is listening on that exact port before returning it — so ``.port``
+    # is always a valid 1-65535 int and this can't raise. Fall back to a
+    # placeholder anyway in case that invariant is ever relaxed.
     port = urlparse(url).port
     port_hint = str(port) if port is not None else "<port>"
     console.print(
@@ -935,7 +941,8 @@ def resume(
                 # Checkpoint unreadable — let the normal resume path surface it.
                 pass
         # Background human gates are now resolvable from the dashboard /
-        # ``conductor gate-respond`` (issue #286); note how instead of aborting.
+        # ``conductor gate-respond`` (issue #286); compute the notice flag
+        # here instead of aborting.
         notify_gate = (
             not skip_gates
             and gate_check_workflow is not None

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -2243,12 +2243,23 @@ class WorkflowEngine:
         agent: AgentDef,
         agent_context: dict[str, Any],
     ) -> GateResult:
-        """Handle a human gate, racing CLI input against web dashboard input.
+        """Handle a human gate, choosing CLI / web / race per environment.
 
-        When a web dashboard is connected, both the CLI prompt and the web
-        dashboard wait concurrently.  The first response wins and the other
-        is cancelled.  When no web dashboard is available, falls back to
-        CLI-only input.
+        Resolution policy (issue #286, extending the #198/#202 max-iterations
+        gate fix in ``_resolve_max_iterations_gate``):
+
+        - No web dashboard attached: existing CLI-only prompt path.
+        - Web dashboard + (bg mode or non-TTY stdin): **web-only** wait. The
+          CLI prompt is deliberately NOT invoked because ``Prompt.ask`` would
+          synchronously raise ``EOFError`` (stdin=DEVNULL in ``--web-bg``),
+          race-win ``FIRST_COMPLETED``, cancel the web arm, and crash the
+          workflow — the original ``--web-bg`` + ``human_gate`` bug. A parked
+          web-only gate is ended by the outer ``_execute_with_stop_signal``
+          kill path (which cancels this await and checkpoints via
+          ``handle_dashboard_stop``, issue #245), so no inner
+          ``wait_for_stop()`` race is needed here.
+        - Web dashboard + TTY foreground (``--web`` from a real terminal):
+          race the CLI prompt against the web response; first wins.
 
         Args:
             agent: The human_gate agent definition.
@@ -2262,6 +2273,13 @@ class WorkflowEngine:
             return await self.gate_handler.handle_gate(
                 agent, agent_context, base_dir=self._workflow_dir
             )
+
+        # Web dashboard + bg or non-TTY → web-only wait (skip the CLI arm; it
+        # would EOFError-and-crash on a DEVNULL stdin, cancelling the web arm
+        # before a dashboard user could respond).
+        cli_usable = not self._bg_mode and sys.stdin.isatty()
+        if not cli_usable:
+            return await self._wait_for_web_gate(agent)
 
         # Race CLI vs web input. We start the web task unconditionally (not only
         # when a client is currently connected), because the human often opens

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -2248,18 +2248,26 @@ class WorkflowEngine:
         Resolution policy (issue #286, extending the #198/#202 max-iterations
         gate fix in ``_resolve_max_iterations_gate``):
 
-        - No web dashboard attached: existing CLI-only prompt path.
-        - Web dashboard + (bg mode or non-TTY stdin): **web-only** wait. The
-          CLI prompt is deliberately NOT invoked because ``Prompt.ask`` would
-          synchronously raise ``EOFError`` (stdin=DEVNULL in ``--web-bg``),
-          race-win ``FIRST_COMPLETED``, cancel the web arm, and crash the
-          workflow — the original ``--web-bg`` + ``human_gate`` bug. A parked
-          web-only gate is ended by the outer ``_execute_with_stop_signal``
-          kill path (which cancels this await and checkpoints via
+        - No web dashboard + not bg mode: existing CLI-only prompt path,
+          unchanged. This covers plain foreground runs and non-TTY stdin
+          without a dashboard (e.g. piped input, tests) — a pre-existing,
+          already-safe combination that must not be newly restricted here.
+        - No web dashboard + bg mode (the dashboard failed to start in a
+          ``--web-bg`` child): neither input source can be used safely — the
+          CLI prompt would still hit the ``EOFError`` crash below. Raise
+          ``HumanGateError`` instead of falling through to it.
+        - Web dashboard attached + CLI usable (foreground TTY, not bg mode):
+          race the CLI prompt against the web response; first wins.
+        - Web dashboard attached + CLI NOT usable (bg mode or non-TTY
+          stdin): **web-only** wait. The CLI prompt is deliberately NOT
+          invoked because ``Prompt.ask`` would synchronously raise
+          ``EOFError`` (stdin=DEVNULL in ``--web-bg``), race-win
+          ``FIRST_COMPLETED``, cancel the web arm, and crash the workflow —
+          the original ``--web-bg`` + ``human_gate`` bug. A parked web-only
+          gate is ended by the outer ``_execute_with_stop_signal`` kill path
+          (which cancels this await and checkpoints via
           ``handle_dashboard_stop``, issue #245), so no inner
           ``wait_for_stop()`` race is needed here.
-        - Web dashboard + TTY foreground (``--web`` from a real terminal):
-          race the CLI prompt against the web response; first wins.
 
         Args:
             agent: The human_gate agent definition.
@@ -2267,9 +2275,26 @@ class WorkflowEngine:
 
         Returns:
             GateResult from whichever input source responded first.
+
+        Raises:
+            HumanGateError: If bg mode is active and no web dashboard is
+                attached (the dashboard failed to start in ``--web-bg``).
         """
-        # If no web dashboard at all, use CLI only.
         if self._web_dashboard is None:
+            if self._bg_mode:
+                from conductor.exceptions import HumanGateError
+
+                raise HumanGateError(
+                    f"Cannot resolve human_gate '{agent.name}': no web dashboard is "
+                    "available and stdin cannot be prompted in background mode.",
+                    suggestion=(
+                        "Restart with --web in the foreground, or resolve the gate "
+                        "with `conductor gate-respond` once the dashboard is reachable."
+                    ),
+                    gate_name=agent.name,
+                )
+            # Not bg mode: use CLI only (foreground, or non-TTY without a
+            # dashboard — e.g. piped stdin, tests).
             return await self.gate_handler.handle_gate(
                 agent, agent_context, base_dir=self._workflow_dir
             )

--- a/tests/test_cli/test_web_flags.py
+++ b/tests/test_cli/test_web_flags.py
@@ -323,82 +323,99 @@ def gate_workflow_file(tmp_path: Path) -> Path:
     return f
 
 
-class TestWebBgHumanGateValidation:
-    """``--web-bg`` must abort pre-fork when the workflow has a ``human_gate``.
+def _fake_bg_launch(url: str = "http://127.0.0.1:9999") -> object:
+    """Build a ``BackgroundLaunch`` stand-in for a mocked ``--web-bg`` fork."""
+    from conductor.cli.bg_runner import BackgroundLaunch
 
-    Without this check, ``--web-bg`` forks a detached child whose stdin is
-    redirected to ``DEVNULL``; ``Prompt.ask`` then raises ``EOFError`` and
-    the parent only sees ``"Background process exited immediately"``, with
-    no mention of ``human_gate`` or ``--skip-gates``. See
-    ``docs/projects/usability-features/external-workflow-friction.plan.md``
-    §4.4.
+    return BackgroundLaunch(
+        url=url,
+        stderr_log=Path("/tmp/conductor-test-deadbeef.bg.stderr.log"),
+        stdout_log=Path("/tmp/conductor-test-deadbeef.bg.stdout.log"),
+        run_id="deadbeef",
+    )
+
+
+# Pin a wide console so the Rich-rendered gate notice never wraps mid-token on
+# CI's narrow non-TTY width (see repo memory on width-sensitive CLI tests).
+_WIDE = {"COLUMNS": "200"}
+
+
+class TestWebBgHumanGateNotice:
+    """``--web-bg`` + ``human_gate`` now forks and points at gate resolution.
+
+    Background human gates are resolvable from the dashboard modal or the
+    ``conductor gate-respond`` CLI (issue #286), so ``--web-bg`` no longer
+    aborts pre-fork. Instead the launch proceeds and prints a notice naming
+    the dashboard URL / port and ``conductor gate-respond``. ``--skip-gates``
+    still auto-selects the first option, so no notice is shown in that mode.
     """
 
-    def test_run_web_bg_with_human_gate_aborts_before_fork(self, gate_workflow_file: Path) -> None:
-        """``run --web-bg`` + ``human_gate`` (no ``--skip-gates``) → no fork."""
-        with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
-            result = runner.invoke(app, ["run", str(gate_workflow_file), "--web-bg"])
-
-        assert result.exit_code != 0
-        assert not mock_launch.called
-        # The error must name the actual problem and at least one remedy.
-        # Include stderr because Click 8.3+ separates streams and the abort
-        # message is intentionally emitted to stderr.
-        combined = (
-            (result.output or "")
-            + (result.stderr or "")
-            + (str(result.exception) if result.exception else "")
-        )
-        assert "human_gate" in combined
-        assert "--skip-gates" in combined
-
-    def test_run_web_bg_with_human_gate_and_skip_gates_proceeds(
+    def test_run_web_bg_with_human_gate_proceeds_with_notice(
         self, gate_workflow_file: Path
     ) -> None:
-        """``--skip-gates`` removes the incompatibility; fork proceeds."""
-        from pathlib import Path as _Path
-
-        from conductor.cli.bg_runner import BackgroundLaunch
-
+        """``run --web-bg`` + ``human_gate`` (no ``--skip-gates``) → fork + notice."""
         with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
-            mock_launch.return_value = BackgroundLaunch(
-                url="http://127.0.0.1:9999",
-                stderr_log=_Path("/tmp/conductor-test-deadbeef.bg.stderr.log"),
-                stdout_log=_Path("/tmp/conductor-test-deadbeef.bg.stdout.log"),
-                run_id="deadbeef",
-            )
+            mock_launch.return_value = _fake_bg_launch()
+            result = runner.invoke(app, ["run", str(gate_workflow_file), "--web-bg"], env=_WIDE)
 
+        assert result.exit_code == 0
+        assert mock_launch.called
+        # The notice must name the problem and how to resolve it. It is emitted
+        # to stderr (Console(stderr=True)); Click 8.3+ separates the streams.
+        combined = (result.output or "") + (result.stderr or "")
+        assert "human_gate" in combined
+        assert "gate-respond" in combined
+        assert "9999" in combined  # port extracted from the dashboard URL
+
+    def test_run_web_bg_with_human_gate_and_skip_gates_proceeds_without_notice(
+        self, gate_workflow_file: Path
+    ) -> None:
+        """``--skip-gates`` auto-selects; fork proceeds and no gate notice is shown."""
+        with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
+            mock_launch.return_value = _fake_bg_launch()
             result = runner.invoke(
-                app, ["run", str(gate_workflow_file), "--web-bg", "--skip-gates"]
+                app, ["run", str(gate_workflow_file), "--web-bg", "--skip-gates"], env=_WIDE
             )
 
         assert result.exit_code == 0
         assert mock_launch.called
+        combined = (result.output or "") + (result.stderr or "")
+        assert "gate-respond" not in combined
 
-    def test_resume_web_bg_with_human_gate_aborts_before_fork(
+    def test_run_web_bg_without_gate_shows_no_notice(self, tmp_path: Path) -> None:
+        """A gate-free workflow forks without any gate notice."""
+        f = tmp_path / "plain.yaml"
+        f.write_text(_WORKFLOW_YAML)
+        with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
+            mock_launch.return_value = _fake_bg_launch()
+            result = runner.invoke(app, ["run", str(f), "--web-bg"], env=_WIDE)
+
+        assert result.exit_code == 0
+        assert mock_launch.called
+        combined = (result.output or "") + (result.stderr or "")
+        assert "gate-respond" not in combined
+
+    def test_resume_web_bg_with_human_gate_proceeds_with_notice(
         self, gate_workflow_file: Path
     ) -> None:
-        """Same check applies to ``resume --web-bg`` (run/resume parity)."""
+        """Same behavior applies to ``resume --web-bg`` (run/resume parity)."""
         with patch("conductor.cli.bg_runner.launch_background_resume") as mock_launch:
-            result = runner.invoke(app, ["resume", str(gate_workflow_file), "--web-bg"])
+            mock_launch.return_value = _fake_bg_launch()
+            result = runner.invoke(app, ["resume", str(gate_workflow_file), "--web-bg"], env=_WIDE)
 
-        assert result.exit_code != 0
-        assert not mock_launch.called
-        combined = (
-            (result.output or "")
-            + (result.stderr or "")
-            + (str(result.exception) if result.exception else "")
-        )
+        assert result.exit_code == 0
+        assert mock_launch.called
+        combined = (result.output or "") + (result.stderr or "")
         assert "human_gate" in combined
-        assert "--skip-gates" in combined
+        assert "gate-respond" in combined
 
-    def test_run_web_bg_with_human_gate_inside_for_each_aborts(self, tmp_path: Path) -> None:
-        """``human_gate`` nested in a ``for_each.agent`` must also abort the fork.
+    def test_run_web_bg_with_human_gate_inside_for_each_proceeds_with_notice(
+        self, tmp_path: Path
+    ) -> None:
+        """``human_gate`` nested in a ``for_each.agent`` also triggers the notice.
 
-        The top-level walk over ``config.agents`` misses inline agents
-        declared inside ``for_each`` groups. Without the extra check,
-        ``--web-bg`` still silent-crashes when the gate prompt eventually
-        fires inside the loop.
+        The top-level walk over ``config.agents`` misses inline agents declared
+        inside ``for_each`` groups, so the notice check must scan those too.
         """
         for_each_yaml = """\
 workflow:
@@ -440,27 +457,22 @@ output:
         f.write_text(for_each_yaml)
 
         with patch("conductor.cli.bg_runner.launch_background") as mock_launch:
-            result = runner.invoke(app, ["run", str(f), "--web-bg"])
+            mock_launch.return_value = _fake_bg_launch()
+            result = runner.invoke(app, ["run", str(f), "--web-bg"], env=_WIDE)
 
-        assert result.exit_code != 0
-        assert not mock_launch.called
-        combined = (
-            (result.output or "")
-            + (result.stderr or "")
-            + (str(result.exception) if result.exception else "")
-        )
+        assert result.exit_code == 0
+        assert mock_launch.called
+        combined = (result.output or "") + (result.stderr or "")
         assert "human_gate" in combined
-        assert "--skip-gates" in combined
+        assert "gate-respond" in combined
 
-    def test_resume_web_bg_from_checkpoint_only_aborts(
+    def test_resume_web_bg_from_checkpoint_only_proceeds_with_notice(
         self, gate_workflow_file: Path, tmp_path: Path
     ) -> None:
-        """``resume --from <checkpoint> --web-bg`` (no workflow arg) must still
-        abort when the checkpoint's workflow contains a ``human_gate``.
+        """``resume --from <checkpoint> --web-bg`` (no workflow arg) still notices.
 
-        Previously the abort check was skipped because ``resolved_workflow``
-        is ``None`` in this code path; the workflow path is now recovered from
-        the checkpoint JSON so the same guard fires.
+        ``resolved_workflow`` is ``None`` in this code path; the workflow path
+        is recovered from the checkpoint JSON so the gate notice still fires.
         """
         import json as _json
 
@@ -481,14 +493,13 @@ output:
         )
 
         with patch("conductor.cli.bg_runner.launch_background_resume") as mock_launch:
-            result = runner.invoke(app, ["resume", "--from", str(checkpoint), "--web-bg"])
+            mock_launch.return_value = _fake_bg_launch()
+            result = runner.invoke(
+                app, ["resume", "--from", str(checkpoint), "--web-bg"], env=_WIDE
+            )
 
-        assert result.exit_code != 0
-        assert not mock_launch.called
-        combined = (
-            (result.output or "")
-            + (result.stderr or "")
-            + (str(result.exception) if result.exception else "")
-        )
+        assert result.exit_code == 0
+        assert mock_launch.called
+        combined = (result.output or "") + (result.stderr or "")
         assert "human_gate" in combined
-        assert "--skip-gates" in combined
+        assert "gate-respond" in combined

--- a/tests/test_engine/test_workflow.py
+++ b/tests/test_engine/test_workflow.py
@@ -1726,12 +1726,70 @@ class TestWorkflowEngineHumanGates:
 
         with (
             patch("sys.stdin.isatty", return_value=True),
-            patch.object(engine.gate_handler, "handle_gate", side_effect=_never_returns),
+            patch.object(
+                engine.gate_handler, "handle_gate", side_effect=_never_returns
+            ) as mock_cli_handle,
         ):
             result = await engine.run({})
 
         assert result["received"] == "ok"
         mock_dashboard.wait_for_gate_response.assert_awaited_once_with("approval_gate")
+        # Prove the CLI arm was actually started (not just that the web
+        # dashboard eventually won) — this is what distinguishes "raced" from
+        # "took the web-only shortcut," which would also produce this result.
+        mock_cli_handle.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_human_gate_bg_mode_without_dashboard_raises_clear_error(self) -> None:
+        """bg_mode + no dashboard must raise, not silently crash with EOFError.
+
+        Covers the case where the dashboard failed to start in a ``--web-bg``
+        child (``web_dashboard=None``) while ``_bg_mode`` is still True. Before
+        this fix, ``_handle_gate_with_web`` fell through unconditionally to
+        the CLI prompt handler whenever no dashboard was attached, regardless
+        of ``cli_usable`` — reproducing the original #286 ``EOFError`` crash
+        via a narrower trigger. The CLI handler must never be invoked here;
+        instead a ``HumanGateError`` with an actionable message must surface.
+        """
+        from unittest.mock import patch
+
+        from conductor.engine.workflow import RunContext
+        from conductor.exceptions import HumanGateError
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="gate-bg-no-dashboard", entry_point="approval_gate"),
+            agents=[
+                AgentDef(
+                    name="approval_gate",
+                    type="human_gate",
+                    prompt="Approve?",
+                    options=[
+                        GateOption(label="Approve", value="approved", route="$end"),
+                    ],
+                ),
+            ],
+            output={"result": "done"},
+        )
+
+        def mock_handler(agent, prompt, context):
+            return {"received": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        engine = WorkflowEngine(
+            config,
+            provider,
+            skip_gates=False,
+            web_dashboard=None,
+            run_context=RunContext(bg_mode=True),
+        )
+
+        with (
+            patch.object(engine.gate_handler, "handle_gate") as mock_cli_handle,
+            pytest.raises(HumanGateError, match="approval_gate"),
+        ):
+            await engine.run({})
+
+        mock_cli_handle.assert_not_called()
 
 
 class TestWorkflowEngineLifecycleHooks:

--- a/tests/test_engine/test_workflow.py
+++ b/tests/test_engine/test_workflow.py
@@ -1604,6 +1604,135 @@ class TestWorkflowEngineHumanGates:
         assert rendered_prompts, "echo agent's mock_handler was never invoked"
         assert "User said: README.md" in rendered_prompts[0]
 
+    @pytest.mark.asyncio
+    async def test_human_gate_bg_mode_waits_web_only_and_skips_cli_prompt(self) -> None:
+        """In ``--web-bg`` (bg_mode), the gate must wait web-only (issue #286).
+
+        Before the fix, ``_handle_gate_with_web`` raced the CLI prompt against
+        the web arm unconditionally. With ``stdin`` not a TTY (as in the
+        detached ``--web-bg`` child), ``Prompt.ask`` raises ``EOFError``
+        instantly, race-winning and crashing the workflow before a dashboard
+        user could respond. This test asserts the CLI handler is never even
+        invoked when ``_bg_mode`` is set — only the web dashboard is awaited.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from conductor.engine.workflow import RunContext
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="gate-bg", entry_point="approval_gate"),
+            agents=[
+                AgentDef(
+                    name="approval_gate",
+                    type="human_gate",
+                    prompt="Approve?",
+                    options=[
+                        GateOption(label="Approve", value="approved", route="next"),
+                    ],
+                ),
+                AgentDef(
+                    name="next",
+                    model="gpt-4",
+                    prompt="next",
+                    output={"received": OutputField(type="string")},
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"received": "{{ next.output.received }}"},
+        )
+
+        mock_dashboard = MagicMock()
+        mock_dashboard.wait_for_gate_response = AsyncMock(
+            return_value={"selected_value": "approved", "additional_input": {}}
+        )
+
+        def mock_handler(agent, prompt, context):
+            return {"received": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        engine = WorkflowEngine(
+            config,
+            provider,
+            skip_gates=False,
+            web_dashboard=mock_dashboard,
+            run_context=RunContext(bg_mode=True),
+        )
+
+        with patch.object(engine.gate_handler, "handle_gate") as mock_cli_handle:
+            result = await engine.run({})
+
+        assert result["received"] == "ok"
+        mock_dashboard.wait_for_gate_response.assert_awaited_once_with("approval_gate")
+        mock_cli_handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_human_gate_foreground_tty_still_races_cli_and_web(self) -> None:
+        """Foreground ``--web`` from a real terminal still races CLI vs web.
+
+        Confirms the #286 web-only tier is scoped to bg/non-TTY only — an
+        interactive terminal keeps the pre-existing race behavior, letting
+        whichever of the CLI prompt or the dashboard responds first win.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from conductor.engine.workflow import RunContext
+
+        config = WorkflowConfig(
+            workflow=WorkflowDef(name="gate-tty", entry_point="approval_gate"),
+            agents=[
+                AgentDef(
+                    name="approval_gate",
+                    type="human_gate",
+                    prompt="Approve?",
+                    options=[
+                        GateOption(label="Approve", value="approved", route="next"),
+                        GateOption(label="Reject", value="rejected", route="next"),
+                    ],
+                ),
+                AgentDef(
+                    name="next",
+                    model="gpt-4",
+                    prompt="next",
+                    output={"received": OutputField(type="string")},
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"received": "{{ next.output.received }}"},
+        )
+
+        mock_dashboard = MagicMock()
+        mock_dashboard.wait_for_gate_response = AsyncMock(
+            return_value={"selected_value": "approved", "additional_input": {}}
+        )
+
+        def mock_handler(agent, prompt, context):
+            return {"received": "ok"}
+
+        provider = CopilotProvider(mock_handler=mock_handler)
+        engine = WorkflowEngine(
+            config,
+            provider,
+            skip_gates=False,
+            web_dashboard=mock_dashboard,
+            run_context=RunContext(bg_mode=False),
+        )
+
+        # Foreground TTY: stdin.isatty() True, and the CLI prompt never
+        # returns so the web task deterministically wins the race (mirrors
+        # the existing test_human_gate_web_response_nests_additional_input
+        # pattern above).
+        async def _never_returns(*_args, **_kwargs):
+            await asyncio.Event().wait()
+
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch.object(engine.gate_handler, "handle_gate", side_effect=_never_returns),
+        ):
+            result = await engine.run({})
+
+        assert result["received"] == "ok"
+        mock_dashboard.wait_for_gate_response.assert_awaited_once_with("approval_gate")
+
 
 class TestWorkflowEngineLifecycleHooks:
     """Tests for lifecycle hooks execution."""


### PR DESCRIPTION
Closes #286.

## Problem

`conductor run --web-bg` (and `resume --web-bg`) aborted at launch when the workflow contained a `human_gate`, even though the web dashboard fully supports gate resolution (gate modal, WebSocket `gate_response`, `POST /api/gate-respond`, `conductor gate-respond` CLI).

**Root cause:** `_handle_gate_with_web` raced the CLI prompt against the dashboard unconditionally. In the detached `--web-bg` child (`stdin=DEVNULL`), `Prompt.ask` raised `EOFError` instantly, race-won, cancelled the web arm, and crashed the workflow before a dashboard user could respond.

**Precedent:** issue #198/#202 fixed the identical problem for the max-iterations gate via a `cli_usable` tier in `_resolve_max_iterations_gate`. The human-gate path never got that tier.

## Changes

- **`engine/workflow.py`**: `_handle_gate_with_web` now computes `cli_usable = not self._bg_mode and sys.stdin.isatty()`. When false (bg mode or non-TTY), it waits **web-only** via `_wait_for_web_gate` — the CLI prompt is never invoked. Foreground TTY keeps the existing CLI/web race. Kill/stop while parked at a gate relies on the existing outer `_execute_with_stop_signal` path (checkpoints via `handle_dashboard_stop`, #245) — no new inner stop race was added.
- **`cli/app.py`**: replaced the pre-fork `_abort_web_bg_if_human_gate` abort with `_workflow_has_human_gate` detection + a post-launch `_print_web_bg_human_gate_notice` pointing at the dashboard URL and `conductor gate-respond`. Applies to both `run --web-bg` and `resume --web-bg` (including `resume --from <checkpoint>` with no workflow arg).
- **Docs**: updated `docs/cli-reference.md` and the conductor skill's `execution.md` to describe dashboard/CLI gate resolution instead of the old incompatibility.
- **Tests**: rewrote the "aborts before fork" CLI tests to assert the fork proceeds with a gate notice (run, resume, resume-from-checkpoint-only, `human_gate` nested in `for_each`, `--skip-gates` suppresses the notice, gate-free workflows show no notice). Added engine tests asserting the bg-mode gate waits web-only (CLI handler never invoked) and that foreground TTY still races CLI vs web.

## Design decisions (confirmed with maintainer)

1. Guard → launch-time notice (not full removal) — the fork now proceeds, with a hint on how to resolve gates.
2. Stop/kill at a parked gate relies on the existing outer kill path — no new inner `wait_for_stop()` race inside the gate wait itself, unlike the max-iterations precedent.

## Testing

- `make lint` / `make typecheck` clean (one pre-existing, unrelated `ty` warning in `dialog_evaluator.py` confirmed present on `main`).
- `tests/test_cli/`, `tests/test_engine/`, `tests/test_gates/`, `tests/test_web/`: 1525 passed, 4 skipped.