### PR TITLE
fix(executor): validate nested array item output schemas recursively

### DIFF
--- a/src/conductor/executor/output.py
+++ b/src/conductor/executor/output.py
@@ -19,6 +19,7 @@ def validate_output(
     """Validate agent output against declared schema.
 
     Checks that all required fields are present and have the correct types.
+    Nested object properties and array items are validated recursively.
 
     Args:
         content: Agent's output content as a dictionary.
@@ -40,29 +41,44 @@ def validate_output(
                 suggestion=f"Ensure agent returns '{field_name}' in output",
             )
 
-        value = content[field_name]
-        expected_type = field_def.type
+        _validate_field(field_name, content[field_name], field_def)
 
-        # Type checking
-        if not _check_type(value, expected_type):
-            raise ValidationError(
-                f"Output field '{field_name}' has wrong type: "
-                f"expected {expected_type}, got {type(value).__name__}",
-                suggestion=f"Ensure agent returns correct type for '{field_name}'",
-            )
 
-        # Recursively validate nested structures
-        if expected_type == "object" and field_def.properties and isinstance(value, dict):
-            validate_output(value, field_def.properties)
+def _validate_field(field_name: str, value: Any, field_def: OutputField) -> None:
+    """Validate a single value against its output field definition.
 
-        if expected_type == "array" and field_def.items and isinstance(value, list):
-            for i, item in enumerate(value):
-                if not _check_type(item, field_def.items.type):
-                    raise ValidationError(
-                        f"Array item {i} in '{field_name}' has wrong type: "
-                        f"expected {field_def.items.type}, got {type(item).__name__}",
-                        suggestion=f"Ensure all items in '{field_name}' have correct type",
-                    )
+    Recursively validates nested object properties and array items so
+    ``array<object>`` and deeper combinations are checked at every depth,
+    matching the recursion the object branch has always had.
+
+    Args:
+        field_name: Field name used in error messages (array items keep the
+            parent array's name, matching the existing message style).
+        value: The value to validate.
+        field_def: The field definition to validate against.
+
+    Raises:
+        ValidationError: If the value or any nested value doesn't match.
+    """
+    if not _check_type(value, field_def.type):
+        raise ValidationError(
+            f"Output field '{field_name}' has wrong type: "
+            f"expected {field_def.type}, got {type(value).__name__}",
+            suggestion=f"Ensure agent returns correct type for '{field_name}'",
+        )
+
+    if field_def.type == "object" and field_def.properties and isinstance(value, dict):
+        validate_output(value, field_def.properties)
+
+    if field_def.type == "array" and field_def.items and isinstance(value, list):
+        for i, item in enumerate(value):
+            if not _check_type(item, field_def.items.type):
+                raise ValidationError(
+                    f"Array item {i} in '{field_name}' has wrong type: "
+                    f"expected {field_def.items.type}, got {type(item).__name__}",
+                    suggestion=f"Ensure all items in '{field_name}' have correct type",
+                )
+            _validate_field(field_name, item, field_def.items)
 
 
 def _check_type(value: Any, expected: str) -> bool:

--- a/tests/test_executor/test_output.py
+++ b/tests/test_executor/test_output.py
@@ -8,6 +8,8 @@ Tests cover:
 - JSON parsing from raw responses
 """
 
+from typing import Any
+
 import pytest
 
 from conductor.config.schema import OutputField
@@ -200,6 +202,148 @@ class TestValidateOutputNested:
 
         with pytest.raises(ValidationError, match="Array item 2.*wrong type"):
             validate_output(content, schema)
+
+
+class TestValidateOutputArrayRecursion:
+    """Tests for recursive validation of array item schemas (issue regression)."""
+
+    def test_array_of_objects_valid_passes(self) -> None:
+        """Valid array<object> content must pass unchanged (no false positives)."""
+        schema = {
+            "findings": OutputField(
+                type="array",
+                items=OutputField(
+                    type="object",
+                    properties={
+                        "title": OutputField(type="string"),
+                        "score": OutputField(type="number"),
+                    },
+                ),
+            )
+        }
+        content = {
+            "findings": [
+                {"title": "first", "score": 1.0},
+                {"title": "second", "score": 2.0},
+            ]
+        }
+
+        validate_output(content, schema)
+
+    def test_array_of_objects_missing_nested_field_raises(self) -> None:
+        """Missing required field inside an array item must raise (previously silently accepted)."""
+        schema = {
+            "findings": OutputField(
+                type="array",
+                items=OutputField(
+                    type="object",
+                    properties={
+                        "title": OutputField(type="string"),
+                        "score": OutputField(type="number"),
+                    },
+                ),
+            )
+        }
+        content = {
+            "findings": [
+                {"title": "first", "score": 1.0},
+                {"title": "second"},
+            ]
+        }
+
+        with pytest.raises(ValidationError, match="Missing required output field: score"):
+            validate_output(content, schema)
+
+    def test_array_of_objects_wrong_nested_type_raises(self) -> None:
+        """Wrong-typed nested field inside an array item must raise."""
+        schema = {
+            "findings": OutputField(
+                type="array",
+                items=OutputField(
+                    type="object",
+                    properties={
+                        "title": OutputField(type="string"),
+                        "score": OutputField(type="number"),
+                    },
+                ),
+            )
+        }
+        content = {
+            "findings": [
+                {"title": 42, "score": 1.0},
+            ]
+        }
+
+        with pytest.raises(ValidationError, match="wrong type"):
+            validate_output(content, schema)
+
+    def test_nested_array_of_objects_deep_error_raises(self) -> None:
+        """array<array<object>> must validate the object level, pinning general recursion."""
+        schema = {
+            "matrix": OutputField(
+                type="array",
+                items=OutputField(
+                    type="array",
+                    items=OutputField(
+                        type="object",
+                        properties={"v": OutputField(type="number")},
+                    ),
+                ),
+            )
+        }
+        content = {
+            "matrix": [
+                [{"v": 1.0}, {"v": "x"}],
+            ]
+        }
+
+        with pytest.raises(ValidationError, match="wrong type"):
+            validate_output(content, schema)
+
+    def test_array_without_items_unchanged(self) -> None:
+        """Arrays declared without items keep historical passthrough behavior."""
+        schema = {"tags": OutputField(type="array")}
+        content = {"tags": [1, "two", {"three": 3}]}
+
+        validate_output(content, schema)
+
+    def test_builder_shaped_deep_schema_invalid_content_raises(self) -> None:
+        """A schema at the builder boundary (max_depth=10) must be
+        enforceable without RecursionError."""
+        from conductor.providers._schema import build_json_schema_field
+
+        # Build 5 array/object pairs: depth 10 leaf string at the innermost level.
+        inner: OutputField = OutputField(type="string")
+        for _ in range(5):
+            inner = OutputField(
+                type="array",
+                items=OutputField(
+                    type="object",
+                    properties={"x": inner},
+                ),
+            )
+        schema_root = {"data": inner}
+
+        built = build_json_schema_field(inner)
+        assert isinstance(built, dict)
+
+        # Content mirrors the nested structure with a wrong-typed leaf.
+        content: dict[str, Any] = {"data": [{"x": [{"x": [{"x": [{"x": [{"x": 123}]}]}]}]}]}
+
+        with pytest.raises(ValidationError, match="wrong type"):
+            validate_output(content, schema_root)
+
+    def test_validate_output_does_not_call_check_type_directly(self) -> None:
+        """After refactor all value checks must flow through _validate_field."""
+        import inspect
+
+        from conductor.executor.output import _validate_field, validate_output
+
+        validate_source = inspect.getsource(validate_output)
+        validate_field_source = inspect.getsource(_validate_field)
+
+        assert "_check_type(" not in validate_source
+        assert "_check_type(" in validate_field_source
 
 
 class TestParseJsonOutput:

--- a/tests/test_integration/test_workflows.py
+++ b/tests/test_integration/test_workflows.py
@@ -744,7 +744,7 @@ class TestBackwardCompatibility:
             agent_calls.append(agent.name)
 
             if agent.name == "planner":
-                return {"plan": [{"step": "1"}], "confidence": 0.9}
+                return {"plan": [{"step": "1", "action": "Research"}], "confidence": 0.9}
             elif agent.name == "executor":
                 return {"result": {"success": True, "output": "Done"}}
             return {}


### PR DESCRIPTION
## Summary

Continues the output-schema tightening series started in #311 (shared builders extracted into `_schema.py`) and #317 (Copilot and Hermes aligned on the shared recursive prompt-schema builder). Those PRs made the schema that providers *send to the model* fully recursive — but `validate_output` (`executor/output.py`), which checks the model's response against the declared `output:` contract, still only type-checked top-level `array` items. An `array<object>` (or deeper) output with missing or mistyped nested fields therefore passed validation silently, even though the model had received the full nested schema.

This PR closes that gap: the per-field validation logic is extracted into a recursive `_validate_field` helper that recurses into both `object.properties` (existing behavior, moved verbatim) and `array.items` (new), so nested array item schemas are enforced at every depth — in all five `validate_output` call sites at once (LLM agents, Claude, Hermes, `set` steps, `script` steps).

## Behavior change

This is a **tightening bugfix**: workflows whose agents, `set` steps, or `script` steps emit `array<object>` outputs that violate the declared nested schema will now fail with `ValidationError` instead of passing silently. The declared `output:` contract is finally enforced the same way the schema builders already advertise it to the model.

## Compatibility

- **Flat schemas and `object` nesting: byte-identical behavior and error messages.** All pre-existing validation tests pass unmodified, pinning the message shapes (`Missing required output field: ...`, `Output field '...' has wrong type: ...`, `Array item N in '...' has wrong type: ...`).
- No changes to providers, engine, CLI, or the workflow YAML schema — the fix lives entirely in `executor/output.py` and propagates through the existing call sites.
- No new depth limit in `validate_output`: schemas deeper than the builders' `max_depth=10` are still rejected at schema-build time, before validation ever runs.
- Arrays declared without `items` keep their historical passthrough.

## Explicitly out of scope

- `additionalProperties: false` enforcement (follow-up PR).
- Self-healing / validation retry in the Claude agentic loop (follow-up PR).
- New `OutputField` fields (`enum`, `pattern`, `required`, `nullable`, min/max).
- Path prefixes in error messages (`findings[2].severity`) — messages stay byte-compatible here; a separate diagnostics PR will add paths.

## Test plan

- 7 new regression tests in `TestValidateOutputArrayRecursion`: valid `array<object>` passes, missing nested field raises, wrong nested type raises, `array<array<object>>` deep error raises, no-`items` passthrough preserved, builder-boundary depth-10 schema (5 array/object pairs, verified acceptable to `build_json_schema_field`) rejects invalid content without `RecursionError`, and a source-inspection guard that `validate_output` never calls `_check_type` directly (all value checks flow through `_validate_field`).
- Mutation check: commenting out the recursive array-item call makes exactly the 4 nested-validation tests fail; restoring it returns the suite to green.
- One integration-test mock (`test_workflows.py`) that violated its own declared `array<object>` schema (missing required `action` inside a `plan` item) is brought into conformance — a one-line mock fix, no test-semantics change. This was the only in-repo consumer relying on the previously silent acceptance.
- `make test`: 4338 passed. `make check` (ruff + format + ty): clean. `make validate-examples`: green.
