### PR TITLE
fix(providers): forward YAML api_key to Claude provider (custom endpoints)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   three of the five sinks; two of those were reachable on a bare `conductor run`
   with no flags. Opening tags such as `[bold]` were the quieter half of the same
   bug: rich consumed them without raising and the text simply disappeared.
+- **Structured `runtime.provider` for `name: claude` no longer drops a
+  YAML-declared `api_key`** — the schema accepted `api_key` (alongside
+  `base_url` and `auth_token`) but the provider factory silently discarded it,
+  so only the `ANTHROPIC_API_KEY` env var ever reached the Anthropic client.
+  The factory now forwards it. Two credential-semantics fixes ride along so
+  the documented behavior is what the code does: the Claude provider's model
+  path now resolves credentials as a unit like the Anthropic SDK does —
+  setting either credential in YAML suppresses both `ANTHROPIC_API_KEY` and
+  `ANTHROPIC_AUTH_TOKEN`, where previously a YAML `auth_token` still let an
+  ambient `ANTHROPIC_API_KEY` ride along and the SDK sent both `X-Api-Key`
+  and `Authorization: Bearer` headers to whatever `base_url` pointed at
+  (a credential leak against gateway endpoints). And when both credentials
+  are set, Conductor now logs a warning naming that behavior instead of
+  shipping both headers silently — the same parity warning the Copilot
+  provider already logs for `api_key` + `bearer_token`. New example:
+  [`examples/claude-custom-endpoint.yaml`](examples/claude-custom-endpoint.yaml);
+  see [`docs/providers/claude.md`](docs/providers/claude.md) (Custom
+  Endpoints and Gateways).
 - **`conductor resume --web` no longer shows a running workflow as stopped** —
   a workflow that was paused from the dashboard (Stop, then Kill) recorded an
   `agent_paused` event in its event log with no `agent_resumed` counterpart.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,29 @@ to whatever `base_url` points at, which is a real credential-leak risk.
 Users who want OpenAI-environment-style behavior must opt in
 explicitly via `api_key: ${OPENAI_API_KEY}` interpolation in YAML.
 
+For `name: claude`, missing fields fall back to Anthropic environment variables:
+
+| Field | Env-var fallback |
+|---|---|
+| `base_url` | `ANTHROPIC_BASE_URL` |
+| `api_key` | `ANTHROPIC_API_KEY` |
+| `auth_token` | `ANTHROPIC_AUTH_TOKEN` |
+
+#### Field compatibility by provider
+
+| Field | `copilot` | `claude` |
+|---|---|---|
+| `base_url` | Supported | Supported |
+| `api_key` | Supported | Supported |
+| `auth_token` | Rejected | Supported |
+| `bearer_token` | Supported | Rejected |
+| `type` | Supported | Rejected |
+| `wire_api` | Supported | Rejected |
+| `headers` | Supported | Rejected |
+| `azure` | Supported | Rejected |
+| `runtime_url` | Supported | Rejected |
+| `runtime_token` | Supported | Rejected |
+
 #### Secrets
 
 `api_key` and `bearer_token` are stored as Pydantic `SecretStr` — they
@@ -190,9 +213,10 @@ visible.
 the following misconfigurations at config load time so they cannot
 silently produce a no-op SDK call:
 
-- `name != "copilot"` combined with **any** non-`name` field
-  (structured config for `claude` / `openai-agents` is not yet
-  implemented).
+- Structured provider config for other provider names is not yet implemented.
+- Unsupported structured provider fields for the selected provider name.
+  For `name: claude`, only `base_url`, `api_key`, and `auth_token` are supported
+  (fields `type`, `wire_api`, `headers`, `azure`, `bearer_token`, `runtime_url`, and `runtime_token` remain Copilot-only and are rejected for `claude`).
 - `type: azure` without an `azure: { api_version: ... }` block
   (and the reverse: `azure` block without `type: azure`).
 - Anchorless routing fields: `wire_api`, `type`, `headers`, or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,6 +175,10 @@ For `name: claude`, missing fields fall back to Anthropic environment variables:
 | `api_key` | `ANTHROPIC_API_KEY` |
 | `auth_token` | `ANTHROPIC_AUTH_TOKEN` |
 
