### PR TITLE
fix(cli): render verbose log content literally instead of as Rich markup

### DIFF
--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -136,16 +136,23 @@ def close_file_logging() -> None:
 def verbose_log(message: str, style: str = "dim") -> None:
     """Log a message if verbose mode is enabled.
 
+    ``message`` is rendered literally rather than as console markup, for the
+    same reason as :func:`verbose_log_section`: callers interpolate names,
+    paths and warning text that conductor does not control, and a stray
+    ``[/bold]`` in any of them would otherwise raise ``MarkupError``.
+
     Args:
-        message: The message to log.
-        style: Rich style for the message.
+        message: The message to log. Rendered literally, never as markup.
+        style: Rich style applied to the message on the console.
     """
+    from rich.text import Text
+
     from conductor.cli.app import is_verbose
 
     if is_verbose():
-        _verbose_console.print(f"[{style}]{message}[/{style}]")
+        _verbose_console.print(Text(message, style=style))
     if _file_console is not None:
-        _file_console.print(message)
+        _file_console.print(Text(message))
 
 
 def _describe_provider(provider: ProviderSettings) -> str:
@@ -317,10 +324,18 @@ def verbose_log_section(title: str, content: str) -> None:
     They are shown in FULL mode (default) but skipped in MINIMAL mode (--quiet).
     File logging always receives full content regardless of console verbosity.
 
+    ``content`` is untrusted — rendered prompts carry agent output, tool
+    arguments and plan text — so it is wrapped in :class:`~rich.text.Text` and
+    rendered literally. Passing the raw ``str`` would make Rich parse it as
+    console markup, and a bare ``[/bold]`` in an agent's own words is enough to
+    raise ``MarkupError`` and take the workflow down with it.
+
     Args:
         title: Section title.
