### PR TITLE
fix(tests): stop install-script E2E tests from killing live conductor processes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@
 
 This module contains fixtures used across multiple test modules. It also
 defines a collection hook (``pytest_collection_modifyitems``) that auto-skips
-``@pytest.mark.real_api`` tests unless explicitly selected via ``-m`` — see
-its docstring and issue #326 for the full rationale.
+``@pytest.mark.real_api`` and ``@pytest.mark.install_scripts`` tests unless
+explicitly selected via ``-m`` — see its docstring and issues #326 / #331 for
+the full rationale.
 """
 
 import re
@@ -12,37 +13,53 @@ from pathlib import Path
 import pytest
 
 # Enables the `pytester` fixture used by tests/test_config/test_real_api_marker.py
-# to exercise this file's collection hook via an inner pytest run.
+# and tests/test_config/test_install_scripts_marker.py to exercise this file's
+# collection hook via an inner pytest run.
 pytest_plugins = ["pytester"]
 
-# Matches "real_api" as a whole marker name (not merely a substring) inside a
-# `-m` expression, e.g. "real_api", "not real_api", "not real_api and not
-# performance" all match; "real_api_other" does not.
-_REAL_API_IN_MARKEXPR = re.compile(r"\breal_api\b")
+# Marker names that are opt-in by default: unless the caller's `-m`
+# expression explicitly references one of these (by name, as a whole word),
+# tests carrying it are skipped rather than executed. Both markers gate tests
+# that can reach out and disrupt the *host* environment — real_api spawns
+# real Copilot/Claude subprocesses (issue #326); install_scripts drives
+# install.sh/install.ps1's `--auto-stop`, which SIGTERM-kills every live
+# `conductor` process on the machine (issue #331) — so both must be excluded
+# from a plain `pytest` / `pytest -m "not performance"` run, not just from
+# `make test`.
+_OPT_IN_MARKER_NAMES = ("real_api", "install_scripts")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Make ``@pytest.mark.real_api`` tests opt-in by default.
+    """Make opt-in markers (``real_api``, ``install_scripts``) skip by default.
 
