### PR TITLE
fix(executor): make markdown linkification linear

### DIFF
--- a/src/conductor/executor/linkify.py
+++ b/src/conductor/executor/linkify.py
@@ -52,13 +52,10 @@ _LINKABLE_SUFFIXES = tuple(LINKABLE_EXTENSIONS)
 # ---------------------------------------------------------------------------
 
 # Fenced code block (``` or ~~~, with optional language tag)
-_FENCED_CODE_RE = re.compile(r"^(`{3,}|~{3,}).*?^\1", re.MULTILINE | re.DOTALL)
+_FENCED_CODE_RE = re.compile(r"^(`{3,}+|~{3,}+)[^\n]*\n.*?^\1", re.MULTILINE | re.DOTALL)
 
 # Inline code span (`...`)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
-
-# Existing markdown links: [text](url) or [text][ref]
-_EXISTING_LINK_RE = re.compile(r"\[[^\]]*\]\([^)]*\)|\[[^\]]*\]\[[^\]]*\]")
 
 # Bare URL: http(s)://... terminated at whitespace or common punctuation
 _URL_RE = re.compile(
@@ -121,9 +118,10 @@ def _linkify_with_protection(text: str, base_dir: Path | None) -> str:
     """
     protected: list[tuple[int, int]] = []
 
-    for pattern in (_FENCED_CODE_RE, _INLINE_CODE_RE, _EXISTING_LINK_RE):
+    for pattern in (_FENCED_CODE_RE, _INLINE_CODE_RE):
         for m in pattern.finditer(text):
             protected.append((m.start(), m.end()))
+    protected.extend(_existing_link_spans(text))
 
     # Sort and merge overlapping spans
     protected.sort()
@@ -149,6 +147,39 @@ def _linkify_with_protection(text: str, base_dir: Path | None) -> str:
         result.append(_linkify_segment(text[prev_end:], base_dir))
 
     return "".join(result)
+
+
+def _existing_link_spans(text: str) -> list[tuple[int, int]]:
+    """Find existing ``[text](url)`` and ``[text][ref]`` links."""
+    spans: list[tuple[int, int]] = []
+    search_start = 0
+    unavailable_closers: set[str] = set()
+
+    while (start := text.find("[", search_start)) != -1:
+        label_end = text.find("]", start + 1)
+        if label_end == -1:
+            break
+
+        target_start = label_end + 1
+        if target_start == len(text) or text[target_start] not in "([":
+            search_start = target_start
+            continue
+
+        closer = ")" if text[target_start] == "(" else "]"
+        if closer in unavailable_closers:
+            search_start = target_start + 1
+            continue
+
+        target_end = text.find(closer, target_start + 1)
+        if target_end == -1:
+            unavailable_closers.add(closer)
+            search_start = target_start + 1
+            continue
+
+        spans.append((start, target_end + 1))
+        search_start = target_end + 1
+
+    return spans
 
 
 def _linkify_segment(segment: str, base_dir: Path | None) -> str:
@@ -200,19 +231,11 @@ def _try_linkify_path(token: str, base_dir: Path | None) -> str | None:
     Returns the markdown link string, or None if the token is not a file path.
     """
     # Strip leading/trailing punctuation that isn't part of the path
-    prefix = ""
-    suffix = ""
-    stripped = token
-
-    # Strip common leading chars
-    while stripped and stripped[0] in "([\"'":
-        prefix += stripped[0]
-        stripped = stripped[1:]
-
-    # Strip common trailing chars
-    while stripped and stripped[-1] in ")]\"'.,;:!?":
-        suffix = stripped[-1] + suffix
-        stripped = stripped[:-1]
+    stripped = token.lstrip("([\"'")
+    prefix = token[: len(token) - len(stripped)]
+    path = stripped.rstrip(")]\"'.,;:!?")
+    suffix = stripped[len(path) :]
+    stripped = path
 
     if not stripped:
         return None

--- a/tests/test_executor/test_linkify.py
+++ b/tests/test_executor/test_linkify.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import time
+from collections.abc import Callable
 from pathlib import Path
+
+import pytest
 
 from conductor.executor.linkify import linkify_markdown
 
@@ -61,6 +65,10 @@ class TestUrlLinking:
 
     def test_preserves_existing_markdown_link(self) -> None:
         text = "See [docs](https://example.com/docs) for more"
+        assert linkify_markdown(text) == text
+
+    def test_preserves_existing_reference_link(self) -> None:
+        text = "See [docs][reference] for more"
         assert linkify_markdown(text) == text
 
     def test_url_in_inline_code_untouched(self) -> None:
@@ -211,3 +219,24 @@ class TestCombined:
         """Paths that escape base_dir should not be linked."""
         result = linkify_markdown("See ../../../etc/passwd.txt", base_dir=tmp_path)
         assert "[../../../etc/passwd.txt]" not in result
+
+
+@pytest.mark.performance
+@pytest.mark.parametrize(
+    "make_text",
+    [
+        pytest.param(lambda size: "`" * size, id="backticks"),
+        pytest.param(lambda size: "[" * (size // 2) + "]" * (size // 2), id="brackets"),
+        pytest.param(lambda size: '"' * size, id="punctuation"),
+    ],
+)
+def test_pathological_inputs_scale_near_linearly(make_text: Callable[[int], str]) -> None:
+    """Doubling pathological input must not quadruple processing time."""
+    elapsed: list[float] = []
+    for size in (20_000, 40_000):
+        text = make_text(size)
+        start = time.perf_counter()
+        assert linkify_markdown(text) == text
+        elapsed.append(time.perf_counter() - start)
+
+    assert elapsed[1] < elapsed[0] * 3 + 0.01


### PR DESCRIPTION
Closes #395.

  ## What

  `linkify_markdown` could take seconds to process gate and dialog text containing long runs of backticks, brackets, or path punctuation.

  Because linkification runs synchronously, a pathological prompt blocked the event loop along with dashboard updates, concurrent agents, and timeout enforcement.

  ## Why

  Three paths repeatedly processed the remaining input:

  - The fenced-code regex could backtrack through a long opening fence one character at a time.
  - The existing-link regex retried unmatched `[` characters from every position.
  - Path punctuation was removed with repeated string slices, copying the remaining token on each iteration.

  On the original implementation, doubling a backtick run from 10,000 to 20,000 characters increased local runtime from 0.49s to 1.97s.

  ## How

  - Make fenced-code openers possessive and require the opener line to end with a newline.
  - Replace the existing-link regex with a forward-only scanner for `[text](url)` and `[text][ref]`.
  - Replace character-at-a-time path trimming with `str.lstrip()` and `str.rstrip()`.
  - Add regression coverage for reference links and near-linear scaling across the reported pathological inputs.

  The change stays inside the shared linkification helper, so all gate and dialog callers use the same fix.

  ## Validation

  - `pytest tests/test_executor/test_linkify.py` — 33 passed
  - `ruff check src tests` — passed
  - `ruff format --check src tests` — passed
  - `ty check src/conductor/executor/linkify.py` — passed
  - 40,000/80,000-character backtick runs completed in 0.0022s/0.0042s locally
  - 40,000/80,000-character bracket runs completed in 0.0018s/0.0045s locally

The full local Windows suite is not reported as passing because platform-specific tests outside this module failed. The focused linkification tests and all checks listed above pass.