### PR TITLE
chore(release): cut 0.1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.24...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.25...HEAD)
+
+## [0.1.25](https://github.com/microsoft/conductor/compare/v0.1.24...v0.1.25) - 2026-07-21
+
+### Fixed
+
+- **Web dashboard warns when stuck reconnecting after a silent crash** — a
+  new amber banner appears if the dashboard's WebSocket client has been
+  disconnected and retrying for more than 60 seconds while a workflow is
+  still marked "running", pointing at the best available log
+  (`--web-bg`'s captured stderr/stdout log, the `--log-file` debug log, or
+  the launching terminal) so a silently crashed `--web-bg` process is no
+  longer indistinguishable from a healthy, still-running workflow.
+  ([#332](https://github.com/microsoft/conductor/pull/332))
 
 ## [0.1.24](https://github.com/microsoft/conductor/compare/v0.1.23...v0.1.24) - 2026-07-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.24"
+version = "0.1.25"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 0.1.25

Previous release: `v0.1.24` (2026-07-21)

### Commit audit (2 commits since v0.1.24)

| Commit | PR | Classification |
|---|---|---|
| 4fe0108 | #332 fix(web): warn when dashboard is stuck reconnecting after a silent crash | Fixed — added to changelog |
| 4ac8f03 | #333 fix(tests): stop install-script E2E tests from killing live conductor processes | Internal (test-only), no changelog entry |

### Changelog summary

**Fixed**
- Web dashboard warns when stuck reconnecting after a silent crash (amber banner, 60s threshold, points at bg stderr/stdout log or `--log-file`) ([#332](https://github.com/microsoft/conductor/pull/332))

### Changes in this PR
- Finalized `CHANGELOG.md`: converted `[Unreleased]` → `[0.1.25]`, added the Fixed entry above, opened a fresh empty `[Unreleased]` section.
- Bumped `version` in `pyproject.toml` to `0.1.25`.
- Re-locked `uv.lock` (version-only change for `conductor-cli`).

### Validation
- `make check` — passed (ruff lint, ruff format, ty typecheck; one pre-existing `ty` diagnostic in `dialog_evaluator.py`, confirmed present on `main` prior to this release too)
- `make test` — passed: 4217 passed, 25 skipped, 8 deselected
- No schema or `examples/` changes in this range, so `make validate-examples` was not required

### Next steps
Merging this PR will be followed by tagging the merge commit `v0.1.25` and pushing the tag, which triggers `.github/workflows/release.yml` to build and publish the GitHub Release.

🤖 Generated with GitHub Copilot CLI