### PR TITLE
Honor configured session timeout for Copilot dialog turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.23...HEAD)
 
+### Fixed
+
+- **Copilot dialog turns no longer fail after a hidden 120-second deadline** —
+  lightweight dialog sessions now honor `runtime.max_session_seconds` (or the
+  Copilot provider's 1800-second default), and timeout errors are classified as
+  retryable so console and web dialogs can continue without losing history.
+
 ## [0.1.23](https://github.com/microsoft/conductor/compare/v0.1.22...v0.1.23) - 2026-07-20
 
 ### Added

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -2468,12 +2468,13 @@ class CopilotProvider(AgentProvider):
             session.on(on_event)
             await session.send(full_prompt)
 
+            dialog_timeout = self._idle_recovery_config.max_session_seconds
             try:
-                await asyncio.wait_for(done.wait(), timeout=120.0)
+                await asyncio.wait_for(done.wait(), timeout=dialog_timeout)
             except TimeoutError as exc:
                 raise ProviderError(
-                    "Dialog turn timed out after 120s",
-                    is_retryable=False,
+                    f"Dialog turn timed out after {dialog_timeout:g}s",
+                    is_retryable=True,
                 ) from exc
 
             if error_message:

--- a/tests/test_providers/test_copilot.py
+++ b/tests/test_providers/test_copilot.py
@@ -8,7 +8,12 @@ import pytest
 
 from conductor.config.schema import AgentDef, ProviderSettings, ToolOutputConfig
 from conductor.exceptions import ProviderError
-from conductor.providers.copilot import CopilotProvider, RetryConfig, SDKResponse
+from conductor.providers.copilot import (
+    CopilotProvider,
+    IdleRecoveryConfig,
+    RetryConfig,
+    SDKResponse,
+)
 
 
 def stub_handler(agent: AgentDef, prompt: str, context: dict[str, Any]) -> dict[str, Any]:
@@ -1241,6 +1246,36 @@ class TestCopilotExecuteDialogTurn:
                 user_message="hi",
                 history=[],
             )
+
+    @pytest.mark.asyncio
+    async def test_dialog_turn_honors_configured_session_timeout(self) -> None:
+        """Dialog turns use the configured session limit, not a fixed 120s cap."""
+        from unittest.mock import AsyncMock as _AsyncMock
+
+        provider = CopilotProvider(
+            mock_handler=stub_handler,
+            idle_recovery_config=IdleRecoveryConfig(max_session_seconds=0.01),
+        )
+        provider._started = True
+
+        session = _AsyncMock()
+        session.on = lambda callback: None
+        session.send = _AsyncMock()
+        session.destroy = _AsyncMock()
+
+        client = _AsyncMock()
+        client.create_session = _AsyncMock(return_value=session)
+        provider._client = client
+
+        with pytest.raises(ProviderError, match="timed out after 0.01s") as exc_info:
+            await provider.execute_dialog_turn(
+                system_prompt="sys",
+                user_message="hi",
+                history=[],
+            )
+
+        assert exc_info.value.is_retryable is True
+        session.destroy.assert_awaited_once()
 
 
 class TestCopilotProviderLargeOutput:


### PR DESCRIPTION
## Summary
- replace the hard-coded 120-second Copilot dialog wait with the provider's configured `max_session_seconds`
- classify dialog timeout as retryable so callers can continue the existing dialog
- add regression coverage and an Unreleased changelog entry

## Problem

`CopilotProvider.execute_dialog_turn()` ignored `runtime.max_session_seconds` and always timed out after 120 seconds. Long reasoning responses could therefore fail even when the workflow explicitly allowed a longer session.

## Validation

- `PYTHONPATH= ./.venv/Scripts/pytest.exe tests/test_providers/test_copilot.py` — 128 passed
- Ruff check and format check passed for changed files
- `ty check src/conductor/providers/copilot.py` passed
