### PR TITLE
chore(release): cut 0.1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.26...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.27...HEAD)
+
+## [0.1.27](https://github.com/microsoft/conductor/compare/v0.1.26...v0.1.27) - 2026-08-04
 
 ### Added
+
+- **Skills: `runtime.skills` and per-agent `skills:` give agents opt-in
+  knowledge bases** ([#180](https://github.com/microsoft/conductor/issues/180))
+  — `runtime.skills` enables a list of skills for every provider-backed agent
+  in the workflow, and any agent can override it with its own `skills:`
+  (omitted = inherit, `[]` = explicit opt-out, a list = explicit set).
+  Conductor ships a built-in `conductor` skill covering its own YAML schema,
+  execution model, authoring patterns, and CLI commands, so an agent that
+  writes or reviews workflows can be made Conductor-aware without pasting
+  documentation into its prompt. The observable contract is the same on every
+  provider — the agent has access to the named skill — but the mechanism
+  differs: `copilot` registers the skill directory on the SDK session, so only
+  the frontmatter is read up front and the body is loaded on demand, while
+  providers with no native skill surface receive the skill content injected
+  into the prompt. Providers declare whether they can load skills at all, and
+  `conductor validate` rejects a workflow that enables skills on one that
+  cannot, rather than letting the content be silently dropped at run time.
+  Skills are rejected on step types with no model behind them (`script`,
+  `set`, `wait`, `terminate`, `workflow`, `human_gate`). See
+  [`examples/skills-self-improving-workflow.yaml`](examples/skills-self-improving-workflow.yaml)
+  and [`docs/workflow-syntax.md`](docs/workflow-syntax.md) (Skills).
 
 - **Skill discovery: `runtime.skill_discovery` picks up skills already
   installed on the machine** (issue #362) — `sources: [personal, project,
@@ -146,6 +169,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since `validate_output` also runs on `set` and `script` step output that may
   carry secrets. ([#343](https://github.com/microsoft/conductor/issues/343))
 
+- **Sub-workflow nodes in the dashboard are expandable before they run.** A
+  `type: workflow` node previously became expandable only once the engine
+  actually reached that step, so the inner DAG of a sub-workflow that had not
+  started yet was invisible. Conductor now resolves each sub-workflow's static
+  topology up front and attaches it to the graph, so the real inner DAG can be
+  expanded — recursively, for nested sub-workflows — from the moment the run
+  starts. Resolution is best-effort: a missing file, registry error, cycle, or
+  depth limit simply leaves the node collapsed until the engine reaches it.
+  ([#360](https://github.com/microsoft/conductor/pull/360))
+
 ### Fixed
 
 - **A malformed `SKILL.md` no longer fails silently** (issue #350) — both the
@@ -220,7 +253,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hardcoded module constant of 3 and silently ignored the YAML value that
   Copilot and Claude both respect. ([#343](https://github.com/microsoft/conductor/issues/343))
 
+- **Nested `array` item schemas in `output:` are now enforced.** `validate_output`
+  type-checked only the top level of an array, so an `array<object>` output whose
+  items were missing declared fields — or had the wrong types — passed validation
+  silently, even though the full nested schema had been sent to the model.
+  Validation now recurses through both `object.properties` and `array.items` at
+  every depth, for LLM agents, `set` steps, and `script` steps alike.
+  **Behavior change:** a workflow that was quietly emitting output violating its
+  own declared nested schema will now fail with `ValidationError` instead of
+  passing. Flat schemas and `object` nesting are unaffected, and arrays declared
+  without `items` keep their existing passthrough.
+  ([#337](https://github.com/microsoft/conductor/pull/337))
+
+- **MCP server connections are now closed by the task that opened them.** Each
+  stdio/session lifecycle is held in its own owner task and signalled at
+  shutdown, so AnyIO cancel scopes always exit in the task that entered them.
+  Previously a connection opened in a worker task and closed from the root task
+  could raise a cancel-scope error during teardown, surfacing as a spurious
+  failure at the end of an otherwise successful run. Cleanup failures are logged
+  rather than masking the caller's own cancellation, and registering a duplicate
+  server name is now rejected instead of orphaning the existing connection.
+  ([#353](https://github.com/microsoft/conductor/issues/353))
+
+- **Non-ASCII agent output is no longer truncated ~6x too aggressively before
+  semantic validation.** The `validator:` grader and the dialog-trigger evaluator
+  serialized the agent output with ASCII escaping before applying their fixed
+  character budget, so every Cyrillic or CJK code point cost 6 characters and
+  every emoji 12. Non-English output reached the grader with a fraction of the
+  source material an equivalent English output would get, and the cut could land
+  mid-escape, leaving malformed JSON in the prompt. Both now serialize without
+  escaping, so the budget is measured in real characters for every language.
+  ([#356](https://github.com/microsoft/conductor/issues/356))
+
+- **An inline-expanded sub-workflow now follows the live run after a loop-back.**
+  When a loop-back route re-invoked the same sequential sub-workflow, the inline
+  graph expansion stayed pinned to the first, already-completed invocation, even
+  though double-click navigation and the Activity tab correctly tracked the live
+  one. Inline expansion now resolves newest-first, matching the rest of the
+  dashboard. ([#361](https://github.com/microsoft/conductor/issues/361))
+
+- **Every historical sub-workflow iteration is now reachable from the
+  dashboard.** In the "Subworkflow Runs (N)" list, each row resolved by slot
+  rather than by position, and every re-invocation of a sequential sub-workflow
+  shares a slot — so clicking an older, completed run always landed on the most
+  recent one. Rows now navigate to the exact run clicked, are labelled
+  `Iteration N` once a slot repeats, and the breadcrumb trail says which
+  iteration is being viewed. Following the live run (double-click, inline
+  expansion, deep links) is deliberately unchanged.
+  ([#365](https://github.com/microsoft/conductor/issues/365))
+
+- **Handled fail-open paths no longer print a full traceback at WARNING level.**
+  When a semantic validator rejected an output and the retry itself failed,
+  Conductor correctly kept the original output and carried on — but logged the
+  warning with a complete Python traceback, making a recovered run look like a
+  crash. The warning is now a single line naming the exception type and message,
+  with the traceback kept at DEBUG. The same treatment was applied to the sibling
+  best-effort paths: validator call failures and timeouts, provider session-ID
+  collection for checkpoints, checkpoint save and rotation failures, and
+  event-callback errors in `hermes`.
+  ([#357](https://github.com/microsoft/conductor/issues/357))
+
 ### Changed
+
+- **The `claude` provider now runs its agentic loop through Pydantic AI.** The
+  hand-written inner loop was replaced with a Pydantic AI runtime while keeping
+  Conductor's provider contract at the boundary — the same `AgentOutput`, event
+  vocabulary, retry and interrupt semantics, usage accounting, MCP policy, and
+  output validation. The visible gain is streaming: `claude` now emits model,
+  reasoning, and tool events as they happen rather than only at completion, so
+  the dashboard, console, and event log follow a Claude agent live the way they
+  already followed Copilot. Structured output is produced natively by the
+  runtime and still re-validated against the declared `output:` schema.
+  **This adds `pydantic-ai>=1.44.0` as a required runtime dependency**, so a
+  `conductor` upgrade pulls in a larger dependency set than before.
+  ([#355](https://github.com/microsoft/conductor/pull/355))
 
 - **`claude-agent-sdk` now loads skills natively instead of injecting them into
   every prompt.** The provider previously took the eager preamble path on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.26"
+version = "0.1.27"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -2460,8 +2460,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Release 0.1.27

Prepares the `v0.1.27` release. Previous tag: **`v0.1.26`** (2026-07-27).

## Commit audit

All **19** commits in `v0.1.26..main` were audited and given an explicit disposition — no subset, no silent omissions.

| Commit | Subject | Disposition |
|---|---|---|
| d7f3151 | docs(readme): mention the ACA provider (#341) | Internal (docs) |
| ff7ed5a | fix(executor): validate nested array item output schemas recursively (#337) | **Fixed — entry added** |
| f6b227a | feat(claude-agent-sdk): support workflow MCP servers (#335) | Added — already present |
| 67e42a8 | fix(providers): recover from schema-shape failures (#343) | Added/Fixed — already present (5 entries) |
| 774deaf | chore(deps): bump postcss (#339) | Internal (deps) |
| b24d4ed | feat: skills — opt-in knowledge bases (#180) | **Added — entry added (base feature was undocumented)** |
| c8fad5c | fix(skills): enforce `capabilities.skills` in validate (#351) | **Folded into the base skills entry** (gap never shipped) |
| f39bd63 | feat(claude-agent-sdk): honor `working_dir` (#348) | Added — already present |
| 96bdf6b | fix(claude-agent-sdk): native skills, no ambient inherit (#352) | Changed/Fixed — already present |
| 8f95a8f | fix(mcp): keep connection cleanup in owner tasks (#353) | **Fixed — entry added** |
| e65d845 | fix(engine): `ensure_ascii=False` in grader prompts (#356) | **Fixed — entry added** |
| 3c5df57 | feat(web): sub-workflow nodes expandable before they run (#360) | **Added — entry added** |
| 5dc2002 | fix(web): inline sub-workflow resolves to newest invocation (#361) | **Fixed — entry added** |
| 08bf892 | refactor(providers): run Claude through Pydantic AI (#355) | **Changed — entry added** |
| c9c20ed | chore(deps): bump cryptography 48.0.1 → 50.0.0 (#366) | Internal (deps) |
| 88a3e34 | feat(skills): paths, `SKILL.md` validation, injection bounds (#350) | Added/Fixed — already present |
| d2bbe3b | fix(dashboard): navigate to any historical sub-workflow iteration (#365) | **Fixed — entry added** |
| 7a29b8b | fix(engine): drop tracebacks from fail-open warning logs (#357) | **Fixed — entry added** |
| d5362d3 | feat(skills): discover installed user/project/plugin skills (#362) | Added — already present |

**9 new changelog entries** were written; the pre-existing `[Unreleased]` entries were reviewed and kept as-is.

The most significant gap: **#215 landed the base `skills:` feature** (`runtime.skills`, per-agent `skills:`, the bundled `conductor` skill, `capabilities.skills`) with no changelog entry at all. Every existing skills entry — discovery, path entries, injection bounds, native loading — described *refinements* of a feature that had never been announced. That entry now leads the `Added` section.

## Changelog summary

**Added** — the `skills:` feature and its bundled `conductor` knowledge base; skill discovery from installed personal/project/plugin locations; filesystem paths in `skills:`; `runtime.skill_injection` budgets; `claude-agent-sdk` MCP-server and `working_dir` support; conservative scalar-wrapper unwrapping, recoverable non-object JSON, and the `agent_parse_recovery` event; dashboard sub-workflow nodes expandable before they run.

**Fixed** — nested `array` item schemas now enforced in `output:`; MCP connections closed by their owning task; non-ASCII output no longer over-truncated before semantic validation; inline sub-workflow expansion follows the live run across loop-backs; every historical sub-workflow iteration reachable from the dashboard; no more tracebacks on handled fail-open paths; malformed `SKILL.md` no longer fails silently; several parse-recovery fixes.

**Changed** — the `claude` provider now runs through Pydantic AI (**adds a required `pydantic-ai>=1.44.0` dependency**, and `claude` now streams); `claude-agent-sdk` loads skills natively and no longer inherits ambient MCP config; `claude-agent-sdk>=0.2.82` floor.

Two entries carry explicit **behavior-change** callouts: nested array validation now fails workflows that were silently violating their own declared schema, and `claude-agent-sdk` agents stop inheriting ambient `CLAUDE.md` / settings / hooks.

## Validation

| Gate | Result |
|---|---|
| `make check` (ruff check + format + ty) | ✅ clean |
| `make test` | ✅ 4871 passed, 29 skipped, 8 deselected |
| `make validate-examples` | ✅ 39/39 successful, exit 0 |

## Lockfile note

`uv lock` re-resolution normalized away a redundant marker on `secretstorage`'s own dependency edges (`cryptography` / `jeepney` lost `sys_platform != 'win32'`). This is a no-op for the resolved install set: `secretstorage` is only reachable via `keyring` under `marker = "sys_platform == 'linux'"`, where `!= 'win32'` is always true. Verified that `uv lock` on unmodified `main` is a no-op, so this surfaces only on re-resolution and is not a dependency change. Otherwise `uv.lock` contains only the project-version bump.

## Diff scope

Only `CHANGELOG.md`, `pyproject.toml`, and `uv.lock`.

## Next step

Merging this PR will be followed by tagging the merge commit `v0.1.27` and pushing it, which triggers [`.github/workflows/release.yml`](.github/workflows/release.yml) to build and publish the GitHub Release.
