### PR TITLE
fix(mcp): keep connection cleanup in owner tasks

### DIFF
--- a/src/conductor/mcp/manager.py
+++ b/src/conductor/mcp/manager.py
@@ -125,7 +125,6 @@ class MCPManager:
         self.tool_to_server: dict[str, str] = {}  # prefixed_name -> server
         self._connection_tasks: dict[str, asyncio.Task[None]] = {}
         self._connection_stops: dict[str, asyncio.Event] = {}
-        self._initialized = False
         self._tool_output = tool_output or ToolOutputConfig()
 
     async def connect_server(
@@ -214,7 +213,6 @@ class MCPManager:
 
                     self.sessions[name] = session
                     self.tools[name] = tools
-                    self._initialized = True
                     ready.set_result(tools)
                     await stop.wait()
             except asyncio.CancelledError:
@@ -240,12 +238,19 @@ class MCPManager:
                 ready.cancel()
             task.cancel()
             cleanup = asyncio.gather(task, return_exceptions=True)
-            try:
-                results = await asyncio.shield(cleanup)
-            except asyncio.CancelledError:
-                results = await cleanup
+            # Await the owner task's teardown under a re-shielding loop: a
+            # repeated cancellation of connect_server() lands on the shield
+            # instead of the gather, so cleanup still completes and the
+            # bookkeeping below always runs.
+            results: list[BaseException | None] | None = None
+            while results is None:
+                try:
+                    results = list(await asyncio.shield(cleanup))
+                except asyncio.CancelledError:
+                    if cleanup.done():
+                        results = list(cleanup.result())
             for result in results:
-                if isinstance(result, Exception) and not isinstance(result, asyncio.CancelledError):
+                if isinstance(result, Exception):
                     logger.warning(f"Error cancelling MCP connection '{name}': {result}")
             self._connection_tasks.pop(name, None)
             self._connection_stops.pop(name, None)
@@ -256,7 +261,7 @@ class MCPManager:
             self._connection_tasks.pop(name, None)
             self._connection_stops.pop(name, None)
             self._discard_server_state(name)
-            logger.error(f"Failed to connect to MCP server '{name}': {exc}")
+            logger.error(f"Failed to connect to MCP server '{name}': {exc}", exc_info=exc)
             raise RuntimeError(f"Failed to connect to MCP server '{name}': {exc}") from exc
 
         logger.info(
@@ -555,36 +560,36 @@ class MCPManager:
 
         This method should be called when the manager is no longer needed.
         It properly closes all stdio connections and cleans up internal state.
+        Cancellation is deliberately absorbed until owner-task teardown
+        completes, so task-affine MCP contexts are never orphaned.
         """
         if not self._connection_tasks:
             return
 
-        logger.debug(f"Closing {len(self.sessions)} MCP server connection(s)")
+        logger.debug(f"Closing {len(self._connection_tasks)} MCP server connection(s)")
 
         for stop in self._connection_stops.values():
             stop.set()
 
         cleanup = asyncio.gather(*self._connection_tasks.values(), return_exceptions=True)
-        try:
+        # Await teardown under a re-shielding loop: a repeated cancellation of
+        # close() lands on the shield instead of the gather, so cleanup still
+        # completes before bookkeeping is cleared.
+        results: list[BaseException | None] | None = None
+        while results is None:
             try:
-                results = await asyncio.shield(cleanup)
+                results = list(await asyncio.shield(cleanup))
             except asyncio.CancelledError:
-                results = await cleanup
-                for result in results:
-                    if isinstance(result, Exception):
-                        logger.warning(f"Error closing MCP connections: {result}")
-                raise
+                if cleanup.done():
+                    results = list(cleanup.result())
 
-            for result in results:
-                if isinstance(result, Exception):
-                    logger.warning(f"Error closing MCP connections: {result}")
-        finally:
-            if cleanup.done():
-                self.sessions.clear()
-                self.tools.clear()
-                self.tool_to_server.clear()
-                self._connection_tasks.clear()
-                self._connection_stops.clear()
-                self._initialized = False
+        self.sessions.clear()
+        self.tools.clear()
+        self.tool_to_server.clear()
+        self._connection_tasks.clear()
+        self._connection_stops.clear()
+        for result in results:
+            if isinstance(result, Exception):
+                logger.warning(f"Error closing MCP connections: {result}")
 
         logger.debug("MCP manager closed")

--- a/src/conductor/mcp/manager.py
+++ b/src/conductor/mcp/manager.py
@@ -15,6 +15,7 @@ part of the returned string.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -35,13 +36,13 @@ try:
     from mcp.client.stdio import StdioServerParameters, stdio_client
     from mcp.types import TextContent
 
-    MCP_SDK_AVAILABLE = True
 except ImportError:
-    MCP_SDK_AVAILABLE = False
     ClientSession = None  # type: ignore[misc, assignment]
     StdioServerParameters = None  # type: ignore[misc, assignment]
     stdio_client = None  # type: ignore[misc, assignment]
     TextContent = None  # type: ignore[misc, assignment]
+
+MCP_SDK_AVAILABLE = ClientSession is not None
 
 
 # Marker constants. The generic hint is embedded by the manager and replaced
@@ -119,10 +120,11 @@ class MCPManager:
         if not MCP_SDK_AVAILABLE:
             raise ImportError("MCP SDK not installed. Install with: uv add 'mcp>=1.0.0'")
 
-        self.sessions: dict[str, ClientSession] = {}
+        self.sessions: dict[str, Any] = {}
         self.tools: dict[str, list[dict[str, Any]]] = {}  # server -> tools
         self.tool_to_server: dict[str, str] = {}  # prefixed_name -> server
-        self._exit_stack = AsyncExitStack()
+        self._connection_tasks: dict[str, asyncio.Task[None]] = {}
+        self._connection_stops: dict[str, asyncio.Event] = {}
         self._initialized = False
         self._tool_output = tool_output or ToolOutputConfig()
 
@@ -163,59 +165,105 @@ class MCPManager:
         """
         if not MCP_SDK_AVAILABLE:
             raise RuntimeError("MCP SDK not available")
+        assert StdioServerParameters is not None
+        assert stdio_client is not None
+        assert ClientSession is not None
+        server_parameters_type = StdioServerParameters
+        open_stdio = stdio_client
+        session_type = ClientSession
+        if name in self._connection_tasks:
+            raise RuntimeError(f"MCP server '{name}' is already connected or connecting")
 
         logger.info(f"Connecting to MCP server '{name}': {command} {args or []}")
 
         # Build server parameters
-        server_params = StdioServerParameters(
+        server_params = server_parameters_type(
             command=command,
             args=args or [],
             env=env,
             cwd=cwd,
         )
 
+        ready: asyncio.Future[list[dict[str, Any]]] = asyncio.get_running_loop().create_future()
+        stop = asyncio.Event()
+
+        async def own_connection_lifecycle() -> None:
+            try:
+                async with AsyncExitStack() as stack:
+                    transport = await stack.enter_async_context(open_stdio(server_params))
+                    read_stream, write_stream = transport
+                    session = await stack.enter_async_context(
+                        session_type(read_stream, write_stream)
+                    )
+                    await session.initialize()
+
+                    response = await session.list_tools()
+                    tools: list[dict[str, Any]] = []
+                    for tool in response.tools:
+                        prefixed_name = f"{name}__{tool.name}"
+                        tools.append(
+                            {
+                                "name": prefixed_name,
+                                "description": tool.description or "",
+                                "input_schema": tool.inputSchema,
+                                "server": name,
+                                "original_name": tool.name,
+                            }
+                        )
+                        self.tool_to_server[prefixed_name] = name
+
+                    self.sessions[name] = session
+                    self.tools[name] = tools
+                    self._initialized = True
+                    ready.set_result(tools)
+                    await stop.wait()
+            except asyncio.CancelledError:
+                if not ready.done():
+                    ready.cancel()
+                raise
+            except Exception as exc:
+                if not ready.done():
+                    ready.set_exception(exc)
+                raise
+
+        task = asyncio.create_task(
+            own_connection_lifecycle(),
+            name=f"mcp-lifecycle-{name}",
+        )
+        self._connection_tasks[name] = task
+        self._connection_stops[name] = stop
+
         try:
-            # Enter the stdio_client context
-            transport = await self._exit_stack.enter_async_context(stdio_client(server_params))
-            read_stream, write_stream = transport
+            tools = await asyncio.shield(ready)
+        except asyncio.CancelledError:
+            if not ready.done():
+                ready.cancel()
+            task.cancel()
+            cleanup = asyncio.gather(task, return_exceptions=True)
+            try:
+                results = await asyncio.shield(cleanup)
+            except asyncio.CancelledError:
+                results = await cleanup
+            for result in results:
+                if isinstance(result, Exception) and not isinstance(result, asyncio.CancelledError):
+                    logger.warning(f"Error cancelling MCP connection '{name}': {result}")
+            self._connection_tasks.pop(name, None)
+            self._connection_stops.pop(name, None)
+            self._discard_server_state(name)
+            raise
+        except Exception as exc:
+            await asyncio.gather(task, return_exceptions=True)
+            self._connection_tasks.pop(name, None)
+            self._connection_stops.pop(name, None)
+            self._discard_server_state(name)
+            logger.error(f"Failed to connect to MCP server '{name}': {exc}")
+            raise RuntimeError(f"Failed to connect to MCP server '{name}': {exc}") from exc
 
-            # Create and initialize session
-            session = await self._exit_stack.enter_async_context(
-                ClientSession(read_stream, write_stream)
-            )
-            await session.initialize()
-
-            self.sessions[name] = session
-            self._initialized = True
-
-            # Fetch and store tools
-            response = await session.list_tools()
-            tools: list[dict[str, Any]] = []
-
-            for tool in response.tools:
-                # Prefix tool name with server name to avoid collisions
-                prefixed_name = f"{name}__{tool.name}"
-                tool_def = {
-                    "name": prefixed_name,
-                    "description": tool.description or "",
-                    "input_schema": tool.inputSchema,
-                    "server": name,
-                    "original_name": tool.name,
-                }
-                tools.append(tool_def)
-                self.tool_to_server[prefixed_name] = name
-
-            self.tools[name] = tools
-            logger.info(
-                f"Connected to MCP server '{name}' with {len(tools)} tools: "
-                f"{[t['original_name'] for t in tools]}"
-            )
-
-            return tools
-
-        except Exception as e:
-            logger.error(f"Failed to connect to MCP server '{name}': {e}")
-            raise RuntimeError(f"Failed to connect to MCP server '{name}': {e}") from e
+        logger.info(
+            f"Connected to MCP server '{name}' with {len(tools)} tools: "
+            f"{[tool['original_name'] for tool in tools]}"
+        )
+        return tools
 
     async def call_tool(
         self,
@@ -491,25 +539,52 @@ class MCPManager:
         """
         return len(self.sessions) > 0
 
+    def _discard_server_state(self, server_name: str) -> None:
+        self.sessions.pop(server_name, None)
+        self.tools.pop(server_name, None)
+        stale_tools = [
+            tool_name
+            for tool_name, mapped_server in self.tool_to_server.items()
+            if mapped_server == server_name
+        ]
+        for tool_name in stale_tools:
+            self.tool_to_server.pop(tool_name, None)
+
     async def close(self) -> None:
         """Close all server connections and clean up resources.
 
         This method should be called when the manager is no longer needed.
         It properly closes all stdio connections and cleans up internal state.
         """
-        if not self._initialized:
+        if not self._connection_tasks:
             return
 
         logger.debug(f"Closing {len(self.sessions)} MCP server connection(s)")
 
-        try:
-            await self._exit_stack.aclose()
-        except Exception as e:
-            logger.warning(f"Error closing MCP connections: {e}")
+        for stop in self._connection_stops.values():
+            stop.set()
 
-        self.sessions.clear()
-        self.tools.clear()
-        self.tool_to_server.clear()
-        self._initialized = False
+        cleanup = asyncio.gather(*self._connection_tasks.values(), return_exceptions=True)
+        try:
+            try:
+                results = await asyncio.shield(cleanup)
+            except asyncio.CancelledError:
+                results = await cleanup
+                for result in results:
+                    if isinstance(result, Exception):
+                        logger.warning(f"Error closing MCP connections: {result}")
+                raise
+
+            for result in results:
+                if isinstance(result, Exception):
+                    logger.warning(f"Error closing MCP connections: {result}")
+        finally:
+            if cleanup.done():
+                self.sessions.clear()
+                self.tools.clear()
+                self.tool_to_server.clear()
+                self._connection_tasks.clear()
+                self._connection_stops.clear()
+                self._initialized = False
 
         logger.debug("MCP manager closed")

--- a/tests/test_mcp/test_manager.py
+++ b/tests/test_mcp/test_manager.py
@@ -9,10 +9,75 @@ This module tests:
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
 import pytest
+
+
+class _TaskAffineMCP:
+    def __init__(self) -> None:
+        self.entries: list[asyncio.Task[Any] | None] = []
+        self.exits: list[asyncio.Task[Any] | None] = []
+        self.initialize_started = asyncio.Event()
+        self.initialize_blocker: asyncio.Event | None = None
+        self.initialize_error: RuntimeError | None = None
+        self.exit_started = asyncio.Event()
+        self.exit_blocker: asyncio.Event | None = None
+        self.exit_error: RuntimeError | None = None
+
+    @asynccontextmanager
+    async def stdio(self, _params: Any) -> AsyncIterator[tuple[MagicMock, MagicMock]]:
+        self.entries.append(asyncio.current_task())
+        with anyio.CancelScope():
+            try:
+                yield MagicMock(), MagicMock()
+            finally:
+                self.exit_started.set()
+                if self.exit_blocker is not None:
+                    await self.exit_blocker.wait()
+                self.exits.append(asyncio.current_task())
+                if self.exit_error is not None:
+                    raise self.exit_error
+
+    @asynccontextmanager
+    async def session(self, _read: Any, _write: Any) -> AsyncIterator[AsyncMock]:
+        self.entries.append(asyncio.current_task())
+        with anyio.CancelScope():
+            try:
+                session = AsyncMock()
+                session.initialize = AsyncMock(side_effect=self._initialize)
+                response = MagicMock()
+                response.tools = []
+                session.list_tools = AsyncMock(return_value=response)
+                yield session
+            finally:
+                self.exits.append(asyncio.current_task())
+
+    async def _initialize(self) -> None:
+        self.initialize_started.set()
+        if self.initialize_error is not None:
+            raise self.initialize_error
+        if self.initialize_blocker is not None:
+            await self.initialize_blocker.wait()
+
+
+@asynccontextmanager
+async def _task_affine_manager() -> AsyncIterator[tuple[Any, _TaskAffineMCP]]:
+    environment = _TaskAffineMCP()
+    with (
+        patch("conductor.mcp.manager.MCP_SDK_AVAILABLE", True),
+        patch("conductor.mcp.manager.StdioServerParameters", return_value=MagicMock()),
+        patch("conductor.mcp.manager.stdio_client", side_effect=environment.stdio),
+        patch("conductor.mcp.manager.ClientSession", side_effect=environment.session),
+    ):
+        from conductor.mcp.manager import MCPManager
+
+        yield MCPManager(), environment
 
 
 class TestMCPManagerImport:
@@ -234,6 +299,12 @@ class TestMCPManagerConnectServer:
         mock_server_params = MagicMock()
         mock_stdio_context = MagicMock()
         mock_client_session = MagicMock()
+        mock_stdio_context.__aenter__ = AsyncMock(
+            return_value=(mock_read_stream, mock_write_stream)
+        )
+        mock_stdio_context.__aexit__ = AsyncMock(return_value=False)
+        mock_client_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_session.__aexit__ = AsyncMock(return_value=False)
 
         # Patch all MCP SDK components
         with (
@@ -251,14 +322,6 @@ class TestMCPManagerConnectServer:
                 return_value=mock_client_session,
             ),
         ):
-            # Override the exit stack to return our mocked transport and session
-            manager._exit_stack.enter_async_context = AsyncMock(
-                side_effect=[
-                    (mock_read_stream, mock_write_stream),
-                    mock_session,
-                ]
-            )
-
             tools = await manager.connect_server(
                 name="web-search",
                 command="npx",
@@ -266,17 +329,18 @@ class TestMCPManagerConnectServer:
                 env={"MODE": "stdio"},
             )
 
-        # Verify results
-        assert len(tools) == 1
-        assert tools[0]["name"] == "web-search__search"
-        assert tools[0]["original_name"] == "search"
-        assert tools[0]["server"] == "web-search"
-        assert tools[0]["description"] == "Search the web"
+            # Verify results
+            assert len(tools) == 1
+            assert tools[0]["name"] == "web-search__search"
+            assert tools[0]["original_name"] == "search"
+            assert tools[0]["server"] == "web-search"
+            assert tools[0]["description"] == "Search the web"
 
-        # Verify internal state
-        assert "web-search" in manager.sessions
-        assert "web-search" in manager.tools
-        assert manager.tool_to_server["web-search__search"] == "web-search"
+            # Verify internal state
+            assert "web-search" in manager.sessions
+            assert "web-search" in manager.tools
+            assert manager.tool_to_server["web-search__search"] == "web-search"
+            await manager.close()
 
     async def test_connect_server_forwards_cwd(self, manager: Any) -> None:
         """Requirement: agent working_dir must reach the MCP server subprocess.
@@ -297,6 +361,12 @@ class TestMCPManagerConnectServer:
         mock_write_stream = MagicMock()
         mock_stdio_context = MagicMock()
         mock_client_session = MagicMock()
+        mock_stdio_context.__aenter__ = AsyncMock(
+            return_value=(mock_read_stream, mock_write_stream)
+        )
+        mock_stdio_context.__aexit__ = AsyncMock(return_value=False)
+        mock_client_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_session.__aexit__ = AsyncMock(return_value=False)
 
         with (
             patch("conductor.mcp.manager.MCP_SDK_AVAILABLE", True),
@@ -310,19 +380,13 @@ class TestMCPManagerConnectServer:
                 return_value=mock_client_session,
             ),
         ):
-            manager._exit_stack.enter_async_context = AsyncMock(
-                side_effect=[
-                    (mock_read_stream, mock_write_stream),
-                    mock_session,
-                ]
-            )
-
             await manager.connect_server(
                 name="fs",
                 command="npx",
                 args=["-y", "@modelcontextprotocol/server-filesystem"],
                 cwd="/repo/worktree-a",
             )
+            await manager.close()
 
         # StdioServerParameters must receive the cwd so the child process
         # starts in that directory.
@@ -347,6 +411,12 @@ class TestMCPManagerConnectServer:
         mock_write_stream = MagicMock()
         mock_stdio_context = MagicMock()
         mock_client_session = MagicMock()
+        mock_stdio_context.__aenter__ = AsyncMock(
+            return_value=(mock_read_stream, mock_write_stream)
+        )
+        mock_stdio_context.__aexit__ = AsyncMock(return_value=False)
+        mock_client_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_session.__aexit__ = AsyncMock(return_value=False)
 
         with (
             patch("conductor.mcp.manager.MCP_SDK_AVAILABLE", True),
@@ -360,14 +430,108 @@ class TestMCPManagerConnectServer:
                 return_value=mock_client_session,
             ),
         ):
-            manager._exit_stack.enter_async_context = AsyncMock(
-                side_effect=[
-                    (mock_read_stream, mock_write_stream),
-                    mock_session,
-                ]
-            )
-
             await manager.connect_server(name="fs", command="npx")
+            await manager.close()
 
         mock_params_cls.assert_called_once()
         assert mock_params_cls.call_args.kwargs["cwd"] is None
+
+
+class TestMCPManagerTaskAffinity:
+    async def test_worker_connect_parent_close_uses_lifecycle_owner_task(self) -> None:
+        # Requirement: parent shutdown exits MCP contexts in the task that entered them.
+        async with _task_affine_manager() as (manager, environment):
+            await asyncio.create_task(manager.connect_server(name="fs", command="server"))
+
+            await manager.close()
+
+        assert environment.exits == environment.entries
+
+    async def test_failed_connection_cleans_up_in_lifecycle_owner_task(self) -> None:
+        # Requirement: a failed MCP connection releases every entered context in its owner task.
+        async with _task_affine_manager() as (manager, environment):
+            environment.initialize_error = RuntimeError("initialization failed")
+
+            with pytest.raises(RuntimeError, match="initialization failed"):
+                await manager.connect_server(name="fs", command="server")
+            await manager.close()
+
+        assert environment.exits == environment.entries
+
+    async def test_cancelled_connection_cleans_up_in_lifecycle_owner_task(self) -> None:
+        # Requirement: cancelling a connection cannot orphan its task-affine MCP contexts.
+        async with _task_affine_manager() as (manager, environment):
+            environment.initialize_blocker = asyncio.Event()
+            connection = asyncio.create_task(manager.connect_server(name="fs", command="server"))
+            await environment.initialize_started.wait()
+
+            connection.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await connection
+            await manager.close()
+
+        assert environment.exits == environment.entries
+
+    async def test_parallel_managers_close_from_parent_task(self) -> None:
+        # Requirement: parent shutdown safely closes managers created by parallel workers.
+        async with _task_affine_manager() as (first_manager, environment):
+            with patch("conductor.mcp.manager.MCP_SDK_AVAILABLE", True):
+                from conductor.mcp.manager import MCPManager
+
+                second_manager = MCPManager()
+            await asyncio.gather(
+                asyncio.create_task(first_manager.connect_server(name="one", command="server")),
+                asyncio.create_task(second_manager.connect_server(name="two", command="server")),
+            )
+
+            await asyncio.gather(first_manager.close(), second_manager.close())
+
+        assert environment.exits == environment.entries
+
+    async def test_cancelled_connection_preserves_cancellation_when_cleanup_fails(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Requirement: cleanup errors must not replace cancellation requested by the caller.
+        async with _task_affine_manager() as (manager, environment):
+            environment.initialize_blocker = asyncio.Event()
+            environment.exit_error = RuntimeError("cleanup failed")
+            connection = asyncio.create_task(manager.connect_server(name="fs", command="server"))
+            await environment.initialize_started.wait()
+
+            connection.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await connection
+
+        assert environment.exits == environment.entries
+        assert "Error cancelling MCP connection 'fs': cleanup failed" in caplog.messages
+
+    async def test_cancelled_close_finishes_owner_task_cleanup(self) -> None:
+        # Requirement: cancelling shutdown cannot interrupt task-affine owner cleanup.
+        async with _task_affine_manager() as (manager, environment):
+            environment.exit_blocker = asyncio.Event()
+            await manager.connect_server(name="fs", command="server")
+
+            closing = asyncio.create_task(manager.close())
+            await environment.exit_started.wait()
+            closing.cancel()
+            await asyncio.sleep(0)
+            assert not closing.done()
+
+            environment.exit_blocker.set()
+            with pytest.raises(asyncio.CancelledError):
+                await closing
+
+        assert environment.exits == environment.entries
+        assert manager.sessions == {}
+        assert manager._connection_tasks == {}
+
+    async def test_duplicate_server_name_is_rejected_without_replacing_owner(self) -> None:
+        # Requirement: a duplicate server name cannot orphan the original lifecycle task.
+        async with _task_affine_manager() as (manager, environment):
+            await manager.connect_server(name="fs", command="server")
+
+            with pytest.raises(RuntimeError, match="already connected or connecting"):
+                await manager.connect_server(name="fs", command="server")
+            await manager.close()
+
+        assert environment.exits == environment.entries

--- a/tests/test_mcp/test_manager.py
+++ b/tests/test_mcp/test_manager.py
@@ -505,6 +505,28 @@ class TestMCPManagerTaskAffinity:
         assert environment.exits == environment.entries
         assert "Error cancelling MCP connection 'fs': cleanup failed" in caplog.messages
 
+    async def test_double_cancelled_connection_clears_bookkeeping(self) -> None:
+        # Requirement: a repeated cancellation cannot leave a stale _connection_tasks entry.
+        async with _task_affine_manager() as (manager, environment):
+            environment.initialize_blocker = asyncio.Event()
+            environment.exit_blocker = asyncio.Event()
+            connection = asyncio.create_task(manager.connect_server(name="fs", command="server"))
+            await environment.initialize_started.wait()
+
+            connection.cancel()
+            await environment.exit_started.wait()
+            connection.cancel()
+            await asyncio.sleep(0)
+            assert not connection.done()
+
+            environment.exit_blocker.set()
+            with pytest.raises(asyncio.CancelledError):
+                await connection
+
+        assert environment.exits == environment.entries
+        assert "fs" not in manager._connection_tasks
+        assert "fs" not in manager._connection_stops
+
     async def test_cancelled_close_finishes_owner_task_cleanup(self) -> None:
         # Requirement: cancelling shutdown cannot interrupt task-affine owner cleanup.
         async with _task_affine_manager() as (manager, environment):
@@ -518,8 +540,28 @@ class TestMCPManagerTaskAffinity:
             assert not closing.done()
 
             environment.exit_blocker.set()
-            with pytest.raises(asyncio.CancelledError):
-                await closing
+            await closing
+
+        assert environment.exits == environment.entries
+        assert manager.sessions == {}
+        assert manager._connection_tasks == {}
+
+    async def test_double_cancelled_close_still_finishes_cleanup(self) -> None:
+        # Requirement: a repeated cancellation of close() cannot orphan teardown either.
+        async with _task_affine_manager() as (manager, environment):
+            environment.exit_blocker = asyncio.Event()
+            await manager.connect_server(name="fs", command="server")
+
+            closing = asyncio.create_task(manager.close())
+            await environment.exit_started.wait()
+            closing.cancel()
+            await asyncio.sleep(0)
+            closing.cancel()
+            await asyncio.sleep(0)
+            assert not closing.done()
+
+            environment.exit_blocker.set()
+            await closing
 
         assert environment.exits == environment.entries
         assert manager.sessions == {}


### PR DESCRIPTION
## Summary

- move each MCP stdio/session context lifecycle into a persistent owner task
- signal owner tasks during manager shutdown so AnyIO cancel scopes exit in the task that entered them
- preserve caller cancellation while consuming and logging cleanup failures
- protect owner-task teardown when manager shutdown is cancelled
- reject duplicate server names without orphaning the existing connection

## Testing

- `PYTHONASYNCIODEBUG=1 uv run pytest tests/test_mcp -q` (51 passed)
- `make check`
- direct stdio MCP lifecycle driver covering connect, tool call, duplicate names, failure, cancellation, concurrency, and idempotent close

Fixes #353