-        content: Section content.
+        content: Section content. Rendered literally, never as markup.
     """
+    from rich.text import Text
+
     from conductor.cli.app import is_full, is_verbose
 
     # Sections are detail-level: show on console only in FULL mode
@@ -329,12 +344,14 @@ def verbose_log_section(title: str, content: str) -> None:
     if not should_console and not should_file:
         return
 
+    body = Text(content)
+
     if should_console:
-        _verbose_console.print(Panel(content, title=f"[cyan]{title}[/cyan]", border_style="dim"))
+        _verbose_console.print(Panel(body, title=f"[cyan]{title}[/cyan]", border_style="dim"))
 
     # File always gets full untruncated content
     if _file_console is not None:
-        _file_console.print(Panel(content, title=title, border_style="dim"))
+        _file_console.print(Panel(body, title=title, border_style="dim"))
 
 
 def verbose_log_timing(operation: str, elapsed: float) -> None:

--- a/tests/test_cli/test_logging.py
+++ b/tests/test_cli/test_logging.py
@@ -504,6 +504,91 @@ class TestVerboseLogging:
             full_mode.reset(token_full)
             verbose_mode.reset(token_verbose)
 
+    def test_verbose_log_section_rejects_markup_interpretation(self) -> None:
+        """Content that looks like Rich markup must not be parsed as markup.
+
+        Rendered prompts carry agent output verbatim, so a bare ``[/bold]`` in
+        an agent's own words reaches this function. Passing the raw string to
+        ``Panel`` made Rich parse it and raise ``MarkupError``, killing the
+        workflow mid-run.
+        """
+        import re
+        from io import StringIO
+
+        from rich.console import Console
+
+        from conductor.cli.run import verbose_log_section
+
+        # A closing tag with no opening tag — the exact shape that crashed.
+        content = "Valid metadata such as `[/bold]` raises Rich MarkupError."
+        output = StringIO()
+        token_verbose = verbose_mode.set(True)
+        token_full = full_mode.set(True)
+        try:
+            with patch(
+                "conductor.cli.run._verbose_console",
+                Console(file=output, force_terminal=True, width=200),
+            ):
+                verbose_log_section("Prompt", content)
+            clean_text = re.sub(r"\x1b\[[0-9;]*m", "", output.getvalue())
+            assert "[/bold]" in clean_text
+        finally:
+            full_mode.reset(token_full)
+            verbose_mode.reset(token_verbose)
+
+    def test_verbose_log_section_file_output_rejects_markup(self) -> None:
+        """The file console must not parse markup either.
+
+        File logging is enabled for every ``--web-bg`` run regardless of
+        console verbosity, so this path is reached even when nothing is
+        printed to the terminal.
+        """
+        from io import StringIO
+
+        from rich.console import Console
+
+        from conductor.cli.run import verbose_log_section
+
+        content = "unbalanced [/bold] tag"
+
+        file_output = StringIO()
+        token_verbose = verbose_mode.set(False)
+        token_full = full_mode.set(False)
+        try:
+            with patch(
+                "conductor.cli.run._file_console",
+                Console(file=file_output, width=200),
+            ):
+                verbose_log_section("Prompt", content)
+            assert "[/bold]" in file_output.getvalue()
+        finally:
+            full_mode.reset(token_full)
+            verbose_mode.reset(token_verbose)
+
+    def test_verbose_log_rejects_markup_interpretation(self) -> None:
+        """``verbose_log`` shares the flaw: it interpolated into a markup string."""
+        import re
+        from io import StringIO
+
+        from rich.console import Console
+
+        from conductor.cli.run import verbose_log
+
+        content = "plugin warning: [/dim] unbalanced"
+
+        output = StringIO()
+        token = verbose_mode.set(True)
+        try:
+            with patch(
+                "conductor.cli.run._verbose_console",
+                Console(file=output, force_terminal=True, width=200),
+            ):
+                verbose_log(content)
+            clean_text = re.sub(r"\x1b\[[0-9;]*m", "", output.getvalue())
+            assert "[/dim]" in clean_text
+        finally:
+            verbose_mode.reset(token)
+
     def test_verbose_log_section_skipped_in_silent_mode(self) -> None:
         """Test that verbose_log_section skips console output in SILENT mode."""
         from io import StringIO


### PR DESCRIPTION
Fixes #402.

## The bug

`verbose_log_section` passed its content straight to `Panel`, and `verbose_log` interpolated its message into `f"[{style}]{message}[/{style}]"`. Rich parses a plain `str` as console markup, so any square-bracket tag in that text was interpreted rather than displayed.

That content is untrusted — `verbose_log_section` is called with the rendered prompt (`executor/agent.py:435`), which carries agent output, plan text and tool arguments verbatim. An agent that writes `[/bold]` in a code span produces an unbalanced closing tag, Rich raises `MarkupError`, and the exception propagates out of the log call and **kills the workflow**.

It killed a real run at iteration 45, after seven epics had been committed. The trigger is worth reading twice: a review agent had filed a finding about unescaped markup crashing a Textual screen, quoting `[/bold]` as the example. Rendering the prompt that carried that finding to the next agent raised the exact error the finding described.

The file-console path makes this more than a verbosity-flag bug — file logging is on for every `--web-bg` run regardless of console verbosity, so background runs are exposed even with `--quiet`.

## The fix

Wrap both in `rich.text.Text`, which renders literally. `Text` takes a style directly, so the console output keeps its formatting and the file output is unchanged apart from no longer being parsed.

## Tests

Three regression tests in `tests/test_cli/test_logging.py`, each asserting the literal tag survives to the output:

- `test_verbose_log_section_rejects_markup_interpretation` — console path
- `test_verbose_log_section_file_output_rejects_markup` — file path, reached with console verbosity off (the `--web-bg` case)
- `test_verbose_log_rejects_markup_interpretation` — `verbose_log`

Verified they fail on `main` with `MarkupError` and pass with the fix.

## Verification

- `make check` — ruff check, ruff format, ty: all pass
- `uv run pytest tests/test_cli/` — 529 passed, 3 skipped

## Note on scope

I fixed `verbose_log` alongside `verbose_log_section` even though only the latter caused the crash: it is the same one-line flaw in the adjacent function in the same file, and its callers interpolate plugin warnings and MCP server names that conductor does not control either. Happy to split it out if you would rather keep the change to the reproduced path.

`rich.markup.escape` is already used correctly in `cli/doctor.py` and `gates/interrupt.py`, so these two call sites look like they simply predate that pattern. #402 suggests a broader audit as follow-up.