+Unlike the Copilot chains above, the two credential rows are not independent.
+The Anthropic SDK resolves them as a unit: set either one in YAML and it reads
+neither env var. Only `base_url` falls back on its own.
+
 #### Field compatibility by provider
 
 | Field | `copilot` | `claude` |

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -8,6 +8,7 @@ The Claude provider enables Conductor workflows to use Anthropic's Claude models
 - [Architecture & Internal Design](#architecture--internal-design)
 - [Behavioral & Migration Notes](#behavioral--migration-notes)
 - [API Key Setup](#api-key-setup)
+- [Custom Endpoints and Gateways](#custom-endpoints-and-gateways)
 - [Model Selection](#model-selection)
 - [Runtime Configuration](#runtime-configuration)
 - [System Prompt](#system-prompt)
@@ -122,6 +123,80 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 ```bash
 echo '.env' >> .gitignore
+```
+
+## Custom Endpoints and Gateways
+
+You can route Claude requests through custom API gateways, LiteLLM proxies, or enterprise endpoints such as Databricks AI Gateway. Configure these targets by passing a structured `provider` object under `runtime`.
+
+### Provider Options
+
+```yaml
+workflow:
+  runtime:
+    provider:
+      name: claude
+      base_url: "https://gateway.example.com/v1"
+      api_key: "${ANTHROPIC_API_KEY}"
+      auth_token: "${GATEWAY_TOKEN}"
+```
+
+| Field | Description | Env Fallback |
+|-------|-------------|--------------|
+| `base_url` | Custom Anthropic-compatible endpoint URL | `ANTHROPIC_BASE_URL` |
+| `api_key` | Key sent in `x-api-key` header | `ANTHROPIC_API_KEY` |
+| `auth_token` | Token sent in `Authorization: Bearer` header | `ANTHROPIC_AUTH_TOKEN` |
+
+### Configuration Rules and Precedence
+
+- **YAML precedence over environment variables**: Setting a field in YAML overrides its corresponding environment variable (`api_key` in YAML overrides `ANTHROPIC_API_KEY`, `auth_token` overrides `ANTHROPIC_AUTH_TOKEN`, and `base_url` overrides `ANTHROPIC_BASE_URL`).
+- **Authentication header selection**: Use `api_key` for standard Anthropic keys (`x-api-key` header). Use `auth_token` for gateways expecting bearer authentication (`Authorization: Bearer` header). If both `api_key` and `auth_token` are configured, Conductor passes both parameters directly to the Anthropic SDK, which handles client authorization. Pick the single option your endpoint requires; `auth_token` is designed for bearer proxies.
+
+### Security Warning
+
+Secrets must always use environment variable interpolation (such as `${ANTHROPIC_API_KEY}` or `${GATEWAY_TOKEN}`), never literal string values. Conductor embeds raw workflow source code inside the `yaml_source` attribute of `workflow_started` events. Hardcoding a literal secret key in YAML exposes it in JSONL event logs and the web dashboard.
+
+### Example Configurations
+
+#### Example 1: LiteLLM or Enterprise Gateway (Bearer Auth)
+
+To route requests through a LiteLLM proxy or Databricks AI Gateway using `base_url` and `auth_token`:
+
+```yaml
+workflow:
+  name: gateway-workflow
+  runtime:
+    provider:
+      name: claude
+      base_url: "https://litellm.internal.company.com/v1"
+      auth_token: "${GATEWAY_BEARER_TOKEN}"
+    default_model: claude-sonnet-4.5
+
+agents:
+  - name: processor
+    prompt: "Process this input: {{ workflow.input.text }}"
+    routes:
+      - to: $end
+```
+
+#### Example 2: Direct Anthropic Endpoint with YAML Key
+
+To target the standard Anthropic endpoint while managing `api_key` in YAML:
+
+```yaml
+workflow:
+  name: direct-anthropic-workflow
+  runtime:
+    provider:
+      name: claude
+      api_key: "${ANTHROPIC_API_KEY}"
+    default_model: claude-sonnet-4.5
+
+agents:
+  - name: processor
+    prompt: "Summarize: {{ workflow.input.text }}"
+    routes:
+      - to: $end
 ```
 
 ## Model Selection

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -136,7 +136,7 @@ workflow:
   runtime:
     provider:
       name: claude
-      base_url: "https://gateway.example.com/v1"
+      base_url: "https://gateway.example.com"
       auth_token: "${GATEWAY_TOKEN}"
       # For an endpoint that expects an Anthropic key instead, use api_key
       # and omit auth_token. Do not set both.
@@ -145,13 +145,14 @@ workflow:
 
 | Field | Description | Env Fallback |
 |-------|-------------|--------------|
-| `base_url` | Custom Anthropic-compatible endpoint URL | `ANTHROPIC_BASE_URL` |
+| `base_url` | Custom Anthropic-compatible endpoint URL. The SDK appends `/v1/messages` itself — whether the `/v1` prefix belongs in `base_url` depends on the gateway (see the note below) | `ANTHROPIC_BASE_URL` |
 | `api_key` | Key sent in `x-api-key` header | `ANTHROPIC_API_KEY` |
 | `auth_token` | Token sent in `Authorization: Bearer` header | `ANTHROPIC_AUTH_TOKEN` |
 
 ### Configuration Rules and Precedence
 
 - **`base_url` precedence**: YAML `base_url` overrides `ANTHROPIC_BASE_URL`; when omitted, the env var is used.
+- **`base_url` and the `/v1` prefix**: the Anthropic SDK appends `/v1/messages` (and `/v1/...` for other endpoints) to `base_url` itself. LiteLLM-style gateways therefore expect `base_url` **without** `/v1` — a `base_url` of `https://gateway.example.com/v1` would send requests to `/v1/v1/messages`. Some gateways (e.g. Databricks AI Gateway) do require the `/v1` prefix in `base_url`. Check your gateway's documentation.
 - **Credential precedence**: `api_key` and `auth_token` are resolved together, not independently. Setting **either** in YAML makes the Anthropic SDK skip environment-variable credential resolution entirely, so a YAML `auth_token` also suppresses `ANTHROPIC_API_KEY`, and vice versa. If you set one credential in YAML and expect the other from the environment, it resolves to `None` with no warning.
 - **Authentication header selection**: Use `api_key` for standard Anthropic keys (`x-api-key` header). Use `auth_token` for gateways expecting bearer authentication (`Authorization: Bearer` header). **Set exactly one.** If both are configured, the Anthropic SDK does not choose between them: it sends `X-Api-Key` and `Authorization: Bearer` on every request, so your Anthropic key reaches whatever `base_url` points at. Conductor forwards both without arbitrating and logs a warning.
 
@@ -171,7 +172,7 @@ workflow:
   runtime:
     provider:
       name: claude
-      base_url: "https://litellm.internal.company.com/v1"
+      base_url: "https://litellm.internal.company.com"
       auth_token: "${GATEWAY_BEARER_TOKEN}"
     default_model: claude-sonnet-4.5
 

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -137,8 +137,10 @@ workflow:
     provider:
       name: claude
       base_url: "https://gateway.example.com/v1"
-      api_key: "${ANTHROPIC_API_KEY}"
       auth_token: "${GATEWAY_TOKEN}"
+      # For an endpoint that expects an Anthropic key instead, use api_key
+      # and omit auth_token. Do not set both.
+      # api_key: "${ANTHROPIC_API_KEY}"
 ```
 
 | Field | Description | Env Fallback |
@@ -149,8 +151,9 @@ workflow:
 
 ### Configuration Rules and Precedence
 
-- **YAML precedence over environment variables**: Setting a field in YAML overrides its corresponding environment variable (`api_key` in YAML overrides `ANTHROPIC_API_KEY`, `auth_token` overrides `ANTHROPIC_AUTH_TOKEN`, and `base_url` overrides `ANTHROPIC_BASE_URL`).
-- **Authentication header selection**: Use `api_key` for standard Anthropic keys (`x-api-key` header). Use `auth_token` for gateways expecting bearer authentication (`Authorization: Bearer` header). If both `api_key` and `auth_token` are configured, Conductor passes both parameters directly to the Anthropic SDK, which handles client authorization. Pick the single option your endpoint requires; `auth_token` is designed for bearer proxies.
+- **`base_url` precedence**: YAML `base_url` overrides `ANTHROPIC_BASE_URL`; when omitted, the env var is used.
+- **Credential precedence**: `api_key` and `auth_token` are resolved together, not independently. Setting **either** in YAML makes the Anthropic SDK skip environment-variable credential resolution entirely, so a YAML `auth_token` also suppresses `ANTHROPIC_API_KEY`, and vice versa. If you set one credential in YAML and expect the other from the environment, it resolves to `None` with no warning.
+- **Authentication header selection**: Use `api_key` for standard Anthropic keys (`x-api-key` header). Use `auth_token` for gateways expecting bearer authentication (`Authorization: Bearer` header). **Set exactly one.** If both are configured, the Anthropic SDK does not choose between them: it sends `X-Api-Key` and `Authorization: Bearer` on every request, so your Anthropic key reaches whatever `base_url` points at. Conductor forwards both without arbitrating and logs a warning.
 
 ### Security Warning
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -232,12 +232,12 @@ for env-var fallbacks, validator rules, and the security rationale.
 
 Route the Claude provider through a custom Anthropic-compatible endpoint or proxy. Demonstrates:
 - Object form of `runtime.provider` for the `claude` provider
-- `base_url` and `auth_token` (or `api_key`) forwarded to the Anthropic client
-- Secret hygiene via `${ANTHROPIC_AUTH_TOKEN:-placeholder-token}` / `${ANTHROPIC_API_KEY:-placeholder-key}` interpolation
-- BYOK `api_key` variant shown in a commented block
+- `base_url` and `api_key` forwarded to the Anthropic client
+- Secret hygiene via `${ANTHROPIC_API_KEY:-placeholder-key}` interpolation
+- Bearer-token gateway variant (`auth_token`) shown in a commented block at the bottom of the file
 
 ```bash
-# Requires ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN to be set in the environment
+# Requires ANTHROPIC_API_KEY (the bearer-token gateway variant is at the bottom of the example file)
 conductor run examples/claude-custom-endpoint.yaml --input question="What is Python?"
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -228,6 +228,21 @@ conductor run examples/copilot-local-llm.yaml --input question="What is Python?"
 See [Configuration → Custom Provider Routing](../docs/configuration.md#custom-provider-routing-ollama--vllm--azure-openai)
 for env-var fallbacks, validator rules, and the security rationale.
 
+### claude-custom-endpoint.yaml
+
+Route the Claude provider through a custom Anthropic-compatible endpoint or proxy. Demonstrates:
+- Object form of `runtime.provider` for the `claude` provider
+- `base_url` and `auth_token` (or `api_key`) forwarded to the Anthropic client
+- Secret hygiene via `${ANTHROPIC_AUTH_TOKEN:-placeholder-token}` / `${ANTHROPIC_API_KEY:-placeholder-key}` interpolation
+- BYOK `api_key` variant shown in a commented block
+
+```bash
+# Requires ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN to be set in the environment
+conductor run examples/claude-custom-endpoint.yaml --input question="What is Python?"
+```
+
+See [Claude Provider](../docs/providers/claude.md) for setup details.
+
 ## Step Types
 
 ### script-step.yaml

--- a/examples/claude-custom-endpoint.yaml
+++ b/examples/claude-custom-endpoint.yaml
@@ -1,0 +1,66 @@
+# Claude provider with a custom / bring-your-own endpoint
+#
+# Demonstrates structured ``runtime.provider`` configuration for the Claude
+# provider (issue #353). Use this when you need to route Anthropic Claude API
+# calls through a custom gateway, proxy, or region-specific endpoint instead of
+# the default https://api.anthropic.com.
+#
+# Usage:
+#
+#   export ANTHROPIC_AUTH_TOKEN=sk-ant-...
+#   conductor run examples/claude-custom-endpoint.yaml --input question="What is Python?"
+#
+# Security: never commit real API keys or tokens in this file. Always pass
+# secrets via ``${ENV_VAR:-placeholder}`` interpolation so env-free static
+# validation can still pass. Literal values leak into the ``workflow_started``
+# event's embedded ``yaml_source`` and into checkpoints. Replace the
+# placeholder defaults at runtime by setting the corresponding environment
+# variable.
+
+workflow:
+  name: claude-custom-endpoint
+  description: Route the Claude provider through a custom Anthropic-compatible endpoint
+  version: "1.0.0"
+  entry_point: answerer
+
+  runtime:
+    provider:
+      name: claude
+      base_url: ${ANTHROPIC_BASE_URL:-https://api.anthropic.com}
+      auth_token: ${ANTHROPIC_AUTH_TOKEN:-placeholder-token}
+    default_model: claude-sonnet-4
+
+  input:
+    question:
+      type: string
+      required: true
+      description: The question to answer
+
+agents:
+  - name: answerer
+    description: Answers the user's question via the configured Claude endpoint
+    prompt: |
+      You are a helpful assistant. Please answer the following question
+      clearly and concisely:
+
+      Question: {{ workflow.input.question }}
+
+      Provide a direct answer without unnecessary preamble.
+    output:
+      answer:
+        type: string
+        description: The answer to the question
+    routes:
+      - to: $end
+
+output:
+  answer: "{{ answerer.output.answer }}"
+
+# Alternative BYOK variant using ``api_key`` instead of ``auth_token`` (commented out):
+#
+#   runtime:
+#     provider:
+#       name: claude
+#       base_url: ${ANTHROPIC_BASE_URL:-https://api.anthropic.com}
+#       api_key: ${ANTHROPIC_API_KEY:-placeholder-key}
+#     default_model: claude-sonnet-4

--- a/examples/claude-custom-endpoint.yaml
+++ b/examples/claude-custom-endpoint.yaml
@@ -1,13 +1,13 @@
 # Claude provider with a custom / bring-your-own endpoint
 #
 # Demonstrates structured ``runtime.provider`` configuration for the Claude
-# provider (issue #353). Use this when you need to route Anthropic Claude API
+# provider. Use this when you need to route Anthropic Claude API
 # calls through a custom gateway, proxy, or region-specific endpoint instead of
 # the default https://api.anthropic.com.
 #
 # Usage:
 #
-#   export ANTHROPIC_AUTH_TOKEN=sk-ant-...
+#   export ANTHROPIC_API_KEY=sk-ant-...
 #   conductor run examples/claude-custom-endpoint.yaml --input question="What is Python?"
 #
 # Security: never commit real API keys or tokens in this file. Always pass
@@ -27,8 +27,8 @@ workflow:
     provider:
       name: claude
       base_url: ${ANTHROPIC_BASE_URL:-https://api.anthropic.com}
-      auth_token: ${ANTHROPIC_AUTH_TOKEN:-placeholder-token}
-    default_model: claude-sonnet-4
+      api_key: ${ANTHROPIC_API_KEY:-placeholder-key}
+    default_model: claude-sonnet-4-5
 
   input:
     question:
@@ -56,11 +56,14 @@ agents:
 output:
   answer: "{{ answerer.output.answer }}"
 
-# Alternative BYOK variant using ``api_key`` instead of ``auth_token`` (commented out):
+# Gateway variant: to authenticate against a bearer-token proxy (LiteLLM,
+# Databricks AI Gateway), replace the ``runtime:`` block above (lines 26-31)
+# with the following. Note that supplying auth_token means ANTHROPIC_API_KEY
+# is ignored.
 #
 #   runtime:
 #     provider:
 #       name: claude
-#       base_url: ${ANTHROPIC_BASE_URL:-https://api.anthropic.com}
-#       api_key: ${ANTHROPIC_API_KEY:-placeholder-key}
-#     default_model: claude-sonnet-4
+#       base_url: ${ANTHROPIC_BASE_URL:-https://gateway.example.com/v1}
+#       auth_token: ${ANTHROPIC_AUTH_TOKEN:-placeholder-token}
+#     default_model: claude-sonnet-4-5

--- a/examples/claude-custom-endpoint.yaml
+++ b/examples/claude-custom-endpoint.yaml
@@ -61,9 +61,15 @@ output:
 # with the following. Note that supplying auth_token means ANTHROPIC_API_KEY
 # is ignored.
 #
+# base_url note: the Anthropic SDK appends ``/v1/messages`` itself, so whether
+# the suffix belongs in base_url depends on the proxy. LiteLLM-style gateways
+# expect base_url WITHOUT ``/v1`` (otherwise requests land on
+# ``/v1/v1/messages``); some gateways (e.g. Databricks AI Gateway) require
+# the ``/v1`` prefix in base_url. Check your gateway's docs.
+#
 #   runtime:
 #     provider:
 #       name: claude
-#       base_url: ${ANTHROPIC_BASE_URL:-https://gateway.example.com/v1}
+#       base_url: ${ANTHROPIC_BASE_URL:-https://gateway.example.com}
 #       auth_token: ${ANTHROPIC_AUTH_TOKEN:-placeholder-token}
 #     default_model: claude-sonnet-4-5

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -2578,11 +2578,17 @@ class ProviderSettings(BaseModel):
     auth_token: SecretStr | None = None
     """Bearer token for OAuth / gateway authentication. Claude-only.
 
-    Sent as ``Authorization: Bearer <token>`` by the Anthropic SDK instead
-    of the usual ``x-api-key`` header. Use for Databricks AI Gateway,
-    LiteLLM proxies, or any endpoint that expects a bearer token.
+    Sent as ``Authorization: Bearer <token>`` by the Anthropic SDK. Use for
+    Databricks AI Gateway, LiteLLM proxies, or any endpoint that expects a
+    bearer token rather than an ``x-api-key`` credential. Set exactly one of
+    ``auth_token`` / ``api_key``: the Anthropic SDK does not choose between
+    them — when both are set it sends both ``X-Api-Key`` and
+    ``Authorization: Bearer`` headers on every request, so the API key
+    reaches whatever ``base_url`` points at.
 
-    Falls back to ``ANTHROPIC_AUTH_TOKEN`` env var when not set in YAML.
+    Credentials resolve as a unit: setting either credential in YAML
+    suppresses both ``ANTHROPIC_API_KEY`` and ``ANTHROPIC_AUTH_TOKEN`` env
+    vars. The env fallback applies only when no credential is set in YAML.
 
     Example::
 

--- a/src/conductor/providers/_pydantic_ai/agent_builder.py
+++ b/src/conductor/providers/_pydantic_ai/agent_builder.py
@@ -83,11 +83,13 @@ def _resolve_anthropic_model(
     Args:
         agent: The Conductor agent definition.
         default_model: Fallback model identifier when ``agent.model`` is unset.
-        api_key: Anthropic API key. Falls back to ``ANTHROPIC_API_KEY`` env var.
+        api_key: Anthropic API key. When either credential is passed
+            explicitly, neither ``ANTHROPIC_API_KEY`` nor
+            ``ANTHROPIC_AUTH_TOKEN`` is consulted (SDK unit semantics).
         base_url: Optional custom API endpoint.
         auth_token: Optional bearer-auth token for gateway / LiteLLM
-            endpoints. Falls back to ``ANTHROPIC_AUTH_TOKEN`` env var handled by
-            the SDK when omitted here.
+            endpoints. Falls back to ``ANTHROPIC_AUTH_TOKEN`` env var only
+            when no credential is passed explicitly.
         timeout: Request timeout in seconds. ``None`` lets the Anthropic SDK
             apply its own default.
 
@@ -97,8 +99,25 @@ def _resolve_anthropic_model(
     Raises:
         ValidationError: If no API key or auth token is available.
     """
-    effective_api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
-    effective_auth_token = auth_token or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+    # The Anthropic SDK resolves credentials as a unit: passing either
+    # credential explicitly disables env-var resolution for both. Mirror that
+    # here so an explicit credential never mixes with an ambient env
+    # credential — otherwise e.g. a YAML auth_token plus an ambient
+    # ANTHROPIC_API_KEY would send both headers to whatever base_url points
+    # at, leaking the user's Anthropic key to a gateway.
+    if api_key is not None or auth_token is not None:
+        effective_api_key = api_key
+        effective_auth_token = auth_token
+    else:
+        effective_api_key = os.environ.get("ANTHROPIC_API_KEY")
+        effective_auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+
+    if effective_api_key and effective_auth_token:
+        logger.warning(
+            "Both api_key and auth_token are set; the Anthropic SDK sends both "
+            "X-Api-Key and Authorization: Bearer headers on every request, so "
+            "the api_key reaches whatever base_url points at. Set exactly one."
+        )
 
     if not effective_api_key and not effective_auth_token:
         raise ValidationError(

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -274,6 +274,12 @@ class ClaudeProvider(AgentProvider):
             client_kwargs["auth_token"] = self._auth_token
         if self._base_url is not None:
             client_kwargs["base_url"] = self._base_url
+        if "api_key" in client_kwargs and "auth_token" in client_kwargs:
+            logger.warning(
+                "Both api_key and auth_token are set; the Anthropic SDK sends both "
+                "X-Api-Key and Authorization: Bearer headers on every request, so "
+                "the api_key reaches whatever base_url points at. Set exactly one."
+            )
         self._client = AsyncAnthropic(**client_kwargs)
 
         # Log SDK version

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -274,7 +274,14 @@ class ClaudeProvider(AgentProvider):
             client_kwargs["auth_token"] = self._auth_token
         if self._base_url is not None:
             client_kwargs["base_url"] = self._base_url
-        if "api_key" in client_kwargs and "auth_token" in client_kwargs:
+        both_passed = "api_key" in client_kwargs and "auth_token" in client_kwargs
+        both_from_env = (
+            self._api_key is None
+            and self._auth_token is None
+            and bool(os.environ.get("ANTHROPIC_API_KEY"))
+            and bool(os.environ.get("ANTHROPIC_AUTH_TOKEN"))
+        )
+        if both_passed or both_from_env:
             logger.warning(
                 "Both api_key and auth_token are set; the Anthropic SDK sends both "
                 "X-Api-Key and Authorization: Bearer headers on every request, so "

--- a/src/conductor/providers/factory.py
+++ b/src/conductor/providers/factory.py
@@ -119,11 +119,15 @@ async def create_provider(
                 )
             claude_auth_token: str | None = None
             claude_base_url: str | None = None
+            claude_api_key: str | None = None
             if provider_settings is not None and provider_settings.name == "claude":
                 if provider_settings.auth_token is not None:
                     claude_auth_token = provider_settings.auth_token.get_secret_value()
+                if provider_settings.api_key is not None:
+                    claude_api_key = provider_settings.api_key.get_secret_value()
                 claude_base_url = provider_settings.base_url
             provider = ClaudeProvider(
+                api_key=claude_api_key,
                 model=default_model,
                 temperature=temperature,
                 max_tokens=max_tokens,

--- a/tests/test_config/test_provider_settings.py
+++ b/tests/test_config/test_provider_settings.py
@@ -94,6 +94,34 @@ class TestProviderSettingsValidation:
         assert s.base_url == "https://my-gateway.example.com/api/v1"
         assert s.auth_token.get_secret_value() == "dapi-abc123"
 
+    def test_claude_structured_fields_accepted(self) -> None:
+        # ProviderSettings accepts base_url and api_key for name="claude".
+        s = ProviderSettings(
+            name="claude",
+            base_url="https://example.com/api/v1",
+            api_key="sk-secret",
+        )
+        assert s.base_url == "https://example.com/api/v1"
+        assert isinstance(s.api_key, SecretStr)
+        assert s.api_key.get_secret_value() == "sk-secret"
+        assert s.has_custom_routing()
+
+    def test_claude_api_key_and_auth_token_coexist(self) -> None:
+        # api_key and auth_token may both be set for name="claude" without conflict.
+        s = ProviderSettings(
+            name="claude",
+            base_url="https://example.com/api/v1",
+            api_key="sk-secret",
+            auth_token="bt-secret",
+        )
+        assert s.api_key.get_secret_value() == "sk-secret"
+        assert s.auth_token.get_secret_value() == "bt-secret"
+
+    def test_claude_empty_api_key_rejected(self) -> None:
+        # Empty api_key must raise ValidationError rather than silently normalize to None.
+        with pytest.raises(ValidationError, match="'api_key' is empty"):
+            ProviderSettings(name="claude", api_key="")
+
     def test_auth_token_on_non_claude_rejected(self) -> None:
         with pytest.raises(ValidationError, match="only supported when name='claude'"):
             ProviderSettings(name="copilot", auth_token="some-token", base_url="http://x/v1")
@@ -199,6 +227,15 @@ class TestProviderSettingsSerialization:
         dumped = rc.model_dump(mode="json", exclude_none=True)
         # Pydantic SecretStr renders as "**********" in model_dump
         assert dumped["provider"]["api_key"] == "**********"
+
+    def test_claude_api_key_redacted_in_json_dump(self) -> None:
+        # SecretStr redaction covers model_dump output only; literal secrets in
+        # YAML still leak via yaml_source in workflow_started, so ${ENV_VAR}
+        # interpolation is required for true secrecy.
+        s = ProviderSettings(name="claude", api_key="sk-secret")
+        dumped = s.model_dump(mode="json")
+        assert dumped["api_key"] == "**********"
+        assert "sk-secret" not in str(dumped)
 
 
 class TestHermesProviderSettings:

--- a/tests/test_providers/test_claude.py
+++ b/tests/test_providers/test_claude.py
@@ -114,6 +114,29 @@ class TestClaudeProviderInitialization:
     @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
     @patch("conductor.providers.claude.AsyncAnthropic")
     @patch("conductor.providers.claude.anthropic")
+    def test_init_with_both_credentials_warns(
+        self,
+        mock_anthropic_module: Mock,
+        mock_anthropic_class: Mock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Both api_key and auth_token must log a both-headers-sent warning."""
+        # Requirement: when both credentials reach the SDK client, Conductor
+        # warns instead of silently shipping X-Api-Key + Authorization: Bearer
+        # on every request (parity with the Copilot provider warning).
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(return_value=Mock(data=[]))
+        mock_anthropic_class.return_value = mock_client
+
+        with caplog.at_level("WARNING"):
+            ClaudeProvider(api_key="sk-key", auth_token="bearer-token")
+
+        assert any("Both api_key and auth_token" in r.message for r in caplog.records)
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
     @patch("conductor.providers.claude.logger")
     def test_sdk_version_warning_old_version(
         self,

--- a/tests/test_providers/test_claude.py
+++ b/tests/test_providers/test_claude.py
@@ -137,6 +137,32 @@ class TestClaudeProviderInitialization:
     @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
     @patch("conductor.providers.claude.AsyncAnthropic")
     @patch("conductor.providers.claude.anthropic")
+    def test_init_with_both_env_credentials_warns(
+        self,
+        mock_anthropic_module: Mock,
+        mock_anthropic_class: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Both credentials from the environment alone must also warn."""
+        # Requirement: the SDK resolves env credentials internally, so an
+        # env-only dual setup would otherwise send both headers before any
+        # agent execution warning could fire.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-env")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "env-token")
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(return_value=Mock(data=[]))
+        mock_anthropic_class.return_value = mock_client
+
+        with caplog.at_level("WARNING"):
+            ClaudeProvider()
+
+        assert any("Both api_key and auth_token" in r.message for r in caplog.records)
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
     @patch("conductor.providers.claude.logger")
     def test_sdk_version_warning_old_version(
         self,

--- a/tests/test_providers/test_claude_parameter_passing.py
+++ b/tests/test_providers/test_claude_parameter_passing.py
@@ -61,6 +61,7 @@ class TestClaudeParameterPassing:
         )
 
         mock_claude_class.assert_called_once_with(
+            api_key=None,
             model="claude-3-opus-20240229",
             temperature=0.7,
             max_tokens=4096,

--- a/tests/test_providers/test_factory.py
+++ b/tests/test_providers/test_factory.py
@@ -190,16 +190,14 @@ class TestCreateProvider:
     @patch("conductor.providers.claude.AsyncAnthropic")
     @patch("conductor.providers.claude.anthropic")
     @pytest.mark.asyncio
-    async def test_create_claude_provider_yaml_api_key_takes_precedence_over_env(
+    async def test_create_claude_provider_forwards_api_key_to_sdk_client(
         self,
         mock_anthropic_module: Any,
         mock_anthropic_class: Any,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When both YAML api_key and ANTHROPIC_API_KEY are set, YAML wins."""
+        """The YAML api_key reaches the Anthropic client as api_key, not as a bearer token."""
         from unittest.mock import AsyncMock
 
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-env")
         mock_anthropic_module.__version__ = "0.77.0"
         mock_client = MagicMock()
         mock_client.models.list = AsyncMock(return_value=MagicMock(data=[]))
@@ -213,7 +211,9 @@ class TestCreateProvider:
             provider_settings=settings,
         )
         assert isinstance(provider, ClaudeProvider)
-        assert provider._api_key == "sk-yaml"
+        assert mock_anthropic_class.call_count == 1
+        assert mock_anthropic_class.call_args.kwargs["api_key"] == "sk-yaml"
+        assert "auth_token" not in mock_anthropic_class.call_args.kwargs
         await provider.close()
 
     @patch("conductor.providers.factory.ANTHROPIC_SDK_AVAILABLE", True)

--- a/tests/test_providers/test_factory.py
+++ b/tests/test_providers/test_factory.py
@@ -8,6 +8,7 @@ from pydantic import SecretStr
 
 from conductor.config.schema import ProviderSettings, ToolOutputConfig
 from conductor.exceptions import ProviderError
+from conductor.providers.claude import ClaudeProvider
 from conductor.providers.copilot import CopilotProvider
 from conductor.providers.factory import create_provider
 
@@ -154,6 +155,91 @@ class TestCreateProvider:
         assert provider._timeout == 300.0
         assert provider._tool_output_config.max_chars == 2500
         assert provider._tool_output_config.spill_dir == "/tmp/claude-out"
+
+    @patch("conductor.providers.factory.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_create_claude_provider_extracts_api_key_from_settings(
+        self,
+        mock_anthropic_module: Any,
+        mock_anthropic_class: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """YAML api_key for name='claude' is forwarded to ClaudeProvider._api_key."""
+        from unittest.mock import AsyncMock
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = MagicMock()
+        mock_client.models.list = AsyncMock(return_value=MagicMock(data=[]))
+        mock_client.close = AsyncMock(return_value=None)
+        mock_anthropic_class.return_value = mock_client
+
+        settings = ProviderSettings(name="claude", api_key=SecretStr("sk-yaml"))
+        provider = await create_provider(
+            "claude",
+            validate=False,
+            provider_settings=settings,
+        )
+        assert isinstance(provider, ClaudeProvider)
+        assert provider._api_key == "sk-yaml"
+        await provider.close()
+
+    @patch("conductor.providers.factory.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_create_claude_provider_yaml_api_key_takes_precedence_over_env(
+        self,
+        mock_anthropic_module: Any,
+        mock_anthropic_class: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When both YAML api_key and ANTHROPIC_API_KEY are set, YAML wins."""
+        from unittest.mock import AsyncMock
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-env")
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = MagicMock()
+        mock_client.models.list = AsyncMock(return_value=MagicMock(data=[]))
+        mock_client.close = AsyncMock(return_value=None)
+        mock_anthropic_class.return_value = mock_client
+
+        settings = ProviderSettings(name="claude", api_key=SecretStr("sk-yaml"))
+        provider = await create_provider(
+            "claude",
+            validate=False,
+            provider_settings=settings,
+        )
+        assert isinstance(provider, ClaudeProvider)
+        assert provider._api_key == "sk-yaml"
+        await provider.close()
+
+    @patch("conductor.providers.factory.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_create_claude_provider_api_key_defaults_to_none(
+        self,
+        mock_anthropic_module: Any,
+        mock_anthropic_class: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without YAML api_key and with no env key, ClaudeProvider._api_key remains None."""
+        from unittest.mock import AsyncMock
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = MagicMock()
+        mock_client.models.list = AsyncMock(return_value=MagicMock(data=[]))
+        mock_client.close = AsyncMock(return_value=None)
+        mock_anthropic_class.return_value = mock_client
+
+        provider = await create_provider("claude", validate=False)
+        assert isinstance(provider, ClaudeProvider)
+        assert provider._api_key is None
+        await provider.close()
 
     @patch("conductor.providers.factory.ANTHROPIC_SDK_AVAILABLE", True)
     @patch("conductor.providers.claude.AsyncAnthropic")

--- a/tests/test_providers/test_pydantic_ai_agent_builder.py
+++ b/tests/test_providers/test_pydantic_ai_agent_builder.py
@@ -583,8 +583,12 @@ class TestClientConstruction:
         assert isinstance(pydantic_agent.model, AnthropicModel)
         assert pydantic_agent.model.client.timeout == 120.0
 
-    def test_auth_token_reaches_client(self) -> None:
-        """The provided auth_token must reach the Anthropic SDK client."""
+    def test_auth_token_reaches_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The provided auth_token must reach the Anthropic SDK client as the sole credential."""
+        # Requirement: an explicit auth_token is sent as Authorization: Bearer,
+        # and the ambient ANTHROPIC_API_KEY must not ride along (the Anthropic
+        # SDK sends both headers when both credentials are set).
+        monkeypatch.delenv("ANTHROPIC_API_KEY")
         agent_def = AgentDef(name="token_agent")
 
         pydantic_agent = build_agent(
@@ -596,6 +600,67 @@ class TestClientConstruction:
 
         assert isinstance(pydantic_agent.model, AnthropicModel)
         assert pydantic_agent.model.client.auth_token == "bearer-token"
+        assert pydantic_agent.model.client.auth_headers == {"Authorization": "Bearer bearer-token"}
+
+    def test_api_key_reaches_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The provided api_key must reach the Anthropic SDK client as the sole credential."""
+        # Requirement: an explicit api_key is sent as X-Api-Key, and an ambient
+        # ANTHROPIC_AUTH_TOKEN must not ride along (SDK unit semantics).
+        monkeypatch.delenv("ANTHROPIC_API_KEY")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "ambient-token")
+        agent_def = AgentDef(name="key_agent")
+
+        pydantic_agent = build_agent(
+            agent_def,
+            system_prompt="",
+            rendered_prompt="",
+            api_key="sk-explicit",
+        )
+
+        assert isinstance(pydantic_agent.model, AnthropicModel)
+        assert pydantic_agent.model.client.auth_headers == {"X-Api-Key": "sk-explicit"}
+
+    def test_explicit_auth_token_suppresses_ambient_env_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit auth_token must not mix with an ambient ANTHROPIC_API_KEY."""
+        # Requirement: credentials resolve as a unit (SDK semantics) — an
+        # explicit credential disables env credential resolution, otherwise the
+        # ambient key would leak to whatever base_url points at via X-Api-Key.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+        agent_def = AgentDef(name="unit_agent")
+
+        pydantic_agent = build_agent(
+            agent_def,
+            system_prompt="",
+            rendered_prompt="",
+            auth_token="bearer-token",
+        )
+
+        assert isinstance(pydantic_agent.model, AnthropicModel)
+        assert pydantic_agent.model.client.auth_headers == {"Authorization": "Bearer bearer-token"}
+
+    def test_both_credentials_warns(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Setting both credentials must log a both-headers-sent warning."""
+        # Requirement: when both credentials are effectively set, Conductor
+        # warns instead of silently shipping both auth headers (parity with
+        # the Copilot provider's api_key/bearer_token warning).
+        monkeypatch.delenv("ANTHROPIC_API_KEY")
+        monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+        agent_def = AgentDef(name="both_agent")
+
+        with caplog.at_level("WARNING"):
+            build_agent(
+                agent_def,
+                system_prompt="",
+                rendered_prompt="",
+                api_key="sk-explicit",
+                auth_token="bearer-token",
+            )
+
+        assert any("Both api_key and auth_token" in r.message for r in caplog.records)
 
 
 class TestToolSchemaSanitization:


### PR DESCRIPTION
## Summary

Enables the Claude provider to accept a YAML-declared `api_key` in structured `runtime.provider` config, completing the custom-endpoint story for `name: claude`. Previously `base_url` and `auth_token` were accepted by the schema but `api_key` was silently dropped at the factory boundary, forcing users to rely solely on the `ANTHROPIC_API_KEY` env var.

- **`fix(providers)`**: `ProviderRegistry` now forwards `settings.api_key` to `ClaudeProvider`, so a YAML `api_key` reaches the Anthropic client instead of being dropped.
- **`fix(providers)`**: `_resolve_anthropic_model` now resolves credentials as a unit, mirroring the Anthropic SDK — setting either credential in YAML suppresses both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`. Previously a YAML `auth_token` still let an ambient `ANTHROPIC_API_KEY` ride along, and the SDK sent both `X-Api-Key` and `Authorization: Bearer` headers to whatever `base_url` pointed at (a credential leak against gateway endpoints).
- **`fix(providers)`**: when both credentials are effectively set, Conductor now logs a warning naming the both-headers-sent behavior (parity with the Copilot provider's `api_key`/`bearer_token` warning), at both Anthropic client construction points.
- **`test(config)`**: schema-level regression tests lock the accepted structured fields for `claude`, `SecretStr` redaction in `model_dump(mode="json")`, `api_key`+`auth_token` coexistence, and rejection of empty-string secrets. Factory tests assert the YAML `api_key` reaches `AsyncAnthropic` as `api_key`; agent-builder tests assert the exact `auth_headers` surface for each credential, including ambient-env suppression.
- **`docs(providers)`** / **`docs(configuration)`**: custom-endpoint and gateway-auth documentation for Claude, including the credential-unit resolution rule and the "set exactly one" header-selection rule; the stale "not yet implemented" claim in `docs/configuration.md` is corrected with a Copilot-vs-Claude field compatibility table.
- **`docs(examples)`**: new `examples/claude-custom-endpoint.yaml` (env-interpolated with `:-placeholder` defaults so `make validate-examples` passes with no env set) + README row.

When both `api_key` and `auth_token` are set, the Anthropic SDK does not arbitrate: it sends both `X-Api-Key` and `Authorization: Bearer` on every request. Conductor forwards both without arbitrating and logs a warning; the docs direct users to set exactly one.

## Test plan

- [x] `make check` (ruff + ty) — clean
- [x] `make test` — 5278 passed, 47 skipped
- [x] `uv run pytest tests/test_config/test_provider_settings.py tests/test_providers/test_factory.py tests/test_providers/test_claude_parameter_passing.py` — passes
- [x] `conductor validate examples/claude-custom-endpoint.yaml` in a clean env — passes
- [x] Mocked pytest asserting the YAML `api_key` reaches `AsyncAnthropic` as `api_key` (and not as `auth_token`)
- [x] `auth_headers`-level tests proving an explicit credential never mixes with an ambient env credential
- [ ] **Live proxy run** (`ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY` against a real gateway) — deferred to PR review; no out-of-band credentials available in the authoring environment

## Notes

- CHANGELOG entry added under Unreleased → Fixed.
- Scope remains minimal: the factory plumbing is 4 lines; the other production-code changes are the credential-unit resolution in `_resolve_anthropic_model` and the dual-credential warnings.
- Known follow-up (not in this PR): `bearer_token` (Copilot) vs `auth_token` (Claude) naming divergence — a non-breaking `bearer_token` alias for Claude was identified as a possible future improvement.