-    Without this hook, nothing deselects ``real_api``-marked tests unless the
-    caller passes an explicit ``-m`` expression (as CI/release workflows do).
-    A plain ``pytest``, ``pytest -m "not performance"``, or ``make test`` would
-    otherwise spawn real Copilot/Claude subprocesses (see issue #326) — which
-    can collide with and kill a live ``conductor run --web-bg`` session.
+    Without this hook, nothing deselects tests carrying one of
+    ``_OPT_IN_MARKER_NAMES`` unless the caller passes an explicit ``-m``
+    expression (as CI/release workflows do). A plain ``pytest``,
+    ``pytest -m "not performance"``, or ``make test`` would otherwise run
+    them — spawning real Copilot/Claude subprocesses (``real_api``, issue
+    #326) or driving the install scripts' host-wide process-killing
+    ``--auto-stop`` path (``install_scripts``, issue #331). Either can
+    collide with and kill a live ``conductor run --web-bg`` session.
 
-    If the caller's ``-m`` expression already references ``real_api`` (e.g.
-    ``-m real_api`` to opt in, or CI's ``-m "not real_api and not
-    performance"``), pytest's own marker-expression evaluation already
-    produces the correct selection/deselection, so this hook steps aside.
+    For each marker name, if the caller's ``-m`` expression already
+    references it (e.g. ``-m real_api`` / ``-m install_scripts`` to opt in,
+    or CI's ``-m "not real_api and not performance"``), pytest's own
+    marker-expression evaluation already produces the correct
+    selection/deselection, so this hook steps aside for that marker.
     """
     marker_expr = config.getoption("markexpr")
-    if _REAL_API_IN_MARKEXPR.search(marker_expr):
-        return
+    for mark_name in _OPT_IN_MARKER_NAMES:
+        # Matches the marker name as a whole word (not merely a substring)
+        # inside the `-m` expression, e.g. "install_scripts", "not
+        # install_scripts", "not real_api and not performance" all match for
+        # their respective marker; "install_scripts_other" does not.
+        if re.search(rf"\b{re.escape(mark_name)}\b", marker_expr):
+            continue  # explicitly referenced; pytest's own evaluation handles it
 
-    skip_real_api = pytest.mark.skip(reason="real_api test: opt in with -m real_api")
-    for item in items:
-        if "real_api" in item.keywords:
-            item.add_marker(skip_real_api)
+        skip = pytest.mark.skip(reason=f"{mark_name} test: opt in with -m {mark_name}")
+        for item in items:
+            if mark_name in item.keywords:
+                item.add_marker(skip)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,13 +19,8 @@ pytest_plugins = ["pytester"]
 
 # Marker names that are opt-in by default: unless the caller's `-m`
 # expression explicitly references one of these (by name, as a whole word),
-# tests carrying it are skipped rather than executed. Both markers gate tests
-# that can reach out and disrupt the *host* environment — real_api spawns
-# real Copilot/Claude subprocesses (issue #326); install_scripts drives
-# install.sh/install.ps1's `--auto-stop`, which SIGTERM-kills every live
-# `conductor` process on the machine (issue #331) — so both must be excluded
-# from a plain `pytest` / `pytest -m "not performance"` run, not just from
-# `make test`.
+# tests carrying it are skipped rather than executed. See the function
+# docstring below for the full rationale and per-invocation behavior.
 _OPT_IN_MARKER_NAMES = ("real_api", "install_scripts")
 
 
@@ -33,13 +28,21 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     """Make opt-in markers (``real_api``, ``install_scripts``) skip by default.
 
     Without this hook, nothing deselects tests carrying one of
-    ``_OPT_IN_MARKER_NAMES`` unless the caller passes an explicit ``-m``
-    expression (as CI/release workflows do). A plain ``pytest``,
-    ``pytest -m "not performance"``, or ``make test`` would otherwise run
-    them — spawning real Copilot/Claude subprocesses (``real_api``, issue
-    #326) or driving the install scripts' host-wide process-killing
-    ``--auto-stop`` path (``install_scripts``, issue #331). Either can
-    collide with and kill a live ``conductor run --web-bg`` session.
+    ``_OPT_IN_MARKER_NAMES`` unless the caller's ``-m`` expression already
+    references that marker name (as CI/release workflows do). Both markers
+    gate tests that can reach out and disrupt the *host* environment:
+    ``real_api`` spawns real Copilot/Claude subprocesses (issue #326);
+    ``install_scripts`` drives the install scripts' host-wide
+    process-killing ``--auto-stop`` path (issue #331). Either can collide
+    with and kill a live ``conductor run --web-bg`` session.
+
+    This hook is load-bearing to different degrees per marker and per
+    invocation: a plain ``pytest`` or ``pytest -m "not performance"`` never
+    mentions either marker, so both are only caught by this hook. ``make
+    test``'s own ``-m "not install_scripts"`` (see ``Makefile``) already
+    deselects ``install_scripts`` independently via pytest's native
+    marker-expression evaluation — but it never mentions ``real_api``, so
+    that marker still relies on this hook there too.
 
     For each marker name, if the caller's ``-m`` expression already
     references it (e.g. ``-m real_api`` / ``-m install_scripts`` to opt in,

--- a/tests/test_config/test_install_scripts_marker.py
+++ b/tests/test_config/test_install_scripts_marker.py
@@ -1,0 +1,143 @@
+"""Regression tests for the ``install_scripts`` marker auto-skip hook (issue #331).
+
+See ``tests/conftest.py::pytest_collection_modifyitems`` for the full
+rationale behind the hook this suite exercises. Without this hook, a plain
+``pytest`` / ``pytest -m "not performance"`` invocation (or CI's main test
+job, whose ``-m`` expression never mentions ``install_scripts``) would run
+the install-script E2E suite, which can SIGTERM-kill any live
+``conductor run --web-bg`` process on the host.
+
+These tests use pytest's built-in ``pytester`` fixture to run an isolated
+inner pytest session whose sandbox ``conftest.py`` delegates to the *actual*
+``pytest_collection_modifyitems`` hook defined in ``tests/conftest.py``
+(loaded by file path, not copy-pasted), so this suite fails if that hook is
+weakened, removed, or its ``-m`` detection regressed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_ROOT_CONFTEST = (Path(__file__).parent.parent / "conftest.py").resolve()
+
+# Delegates to the real hook under test via importlib, rather than
+# duplicating its logic, so this suite tracks tests/conftest.py verbatim.
+_SANDBOX_CONFTEST = f'''
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "conductor_root_conftest_under_test", r"{_ROOT_CONFTEST}"
+)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+pytest_collection_modifyitems = _module.pytest_collection_modifyitems
+'''
+
+_SANDBOX_TEST_MODULE = """
+import pytest
+
+
+def test_regular():
+    assert True
+
+
+@pytest.mark.install_scripts
+def test_marked_install_scripts():
+    assert True
+"""
+
+
+@pytest.fixture
+def install_scripts_sandbox(pytester: pytest.Pytester) -> pytest.Pytester:
+    """A pytester sandbox wired to the real conftest.py hook under test."""
+    pytester.makeconftest(_SANDBOX_CONFTEST)
+    pytester.makepyfile(test_sandbox=_SANDBOX_TEST_MODULE)
+    return pytester
+
+
+def test_install_scripts_skipped_by_default(
+    install_scripts_sandbox: pytest.Pytester,
+) -> None:
+    """No ``-m`` expression: the install_scripts test must be skipped, not executed."""
+    result = install_scripts_sandbox.runpytest()
+    result.assert_outcomes(passed=1, skipped=1)
+
+
+def test_install_scripts_skipped_with_not_performance(
+    install_scripts_sandbox: pytest.Pytester,
+) -> None:
+    """Reproduces the issue's exact repro: ``-m "not performance"`` must still skip it."""
+    result = install_scripts_sandbox.runpytest("-m", "not performance")
+    result.assert_outcomes(passed=1, skipped=1)
+
+
+def test_install_scripts_skipped_by_ci_main_job_expression(
+    install_scripts_sandbox: pytest.Pytester,
+) -> None:
+    """CI's main test-job expression never mentions ``install_scripts``.
+
+    ``.github/workflows/ci.yml`` / ``release.yml`` run
+    ``-m "not real_api and not performance"`` for the main test job — this
+    doesn't reference ``install_scripts`` at all, so before this fix the
+    install-script E2E suite ran there too. The hook must still skip it.
+    """
+    result = install_scripts_sandbox.runpytest("-m", "not real_api and not performance")
+    result.assert_outcomes(passed=1, skipped=1)
+
+
+def test_install_scripts_runs_when_explicitly_selected(
+    install_scripts_sandbox: pytest.Pytester,
+) -> None:
+    """``-m install_scripts`` opts in: the test must run (not be skipped by our hook)."""
+    result = install_scripts_sandbox.runpytest("-m", "install_scripts")
+    result.assert_outcomes(passed=1, deselected=1)
+
+
+def test_install_scripts_deselected_by_make_test_expression(
+    install_scripts_sandbox: pytest.Pytester,
+) -> None:
+    """``make test``'s ``-m "not install_scripts"`` must still deselect it.
+
+    This expression explicitly references the marker, so pytest's own
+    marker-expression evaluation (not our hook) does the deselecting.
+    """
+    result = install_scripts_sandbox.runpytest("-m", "not install_scripts")
+    result.assert_outcomes(passed=1, deselected=1)
+
+
+def test_regex_does_not_match_unrelated_marker_name(
+    install_scripts_sandbox: pytest.Pytester,
+) -> None:
+    """A substring match on an unrelated marker must not be treated as opt-in.
+
+    ``-m "not install_scripts_other"`` references a different (nonexistent)
+    marker that merely contains "install_scripts" as a substring. It must
+    not be confused with an explicit ``install_scripts`` reference, so the
+    hook should still auto-skip the install_scripts test (proving the
+    ``\\binstall_scripts\\b`` word-boundary regex, not a plain substring
+    check, drives the opt-in detection).
+    """
+    result = install_scripts_sandbox.runpytest("-m", "not install_scripts_other")
+    result.assert_outcomes(passed=1, skipped=1)
+
+
+def test_suite_would_catch_a_reverted_hook(
+    install_scripts_sandbox: pytest.Pytester,
+) -> None:
+    """Load-bearing check: a no-op hook must NOT skip the install_scripts test.
+
+    Proves the ``skipped=1`` assertions above are meaningful (i.e. this
+    suite would fail if the real hook were reverted/broken) rather than
+    trivially passing regardless of hook behavior.
+    """
+    install_scripts_sandbox.makeconftest(
+        """
+def pytest_collection_modifyitems(config, items):
+    pass
+"""
+    )
+    result = install_scripts_sandbox.runpytest()
+    result.assert_outcomes(passed=2)

--- a/tests/test_integration/install_scripts_helpers.py
+++ b/tests/test_integration/install_scripts_helpers.py
@@ -6,7 +6,11 @@ isolated ``UV_TOOL_DIR`` sandboxes so the user's real install is never
 touched.
 
 Tests using these fixtures are gated behind ``-m install_scripts`` (see
-``pyproject.toml``) and excluded from the default ``make test`` run.
+``pyproject.toml``) and are auto-skipped by default (not just excluded from
+``make test``) by the ``tests/conftest.py`` collection hook — see issue
+#331. ``run_install_script()`` also defaults to ``auto_stop=False`` so it
+never drives the install scripts' host-wide process-killing ``--auto-stop``
+path unless a test explicitly opts in.
 """
 
 from __future__ import annotations
@@ -176,16 +180,24 @@ def run_install_script(
     sandbox: Sandbox,
     *,
     source: Path | str,
-    auto_stop: bool = True,
+    auto_stop: bool = False,
     force: bool = False,
     extra_env: dict | None = None,
     timeout: int = 600,
 ) -> InstallResult:
     """Drive install.ps1 (Windows) or install.sh (POSIX) against the sandbox.
 
-    Always passes the source via ``--source`` / ``-Source`` and runs in
-    ``--auto-stop`` mode unless overridden so any conductor process the test
-    leaves behind gets reaped automatically.
+    Always passes the source via ``--source`` / ``-Source``. ``auto_stop``
+    defaults to ``False`` (issue #331): the install scripts'
+    ``--auto-stop``/``-AutoStop`` flag makes ``find_running_conductor()``
+    scan and ``kill`` every matching conductor process on the *whole host*,
+    not just ones the test itself spawned — passing it by default here would
+    make every call site in this suite capable of SIGTERM-killing an
+    unrelated live ``conductor run``/``--web-bg`` workflow on the developer's
+    (or agent's) machine. Tests that specifically need to exercise the
+    kill-and-continue behavior (e.g.
+    ``test_running_process_auto_stop_kills_and_continues``) must opt in
+    explicitly with ``auto_stop=True``.
     """
     extra_env = dict(extra_env or {})
     # Prevent the install scripts from running `uv tool update-shell`, which

--- a/tests/test_integration/test_install_scripts.py
+++ b/tests/test_integration/test_install_scripts.py
@@ -8,7 +8,14 @@ Run with::
 
     uv run pytest -m install_scripts -v
 
-Excluded from the default ``make test`` run.
+Excluded from the default ``make test`` run, and auto-skipped by plain
+``pytest`` / ``pytest -m "not performance"`` invocations (and CI's main test
+job) via the ``tests/conftest.py`` collection hook — see issue #331. Without
+that hook, these tests would run under any of those invocations; combined
+with ``install.sh``'s ``find_running_conductor()`` scanning the whole *host*
+process table, a test that opts into ``--auto-stop`` could SIGTERM-kill an
+unrelated live ``conductor run --web-bg`` process. ``run_install_script()``
+now defaults to ``auto_stop=False`` for the same reason.
 
 The tests are deliberately Windows-focused because the upgrade reliability
 problems they exercise are Windows-specific (file locking on a venv whose

--- a/tests/test_integration/test_run_install_script_command.py
+++ b/tests/test_integration/test_run_install_script_command.py
@@ -1,0 +1,75 @@
+"""Fast, unmarked unit tests for ``run_install_script()``'s command construction.
+
+Unlike :mod:`tests.test_integration.test_install_scripts`, which drives the
+real install scripts end-to-end behind the ``install_scripts`` pytest marker
+(auto-skipped by default — see issue #331), these tests mock
+``subprocess.run`` so they run in microseconds as part of the default
+``make test`` / plain ``pytest`` suite.
+
+The specific thing under test is ``run_install_script()``'s
+``auto_stop``-to-flag mapping: whether ``--auto-stop`` / ``-AutoStop`` is
+appended to the command line. This is the exact behavior issue #331's fix
+depends on (``auto_stop`` now defaults to ``False`` so no call site
+accidentally drives the install scripts' host-wide, process-killing
+``--auto-stop`` path). Without a fast, always-run test for it, a future
+change to :func:`run_install_script` could silently flip the default back
+without anything catching it outside the (skipped-by-default) E2E suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from .install_scripts_helpers import Sandbox, run_install_script
+
+
+@pytest.fixture
+def fake_sandbox(tmp_path: Path) -> Sandbox:
+    """A ``Sandbox`` backed by non-existent paths — fine since we never touch disk."""
+    return Sandbox(
+        root=tmp_path,
+        tool_dir=tmp_path / "uv-tools",
+        bin_dir=tmp_path / "uv-bin",
+        cache_dir=tmp_path / "uv-cache",
+    )
+
+
+def _captured_cmd(
+    fake_sandbox: Sandbox, *, auto_stop: bool = False, force: bool = False
+) -> list[str]:
+    """Run ``run_install_script`` with ``subprocess.run`` mocked; return the built cmd."""
+    fake_proc = MagicMock(returncode=0, stdout="", stderr="")
+    with patch(
+        "tests.test_integration.install_scripts_helpers.subprocess.run",
+        return_value=fake_proc,
+    ) as mock_run:
+        run_install_script(fake_sandbox, source="fake-wheel.whl", auto_stop=auto_stop, force=force)
+    args, _kwargs = mock_run.call_args
+    return args[0]
+
+
+def test_auto_stop_flag_omitted_by_default(fake_sandbox: Sandbox) -> None:
+    """Regression guard for issue #331: no flag means no host-wide process kill."""
+    cmd = _captured_cmd(fake_sandbox)
+    assert "--auto-stop" not in cmd
+    assert "-AutoStop" not in cmd
+
+
+def test_auto_stop_flag_included_when_explicitly_requested(fake_sandbox: Sandbox) -> None:
+    """Tests that need the kill-and-continue behavior can still opt in explicitly."""
+    cmd = _captured_cmd(fake_sandbox, auto_stop=True)
+    assert "--auto-stop" in cmd or "-AutoStop" in cmd
+
+
+def test_force_flag_omitted_by_default(fake_sandbox: Sandbox) -> None:
+    cmd = _captured_cmd(fake_sandbox)
+    assert "--force" not in cmd
+    assert "-Force" not in cmd
+
+
+def test_force_flag_included_when_explicitly_requested(fake_sandbox: Sandbox) -> None:
+    cmd = _captured_cmd(fake_sandbox, force=True)
+    assert "--force" in cmd or "-Force" in cmd


### PR DESCRIPTION
## Summary

Fixes #331 — the install-script E2E suite (`@pytest.mark.install_scripts`) drives `install.sh`/`install.ps1`'s `--auto-stop` flag, whose `find_running_conductor()` scans the **whole host process table** and SIGTERM-kills every live `conductor` process it finds. Nothing deselected these tests by default, so a plain `pytest`, `pytest -m "not performance"`, or even CI's main test job (`-m "not real_api and not performance"`, which never mentions `install_scripts`) would run them and could silently kill an unrelated live `conductor run --web-bg` workflow.

## Changes

- **`tests/conftest.py`**: generalized the existing `real_api` auto-skip hook (issue #326) into a loop over `("real_api", "install_scripts")`, using the same word-boundary `-m` opt-in detection. Both markers now auto-skip unless the caller's `-m` expression explicitly references them.
- **`tests/test_integration/install_scripts_helpers.py`**: `run_install_script(..., auto_stop=True)` → default `False` (defense-in-depth). Only `test_running_process_auto_stop_kills_and_continues` needs the kill behavior and already passes `auto_stop=True` explicitly, so no other call sites changed.
- **`tests/test_config/test_install_scripts_marker.py`** (new): regression suite mirroring `test_real_api_marker.py`'s pytester-based approach — covers default skip, `-m "not performance"`, CI's exact main-job expression, explicit `-m install_scripts` opt-in, `-m "not install_scripts"` (current `make test` filter), regex word-boundary robustness, and a "test-the-test" case proving a reverted hook would be caught.
- Doc touch-ups in `test_install_scripts.py` / `install_scripts_helpers.py` docstrings reflecting the new safe-by-default behavior.

## Out of scope

- Changing `install.sh`/`install.ps1`'s `find_running_conductor` host-wide scan breadth — explicitly called out as optional in the issue.
- `Makefile`'s existing `-m "not install_scripts"` filters — redundant with the new hook now but harmless, kept for explicitness.

## Verification

- New `test_install_scripts_marker.py` suite: 7/7 passed.
- Existing `test_real_api_marker.py`: 6/6 passed (no regression from generalizing the hook).
- `uv run pytest -m "not performance" -q`: all `install_scripts`-marked tests now show `SKIPPED ... install_scripts test: opt in with -m install_scripts` (previously they ran).
- `uv run pytest -m "not install_scripts and not performance"`: 4184 passed, 0 failed.
- `make lint`, `make typecheck`: clean (one pre-existing, unrelated `ty` warning in `dialog_evaluator.py` confirmed present on `main` too).
- Confirmed `tests/test_performance.py::TestForEachPerformance::test_batching_scalability` fails identically on unmodified `main` — pre-existing timing flake, unrelated to this change.