### PR TITLE
fix(cli): show non-ASCII workflow inputs literally in verbose output

### DIFF
--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -1698,7 +1698,9 @@ async def run_workflow_async(
         emitter.subscribe(console_subscriber.on_event)
 
         if inputs:
-            verbose_log_section("Workflow Inputs", json.dumps(inputs, indent=2))
+            # ``ensure_ascii=False`` so the panel shows real non-ASCII input values
+            # rather than ``\uXXXX`` escapes (issue #356).
+            verbose_log_section("Workflow Inputs", json.dumps(inputs, indent=2, ensure_ascii=False))
 
         # Apply provider override if specified.
         # Reassigning ``runtime.provider`` to a string re-triggers the

--- a/tests/test_cli/test_logging.py
+++ b/tests/test_cli/test_logging.py
@@ -480,6 +480,59 @@ class TestVerboseLogging:
             full_mode.reset(token_full)
             verbose_mode.reset(token_verbose)
 
+    async def test_workflow_inputs_section_serializes_non_ascii_unescaped(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that the Workflow Inputs section renders non-ASCII values literally."""
+        from typing import Any
+
+        from conductor.cli.run import run_workflow_async
+        from conductor.config.schema import AgentDef
+        from conductor.providers.copilot import CopilotProvider
+
+        workflow_file = tmp_path / "wf.yaml"
+        workflow_file.write_text(
+            "workflow:\n"
+            "  name: inputs-encoding\n"
+            "  entry_point: answer\n"
+            "  input:\n"
+            "    question:\n"
+            "      type: string\n"
+            "      required: true\n"
+            "agents:\n"
+            "  - name: answer\n"
+            "    prompt: 'Echo {{ workflow.input.question }}'\n"
+            "    output:\n"
+            "      answer:\n"
+            "        type: string\n"
+            "    routes:\n"
+            "      - to: $end\n"
+            "output:\n"
+            "  answer: '{{ answer.output.answer }}'\n"
+        )
+
+        def mock_handler(agent: AgentDef, prompt: str, context: dict[str, Any]) -> dict[str, Any]:
+            return {"answer": "ok"}
+
+        sections: list[tuple[str, str]] = []
+
+        with (
+            patch("conductor.providers.registry.create_provider") as mock_factory,
+            patch(
+                "conductor.cli.run.verbose_log_section",
+                side_effect=lambda title, content: sections.append((title, content)),
+            ),
+        ):
+            mock_factory.return_value = CopilotProvider(mock_handler=mock_handler)
+            await run_workflow_async(workflow_file, {"question": "план 你好"})
+
+        # Requirement: the inputs panel must show non-ASCII input values as real
+        # text, not \uXXXX escapes (issue #356).
+        payload = next(content for title, content in sections if title == "Workflow Inputs")
+        assert "план 你好" in payload
+        assert "\\u4f60" not in payload
+        assert "\\u043f" not in payload
+
     def test_verbose_log_section_skipped_in_minimal_mode(self) -> None:
         """Test that verbose_log_section skips console output in MINIMAL mode."""
         from io import StringIO


### PR DESCRIPTION
## Summary

Serialise the verbose "Workflow Inputs" panel with `ensure_ascii=False` so non-ASCII input values are shown as the text the user typed rather than `\uXXXX` escapes.

## Why

`json.dumps(inputs, indent=2)` used the default `ensure_ascii=True`, so running a workflow with a Cyrillic, CJK or emoji input rendered the panel as:

```
{
  "question": "\u043f\u043b\u0430\u043d \u4f60\u597d"
}
```

Every other JSON display path in the repo already passes `ensure_ascii=False` (issue #356, PR #359) with a comment explaining why: `gates/dialog.py`, `engine/workflow.py`, `engine/validator.py`, `engine/dialog_evaluator.py`. This call site was the last one that did not.

## Scope change

This branch originally fixed Rich parsing bracketed prompt text as console markup (#371). That problem was fixed independently on `main` by #387, which reached the same `Panel(Text(content), ...)` console fix and additionally set `markup=False` on the file-log console.

Measured on current `main`: the #371 reproduction (175 KB of link-heavy prompt) renders in 388 ms and 2.7 MB, down from 63 s and 993 MB, with the file log preserving content verbatim. The rest of this branch is therefore rebased away as redundant, and the duplicate test is dropped since `tests/test_cli/test_markup_safety.py` from #387 already covers both sinks more thoroughly.

## Validation

- New regression test `test_workflow_inputs_section_serializes_non_ascii_unescaped`, which fails without the change on `assert 'план 你好' in ...`
- Full suite: 5509 passed, 37 skipped
- `ruff check`, `ruff format --check` and `ty check` all clean
