### PR TITLE
chore(release): cut 0.1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.23...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.24...HEAD)
+
+## [0.1.24](https://github.com/microsoft/conductor/compare/v0.1.23...v0.1.24) - 2026-07-21
 
 ### Added
 
@@ -25,6 +27,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names still work and forward to the new commands, but print a one-line stderr
   deprecation warning, are hidden from `--help`, and will be removed in a future
   release. ([#275](https://github.com/microsoft/conductor/issues/275))
+
+### Fixed
+
+- **`--web-bg` no longer aborts when a workflow contains a `human_gate`** — the
+  dashboard already supported resolving gates (modal, WebSocket
+  `gate_response`, `POST /api/gate-respond`, `conductor gate-respond`), but the
+  detached background process raced a CLI prompt against it and crashed with
+  `EOFError` on its closed stdin. The gate now waits web-only when running in
+  `--web-bg` (or any non-TTY context), and the CLI prints a notice pointing at
+  the dashboard URL and `conductor gate-respond` instead of aborting the launch.
+  ([#286](https://github.com/microsoft/conductor/issues/286))
+- **`--web-bg` could hang forever if no dashboard client ever connected** — the
+  auto-shutdown grace timer was only armed from WebSocket-disconnect code
+  paths, so an unwatched run that finished before anyone opened the dashboard
+  never started its grace countdown and the detached process became a zombie
+  holding its port and PID file. The timer now also arms on the workflow's root
+  completion event. ([#318](https://github.com/microsoft/conductor/issues/318))
+- **`conductor doctor` showed the `copilot` provider as red/unconfigured even
+  when fully authenticated** — credential env vars are now modeled as optional
+  per provider; an absent optional credential (e.g. `copilot`'s GitHub/Copilot
+  CLI login) renders as a neutral `○` with an explanatory note instead of a red
+  `✗`, while genuinely required credentials (e.g. `claude`'s
+  `ANTHROPIC_API_KEY`) still flag as missing.
+  ([#319](https://github.com/microsoft/conductor/issues/319))
+- **Web dashboard could keep showing a stale UI after `conductor update`** —
+  `index.html` is now served with `Cache-Control: no-cache` so the browser
+  revalidates it on every load and always picks up the current build's
+  version-hashed asset bundle. CI also now fails the Frontend job if the
+  committed `static/` bundle doesn't match a fresh `make build-frontend`, so a
+  frontend change can no longer merge without its built assets.
+  ([#321](https://github.com/microsoft/conductor/pull/321))
 
 ## [0.1.23](https://github.com/microsoft/conductor/compare/v0.1.22...v0.1.23) - 2026-07-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.23"
+version = "0.1.24"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 0.1.24

Previous release: **v0.1.23**

### Commit audit (7 commits since v0.1.23)

| PR | Subject | Classification |
|---|---|---|
| #321 | fix(web): revalidate dashboard index.html + CI guard for stale static bundle | Fixed |
| #322 | fix(doctor): render optional provider credentials neutrally (#319) | Fixed |
| #324 | fix(engine,cli): resolve human gates from dashboard in `--web-bg` (closes #286) | Fixed |
| #323 | fix(web): arm `--web-bg` grace timer on root workflow completion (fixes #318) | Fixed |
| #310 | chore(deps): bump mcp 1.26.0 → 1.28.1 | Internal (no changelog) |
| #328 | fix: auto-skip real_api-marked tests by default (fixes #326) | Internal, test-suite only (no changelog) |
| #327 | feat(cli): rework command surface into hybrid grouping (closes #275) | Already covered by existing Unreleased entries |

### Changelog summary

Added a new `### Fixed` section to `[Unreleased]` (now finalized as `[0.1.24]`) covering:

- `--web-bg` no longer aborts on `human_gate` workflows (#286)
- `--web-bg` no longer hangs forever when no dashboard client ever connects (#318)
- `conductor doctor` no longer shows `copilot` as red/unconfigured when authenticated via CLI login (#319)
- Web dashboard no longer shows a stale UI after `conductor update` (#321)

Existing `Added`/`Deprecated` entries for the CLI command-surface rework (#275) were preserved unchanged.

### Version bump

`pyproject.toml` version: `0.1.23` → `0.1.24` (patch bump, default). `uv.lock` re-locked — diff is limited to the `conductor-cli` package version.

### Validation

- `make check` — clean (lint + format + typecheck; one pre-existing, unrelated `ty` warning in `dialog_evaluator.py`, confirmed present on `main` and noted in multiple PRs in this range)
- `make test` — **4206 passed, 25 skipped, 8 deselected**, 0 failed
- `make validate-examples` — all examples validate successfully (one example file changed in this range: `examples/periodic-checkpoints.yaml`)

### Next steps

After this PR merges, I'll tag the merge commit as `v0.1.24` and push the tag, which triggers `.github/workflows/release.yml` to build, test, and publish the GitHub Release.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>