### PR TITLE
fix: auto-skip real_api-marked tests by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 """Pytest configuration and shared fixtures for Conductor tests.
 
-This module contains fixtures used across multiple test modules.
+This module contains fixtures used across multiple test modules. It also
+defines a collection hook (``pytest_collection_modifyitems``) that auto-skips
+``@pytest.mark.real_api`` tests unless explicitly selected via ``-m`` — see
+its docstring and issue #326 for the full rationale.
 """
 
 import re
@@ -32,7 +35,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     performance"``), pytest's own marker-expression evaluation already
     produces the correct selection/deselection, so this hook steps aside.
     """
-    marker_expr = config.getoption("-m") or ""
+    marker_expr = config.getoption("markexpr")
     if _REAL_API_IN_MARKEXPR.search(marker_expr):
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,43 @@
 This module contains fixtures used across multiple test modules.
 """
 
+import re
 from pathlib import Path
 
 import pytest
+
+# Enables the `pytester` fixture used by tests/test_config/test_real_api_marker.py
+# to exercise this file's collection hook via an inner pytest run.
+pytest_plugins = ["pytester"]
+
+# Matches "real_api" as a whole marker name (not merely a substring) inside a
+# `-m` expression, e.g. "real_api", "not real_api", "not real_api and not
+# performance" all match; "real_api_other" does not.
+_REAL_API_IN_MARKEXPR = re.compile(r"\breal_api\b")
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Make ``@pytest.mark.real_api`` tests opt-in by default.
+
+    Without this hook, nothing deselects ``real_api``-marked tests unless the
+    caller passes an explicit ``-m`` expression (as CI/release workflows do).
+    A plain ``pytest``, ``pytest -m "not performance"``, or ``make test`` would
+    otherwise spawn real Copilot/Claude subprocesses (see issue #326) — which
+    can collide with and kill a live ``conductor run --web-bg`` session.
+
+    If the caller's ``-m`` expression already references ``real_api`` (e.g.
+    ``-m real_api`` to opt in, or CI's ``-m "not real_api and not
+    performance"``), pytest's own marker-expression evaluation already
+    produces the correct selection/deselection, so this hook steps aside.
+    """
+    marker_expr = config.getoption("-m") or ""
+    if _REAL_API_IN_MARKEXPR.search(marker_expr):
+        return
+
+    skip_real_api = pytest.mark.skip(reason="real_api test: opt in with -m real_api")
+    for item in items:
+        if "real_api" in item.keywords:
+            item.add_marker(skip_real_api)
 
 
 @pytest.fixture

--- a/tests/test_config/test_real_api_marker.py
+++ b/tests/test_config/test_real_api_marker.py
@@ -1,10 +1,7 @@
 """Regression tests for the ``real_api`` marker auto-skip hook (issue #326).
 
-Without ``tests/conftest.py::pytest_collection_modifyitems``, nothing
-deselects ``@pytest.mark.real_api`` tests by default. A plain ``pytest``,
-``pytest -m "not performance"``, or ``make test`` would run them, spawning
-real Copilot/Claude subprocesses that can collide with (and kill) a live
-``conductor run --web-bg`` session.
+See ``tests/conftest.py::pytest_collection_modifyitems`` for the full
+rationale behind the hook this suite exercises.
 
 These tests use pytest's built-in ``pytester`` fixture to run an isolated
 inner pytest session whose sandbox ``conftest.py`` delegates to the *actual*
@@ -75,8 +72,25 @@ def test_real_api_runs_when_explicitly_selected(real_api_sandbox: pytest.Pyteste
     result.assert_outcomes(passed=1, deselected=1)
 
 
+def test_regex_does_not_match_unrelated_marker_name(real_api_sandbox: pytest.Pytester) -> None:
+    """A substring match on an unrelated marker must not be treated as opt-in.
+
+    ``-m "not real_api_other"`` references a different (nonexistent) marker
+    that merely contains "real_api" as a substring. It must not be confused
+    with an explicit ``real_api`` reference, so the hook should still
+    auto-skip the real_api test (proving the ``\\breal_api\\b`` word-boundary
+    regex, not a plain substring check, drives the opt-in detection).
+    """
+    result = real_api_sandbox.runpytest("-m", "not real_api_other")
+    result.assert_outcomes(passed=1, skipped=1)
+
+
 def test_ci_marker_expression_still_deselects(real_api_sandbox: pytest.Pytester) -> None:
-    """CI's exact ``-m "not real_api and not performance"`` must keep deselecting it."""
+    """CI's exact ``-m "not real_api and not performance"`` must keep deselecting it.
+
+    This expression is duplicated in ``.github/workflows/ci.yml`` and
+    ``release.yml`` — keep this test's ``-m`` string in sync if those change.
+    """
     result = real_api_sandbox.runpytest("-m", "not real_api and not performance")
     result.assert_outcomes(passed=1, deselected=1)
 

--- a/tests/test_config/test_real_api_marker.py
+++ b/tests/test_config/test_real_api_marker.py
@@ -1,0 +1,98 @@
+"""Regression tests for the ``real_api`` marker auto-skip hook (issue #326).
+
+Without ``tests/conftest.py::pytest_collection_modifyitems``, nothing
+deselects ``@pytest.mark.real_api`` tests by default. A plain ``pytest``,
+``pytest -m "not performance"``, or ``make test`` would run them, spawning
+real Copilot/Claude subprocesses that can collide with (and kill) a live
+``conductor run --web-bg`` session.
+
+These tests use pytest's built-in ``pytester`` fixture to run an isolated
+inner pytest session whose sandbox ``conftest.py`` delegates to the *actual*
+``pytest_collection_modifyitems`` hook defined in ``tests/conftest.py``
+(loaded by file path, not copy-pasted), so this suite fails if that hook is
+weakened, removed, or its ``-m`` detection regressed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_ROOT_CONFTEST = (Path(__file__).parent.parent / "conftest.py").resolve()
+
+# Delegates to the real hook under test via importlib, rather than
+# duplicating its logic, so this suite tracks tests/conftest.py verbatim.
+_SANDBOX_CONFTEST = f'''
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "conductor_root_conftest_under_test", r"{_ROOT_CONFTEST}"
+)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+pytest_collection_modifyitems = _module.pytest_collection_modifyitems
+'''
+
+_SANDBOX_TEST_MODULE = """
+import pytest
+
+
+def test_regular():
+    assert True
+
+
+@pytest.mark.real_api
+def test_marked_real_api():
+    assert True
+"""
+
+
+@pytest.fixture
+def real_api_sandbox(pytester: pytest.Pytester) -> pytest.Pytester:
+    """A pytester sandbox wired to the real conftest.py hook under test."""
+    pytester.makeconftest(_SANDBOX_CONFTEST)
+    pytester.makepyfile(test_sandbox=_SANDBOX_TEST_MODULE)
+    return pytester
+
+
+def test_real_api_skipped_by_default(real_api_sandbox: pytest.Pytester) -> None:
+    """No ``-m`` expression: the real_api test must be skipped, not executed."""
+    result = real_api_sandbox.runpytest()
+    result.assert_outcomes(passed=1, skipped=1)
+
+
+def test_real_api_skipped_with_not_performance(real_api_sandbox: pytest.Pytester) -> None:
+    """Reproduces the issue's exact repro: ``-m "not performance"`` must still skip it."""
+    result = real_api_sandbox.runpytest("-m", "not performance")
+    result.assert_outcomes(passed=1, skipped=1)
+
+
+def test_real_api_runs_when_explicitly_selected(real_api_sandbox: pytest.Pytester) -> None:
+    """``-m real_api`` opts in: the test must run (not be skipped by our hook)."""
+    result = real_api_sandbox.runpytest("-m", "real_api")
+    result.assert_outcomes(passed=1, deselected=1)
+
+
+def test_ci_marker_expression_still_deselects(real_api_sandbox: pytest.Pytester) -> None:
+    """CI's exact ``-m "not real_api and not performance"`` must keep deselecting it."""
+    result = real_api_sandbox.runpytest("-m", "not real_api and not performance")
+    result.assert_outcomes(passed=1, deselected=1)
+
+
+def test_suite_would_catch_a_reverted_hook(real_api_sandbox: pytest.Pytester) -> None:
+    """Load-bearing check: a no-op hook must NOT skip the real_api test.
+
+    Proves the ``skipped=1`` assertions above are meaningful (i.e. this
+    suite would fail if the real hook were reverted/broken) rather than
+    trivially passing regardless of hook behavior.
+    """
+    real_api_sandbox.makeconftest(
+        """
+def pytest_collection_modifyitems(config, items):
+    pass
+"""
+    )
+    result = real_api_sandbox.runpytest()
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
## Summary

Fixes #326.

`@pytest.mark.real_api` was registered in `pyproject.toml` but nothing
deselected it by default — only CI/release workflows hand-filtered with
`-m "not real_api and not performance"`. A plain `pytest`,
`pytest -m "not performance"`, or `make test` would run those tests,
spawning real `copilot`/`claude` subprocesses. That's more than a hygiene
issue: it can hard-kill a live `conductor run --web-bg` workflow when run
from inside it (unhandled `SIGTERM`, no `workflow_failed` event, PID file
left behind).

## Changes

- `tests/conftest.py`: add a `pytest_collection_modifyitems` hook that
  skips any `real_api`-marked item unless the caller's `-m` expression
  already references `real_api` (word-boundary match) — covering both
  explicit opt-in (`-m real_api`) and CI's existing
  `-m "not real_api and not performance"`, which keep working unchanged
  since pytest's own marker-expression evaluation handles those cases.
- `tests/test_config/test_real_api_marker.py`: new pytester-based
  regression suite that loads the *actual* hook by file path (not a copy)
  and verifies:
  - default run (no `-m`) skips the real_api test
  - `-m "not performance"` skips it (the issue's exact repro)
  - `-m real_api` runs it
  - CI's exact `-m "not real_api and not performance"` still deselects it
  - a reverted/no-op hook would **not** skip it (load-bearing check, so
    this suite would catch a future regression)

No changes needed to `Makefile`/CI/release workflows — their existing `-m`
expressions are unaffected by the hook.

## Validation

- `make lint` / `make typecheck` — clean (pre-existing unrelated `ty`
  warning in `dialog_evaluator.py` only).
- `uv run pytest tests/test_config/test_real_api_marker.py -v` — 5/5 pass.
- `uv run pytest tests/test_integration/test_copilot_large_write.py
  tests/test_integration/test_claude_real_api.py
  tests/test_config/test_ci_infrastructure.py -v` (no `-m`) — all
  `real_api` tests report **skipped**, proving no subprocess spawn.
- `uv run pytest tests/test_config/test_ci_infrastructure.py -m real_api -v`
  — confirms opt-in still runs them.
- Full suite `uv run pytest -q -m "not performance"` —
  **4161 passed, 29 skipped, 29 deselected, 0 failed** (previously 1 failed
  from a real `session.create` call per the issue repro).

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>