### PR TITLE
fix(cli): stop parsing runtime data as rich console markup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,8 @@ step-by-step checklist.
 
 - **duration.py**: `parse_duration(value)` shared helper. Accepts plain `int`/`float` seconds, or strings with `ms`/`s`/`m`/`h` suffix. Raises `ValueError` (nests cleanly inside Pydantic `ValidationError`). Rejects booleans. Bounds enforcement (e.g. > 0, 24h cap) lives in callers so the parser can be reused.
 
+- **console.py**: `make_console()` / `styled()` / `join()` — the markup-safety primitives (issue #406). A leaf module (like `duration.py`) with no conductor imports, deliberately **top-level rather than under `cli/`** because `gates/` and `providers/` need it and must not import from `cli/`. `make_console` locks `markup=False`, inverting Rich's default so an interpolated runtime value is literal unless it asks to be styled; it *rejects* a `markup=` kwarg rather than allowing an override. `styled("<template>", ...)` parses the template's markup — conductor's own literal — while inserting values verbatim. It works by replacing each field with a **length-matched filler run**, parsing once, then substituting by offset: matching the width keeps the parsed template's spans valid, which is what makes nested styling around a placeholder (`[bold][red]{}[/red][/bold]`) come out right. Reading `spans[0].style` and re-applying it — the obvious alternative — collapses the nesting. A value that is already a `Text` is spliced in with its own spans re-anchored, so pre-styled fragments compose (`styled("{} {}", CHECK, name)`); without that, `format()` would flatten it and silently drop the colour from every doctor table cell. `join(sep, parts)` exists because `Text.join` requires every part to already be a `Text`, while the common shape here is a `content_lines` list mixing conductor-styled fragments with plain runtime values. `rich.markup.escape` is deliberately unused throughout: the parser treats `\[` as an escaped bracket, so `\[0-9\]+` renders as `[0-9\]+` whether escaped or not, whereas a `Text` is byte-exact. See the Console Output section under Code Style.
+
 - **providers/**: SDK provider abstraction
   - `base.py` - `AgentProvider` ABC defining `execute()`, `validate_connection()`, `close()`
   - `_output_shape.py` - `normalize_agent_output(content, schema)` — the single entry point providers call before `validate_output` (issue #343). It raises `ValidationError` when the parsed response is not a JSON object (a bare `42`/`null`/array), because `validate_output` would otherwise either raise `TypeError` from a membership test (numbers, booleans, null) or report a misleading "missing required field" (strings, arrays). It then applies `unwrap_scalar_wrappers`: fires only when the schema declares `string`/`number`/`boolean`, a `dict` arrived, and **exactly one** candidate slot has the expected type. Candidate slots are the field's own name plus the generic `value`/`result` keys, deduped so a field literally named `value` or `result` isn't rejected as ambiguous against itself. Two matches count as ambiguous; any other key shape is ignored. Both are left untouched (same object identity) so the caller re-prompts rather than guessing — this is what stops `{"answer": {"error": "..."}}` being laundered into an answer. Every unwrap logs a warning, naming discarded sibling keys when there are any. Kept out of `executor/output.py` on purpose — see the note there.
@@ -221,7 +223,7 @@ log. See issue #116.
 ## Tests Structure
 
 Tests mirror source structure in `tests/`:
-- `test_cli/` - CLI command tests, e2e tests
+- `test_cli/` - CLI command tests, e2e tests. `test_markup_guards.py` is the one that keeps issue #406 closed: it reads `src/conductor` with `ast` and fails with file:line when a new call site builds a bare `Console`, hands an interpolated string to a `Panel` title or a `Prompt`, passes an f-string to `Text.from_markup`, or leaves a markup literal at a print/cell sink. Each rule has a negative control, because a source-scanning check that quietly matches nothing reports "all clear" forever. `test_markup_injection.py` covers the same ground behaviourally, driving the real commands — the two layers are not redundant: the guard alone cannot prove `styled` renders correctly, and the behavioural tests alone cannot stop the *next* call site, which is the actual failure mode here
 - `test_config/` - Schema validation, loader tests
 - `test_engine/` - Workflow, router, context, limits tests
 - `test_executor/` - Agent, template, output tests
@@ -257,6 +259,50 @@ When adding new fields to `LimitEnforcer`:
 - Type hints required, checked with ty (Red Knot)
 - Pydantic v2 for data validation
 - async/await for all provider operations
+
+### Console Output
+
+**Never put a runtime value into a string that Rich will parse as markup.**
+Rich reads `[...]` in a plain `str` as a style tag, so a workflow name, an
+agent name, a plugin name from a cloned repo, a path, or an `str(e)` that
+happens to contain a bracketed token is interpreted as styling. In rich a
+token is a tag when its **first character** is lowercase, `#`, `/` or `@`,
+which splits three ways: `[0]` renders literally, `[task1]` is **silently
+deleted**, and `[/etc/x]` raises `MarkupError` out of the print call. The
+quiet half is the dangerous one — a listing that drops half a name looks
+like it worked. Note `style=` does **not** disable parsing (issues #382,
+#387, #406).
+
+The rules, all enforced by `tests/test_cli/test_markup_guards.py`, which
+reads the source and reports file:line:
+
+- **Build every console with `conductor.console.make_console()`.** It locks
+  `markup=False`, so a plain string is literal unless it asks to be styled.
+  This covers plain prints, `Panel` bodies, `Table` cells, headers, titles
+  and captions, and `Rule` titles. A `Console` subclass must lock it too
+  (see `cli/run.py::_SilentAwareConsole`).
+- **Style with `conductor.console.styled("<template>", value, ...)`.** The
+  template is conductor's own literal and is parsed; values are inserted
+  verbatim and never reach the parser. A value that is already a `Text` is
+  spliced in with its styling intact, so pre-styled fragments compose. Use
+  `Text.from_markup("...")` when there is nothing to interpolate, and
+  `conductor.console.join(sep, parts)` to join a list mixing `str` and
+  `Text` (`Text.join` requires every part to be a `Text` already).
+- **`Panel(title=)`, `Panel(subtitle=)` and `Prompt`/`Confirm`/`IntPrompt`
+  prompts must be handed a `Text`.** Rich calls `Text.from_markup` on those
+  unconditionally (`rich/panel.py`, `rich/prompt.py`), so `markup=False`
+  never reaches them. This is the trap that made #387 incomplete: it fixed
+  the panel *body* and left the `title=` f-string one line away.
+- **Do not use `rich.markup.escape`.** It is not byte-exact — the parser
+  treats `\[` as an escaped bracket, so an ordinary regex like `\[0-9\]+`
+  renders as `[0-9\]+` whether or not it was escaped first. Building a
+  `Text` avoids the parser entirely.
+- Typer's own `help=` / `epilog=` are **outside** this convention: Typer
+  renders them through its own console.
+
+The worst outcome of forgetting is now a visible literal `[green]` in the
+output rather than a crash or a silent deletion, and rule D of the guard
+catches that statically.
 
 ### Provider Parity
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ step-by-step checklist.
 
 - **duration.py**: `parse_duration(value)` shared helper. Accepts plain `int`/`float` seconds, or strings with `ms`/`s`/`m`/`h` suffix. Raises `ValueError` (nests cleanly inside Pydantic `ValidationError`). Rejects booleans. Bounds enforcement (e.g. > 0, 24h cap) lives in callers so the parser can be reused.
 
-- **console.py**: `make_console()` / `styled()` / `join()` — the markup-safety primitives (issue #406). A leaf module (like `duration.py`) with no conductor imports, deliberately **top-level rather than under `cli/`** because `gates/` and `providers/` need it and must not import from `cli/`. `make_console` locks `markup=False`, inverting Rich's default so an interpolated runtime value is literal unless it asks to be styled; it *rejects* a `markup=` kwarg rather than allowing an override. `styled("<template>", ...)` parses the template's markup — conductor's own literal — while inserting values verbatim. It works by replacing each field with a **length-matched filler run**, parsing once, then substituting by offset: matching the width keeps the parsed template's spans valid, which is what makes nested styling around a placeholder (`[bold][red]{}[/red][/bold]`) come out right. Reading `spans[0].style` and re-applying it — the obvious alternative — collapses the nesting. A value that is already a `Text` is spliced in with its own spans re-anchored, so pre-styled fragments compose (`styled("{} {}", CHECK, name)`); without that, `format()` would flatten it and silently drop the colour from every doctor table cell. `join(sep, parts)` exists because `Text.join` requires every part to already be a `Text`, while the common shape here is a `content_lines` list mixing conductor-styled fragments with plain runtime values. `rich.markup.escape` is deliberately unused throughout: the parser treats `\[` as an escaped bracket, so `\[0-9\]+` renders as `[0-9\]+` whether escaped or not, whereas a `Text` is byte-exact. See the Console Output section under Code Style.
+- **console.py**: `make_console()` / `styled()` / `join()` — the markup-safety primitives (issue #406). A leaf module (like `duration.py`) with no conductor imports, deliberately **top-level rather than under `cli/`** because `gates/` and `providers/` need it and must not import from `cli/`. `make_console` locks `markup=False`, inverting Rich's default so an interpolated runtime value is literal unless it asks to be styled; it *rejects* a `markup=` kwarg rather than allowing an override — on the constructor and on `print`/`log`, since rich's per-call `markup=True` would otherwise reopen the defect from a single line. `styled("<template>", ...)` parses the template's markup — conductor's own literal — while inserting values verbatim. It works by replacing each field with a **length-matched filler run**, parsing once, then locating each run to substitute the value back: matching the width keeps the parsed template's spans valid, which is what makes nested styling around a placeholder (`[bold][red]{}[/red][/bold]`) come out right. Reading `spans[0].style` and re-applying it — the obvious alternative — collapses the nesting. A value that is already a `Text` is spliced in with its own spans re-anchored, so pre-styled fragments compose (`styled("{} {}", CHECK, name)`); without that, `format()` would flatten it and silently drop the colour from every doctor table cell. `join(sep, parts)` exists because `Text.join` requires every part to already be a `Text`, while the common shape here is a `content_lines` list mixing conductor-styled fragments with plain runtime values. `rich.markup.escape` is deliberately unused throughout: the parser treats `\[` as an escaped bracket, so `\[0-9\]+` renders as `[0-9\]+` whether escaped or not, whereas a `Text` is byte-exact. See the Console Output section under Code Style.
 
 - **providers/**: SDK provider abstraction
   - `base.py` - `AgentProvider` ABC defining `execute()`, `validate_connection()`, `close()`
@@ -223,7 +223,7 @@ log. See issue #116.
 ## Tests Structure
 
 Tests mirror source structure in `tests/`:
-- `test_cli/` - CLI command tests, e2e tests. `test_markup_guards.py` is the one that keeps issue #406 closed: it reads `src/conductor` with `ast` and fails with file:line when a new call site builds a bare `Console`, hands an interpolated string to a `Panel` title or a `Prompt`, passes an f-string to `Text.from_markup`, or leaves a markup literal at a print/cell sink. Each rule has a negative control, because a source-scanning check that quietly matches nothing reports "all clear" forever. `test_markup_injection.py` covers the same ground behaviourally, driving the real commands — the two layers are not redundant: the guard alone cannot prove `styled` renders correctly, and the behavioural tests alone cannot stop the *next* call site, which is the actual failure mode here
+- `test_cli/` - CLI command tests, e2e tests. `test_markup_guards.py` is the one that keeps issue #406 closed: it reads `src/conductor` with `ast` and fails with file:line across eight rules — a bare `Console` or a `Console` subclass (A), an interpolated `Panel` title or `Prompt` (B), an f-string into `Text.from_markup` (C), a markup literal at a print/cell sink (D), a `Text` through the builtin `print` (E) or into an f-string (F), unescaped brackets in `typer` help text (G), and any use of `rich.markup.escape` (H). Each rule is a shared predicate called by both the source scan and its negative control, so a control cannot pass against a drifted rule — that had already happened once. Each rule has a negative control, because a source-scanning check that quietly matches nothing reports "all clear" forever. `test_markup_injection.py` covers the same ground behaviourally, driving the real commands — the two layers are not redundant: the guard alone cannot prove `styled` renders correctly, and the behavioural tests alone cannot stop the *next* call site, which is the actual failure mode here
 - `test_config/` - Schema validation, loader tests
 - `test_engine/` - Workflow, router, context, limits tests
 - `test_executor/` - Agent, template, output tests
@@ -273,14 +273,18 @@ quiet half is the dangerous one — a listing that drops half a name looks
 like it worked. Note `style=` does **not** disable parsing (issues #382,
 #387, #406).
 
-The rules, all enforced by `tests/test_cli/test_markup_guards.py`, which
-reads the source and reports file:line:
+Each rule below is enforced by a matching rule in
+`tests/test_cli/test_markup_guards.py`, which reads the source and reports
+file:line:
 
-- **Build every console with `conductor.console.make_console()`.** It locks
-  `markup=False`, so a plain string is literal unless it asks to be styled.
-  This covers plain prints, `Panel` bodies, `Table` cells, headers, titles
-  and captions, and `Rule` titles. A `Console` subclass must lock it too
-  (see `cli/run.py::_SilentAwareConsole`).
+- **Build every console with `conductor.console.make_console()`** (rule A).
+  It locks `markup=False`, so a plain string is literal unless it asks to be
+  styled. This covers plain prints, `Panel` bodies, `Table` cells, headers,
+  titles and captions, and `Rule` titles. `markup` is not overridable —
+  passing it to the constructor, to `print` or to `log` raises `TypeError`,
+  because rich's per-call `markup=True` would otherwise reopen the whole
+  defect from one line. Subclass `MarkupFreeConsole` rather than rich's
+  `Console` so the refusal is inherited (see `cli/run.py::_SilentAwareConsole`).
 - **Style with `conductor.console.styled("<template>", value, ...)`.** The
   template is conductor's own literal and is parsed; values are inserted
   verbatim and never reach the parser. A value that is already a `Text` is
@@ -289,20 +293,33 @@ reads the source and reports file:line:
   `conductor.console.join(sep, parts)` to join a list mixing `str` and
   `Text` (`Text.join` requires every part to be a `Text` already).
 - **`Panel(title=)`, `Panel(subtitle=)` and `Prompt`/`Confirm`/`IntPrompt`
-  prompts must be handed a `Text`.** Rich calls `Text.from_markup` on those
-  unconditionally (`rich/panel.py`, `rich/prompt.py`), so `markup=False`
-  never reaches them. This is the trap that made #387 incomplete: it fixed
-  the panel *body* and left the `title=` f-string one line away.
-- **Do not use `rich.markup.escape`.** It is not byte-exact — the parser
-  treats `\[` as an escaped bracket, so an ordinary regex like `\[0-9\]+`
-  renders as `[0-9\]+` whether or not it was escaped first. Building a
-  `Text` avoids the parser entirely.
-- Typer's own `help=` / `epilog=` are **outside** this convention: Typer
-  renders them through its own console.
+  prompts must be handed a `Text`** (rule B). Rich calls `Text.from_markup`
+  on those unconditionally (`rich/panel.py`, `rich/prompt.py`), so
+  `markup=False` never reaches them. This is the trap that made #387
+  incomplete: it fixed the panel *body* and left the `title=` f-string one
+  line away.
+- **Never let a `Text` reach a plain-string context** — an f-string (rule F),
+  `str()`, or the builtin `print` (rule E). `str(Text)` is its *plain* form,
+  so styling is dropped and any text rich already parsed as a tag is gone
+  outright. This one has the worst record in the codebase: it shipped four
+  separate times during #406 alone, twice destroying data rather than
+  colour. Use `styled("{}{}", ...)` or `join(...)` instead.
+- **Do not use `rich.markup.escape`** (rule H). It is not
+  byte-exact — the parser treats `\[` as an escaped bracket, so an ordinary
+  regex like `\[0-9\]+` renders as `[0-9\]+` whether or not it was escaped
+  first. Building a `Text` avoids the parser entirely.
+- **Typer's `help=` / `epilog=` must escape their brackets** as `\[ ... ]`
+  (rule G). These are outside the *console* convention — Typer renders them
+  through its own rich console — but they are still markup-parsed. Escaping
+  is the remedy here rather than a `Text`, because Typer takes a `str`.
+  Forgetting cost `conductor run --help` the entire `[@registry][@version]`
+  syntax, which appears nowhere else in the help output.
 
 The worst outcome of forgetting is now a visible literal `[green]` in the
 output rather than a crash or a silent deletion, and rule D of the guard
-catches that statically.
+catches that statically. Each rule is a shared predicate called by both the
+source scan and its negative control, so a control cannot pass while the rule
+it guards has drifted.
 
 ### Provider Parity
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bracketed text no longer crashes or corrupts CLI output** (#406). The same
+  defect as #382, which #387 fixed only in `cli/run.py`. `conductor validate`
+  died with an unhandled `MarkupError` traceback on a workflow whose `name:`
+  contained `[/bold]`, and silently deleted the token when it contained
+  `[dim]`. The quiet half is the more damaging one: a listing that drops part
+  of a name looks like it worked. Rich treats a bracketed token as a style tag
+  when its first character is lowercase, `#`, `/` or `@`, so `[0]` is fine,
+  `[task1]` disappears, and `[/etc/x]` raises — and `style=` does not turn
+  parsing off, which is what made the earlier fix look complete.
+
+  Two consequences shipped unnoticed. Every for-each iteration's verbose panel
+  read the same, because the engine qualifies a member's name as
+  `<agent>[<key>]` so interleaved output can be attributed to one iteration,
+  and a `key_by:` key of `task1` erased exactly that identity — while a key
+  starting with `/`, which `key_by:` over paths or URLs produces, killed the
+  run from a logging call. This needed no flags: verbose and full mode both
+  default on. Separately, `conductor status` (#389) and `conductor plugin
+  list` (#398) were written against the unfixed pattern in files #387 never
+  touched, and #398 made these strings third-party rather than the author's
+  own YAML, since plugin, marketplace, skill and subagent names are now read
+  out of git-cloned repositories.
+
+  Rather than escape ~450 call sites, the default is inverted: every console
+  is built by the new `conductor.console.make_console()` with `markup=False`,
+  so a plain string is literal unless it asks to be styled, and conductor's
+  own styling goes through `styled("<template>", value)`, which parses the
+  template but inserts values verbatim and byte-exact. `Panel` titles and
+  `Prompt` prompts are handled separately because rich parses those
+  regardless of the console setting — that is the trap that left #387
+  incomplete one line from the code it changed. `rich.markup.escape` is no
+  longer used anywhere: it cannot round-trip a value containing a backslash
+  before a bracket, so an ordinary regex came out mangled. Four static guards
+  now read the source and fail with file:line if a new call site
+  reintroduces any of these shapes.
 - **Agent text containing bracketed tokens no longer kills a run** (#382). A
   step whose output contained ordinary technical prose such as
   `{provider}/{type}[/{nestedType}...]/read` was parsed by rich as a closing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,9 +198,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regardless of the console setting — that is the trap that left #387
   incomplete one line from the code it changed. `rich.markup.escape` is no
   longer used anywhere: it cannot round-trip a value containing a backslash
-  before a bracket, so an ordinary regex came out mangled. Four static guards
-  now read the source and fail with file:line if a new call site
-  reintroduces any of these shapes.
+  before a bracket, so an ordinary regex came out mangled. Eight static guards
+  now read the source and fail with file:line if a new call site reintroduces
+  any of these shapes — including a `Text` flattened back into an f-string,
+  which is how the defect kept coming back, and unescaped brackets in `typer`
+  help text, which had silently cost `conductor run --help` the whole
+  `[@registry][@version]` syntax.
 - **Agent text containing bracketed tokens no longer kills a run** (#382). A
   step whose output contained ordinary technical prose such as
   `{provider}/{type}[/{nestedType}...]/read` was parsed by rich as a closing

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -18,6 +18,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from conductor import __version__
+from conductor.console import make_console, styled
 from conductor.exceptions import WorkflowTerminated
 
 logger = logging.getLogger(__name__)
@@ -51,8 +52,8 @@ app.add_typer(gate_app, rich_help_panel="Interact")
 app.add_typer(checkpoint_app, rich_help_panel="State")
 
 # Rich console for formatted output
-console = Console(stderr=True)
-output_console = Console()
+console = make_console(stderr=True)
+output_console = make_console()
 
 # Context variable for verbose mode (default True - show progress output)
 verbose_mode: contextvars.ContextVar[bool] = contextvars.ContextVar("verbose_mode", default=True)
@@ -133,7 +134,7 @@ def format_error(error: Exception) -> Panel:
 
     return Panel(
         content,
-        title=f"[bold red]❌ {error_type}[/bold red]",
+        title=styled("[bold red]❌ {}[/bold red]", error_type),
         border_style="red",
         padding=(1, 2),
     )
@@ -155,7 +156,7 @@ def print_error(error: Exception) -> None:
         content.append(str(error), style="red")
         panel = Panel(
             content,
-            title=f"[bold red]❌ {type(error).__name__}[/bold red]",
+            title=styled("[bold red]❌ {}[/bold red]", type(error).__name__),
             border_style="red",
             padding=(1, 2),
         )
@@ -211,10 +212,13 @@ def _print_web_bg_human_gate_notice(url: str) -> None:
     port = urlparse(url).port
     port_hint = str(port) if port is not None else "<port>"
     console.print(
-        "[yellow]This workflow contains steps that wait for you[/yellow] "
-        "(human_gate / questions). Resolve them from "
-        "the dashboard above, or run "
-        f"[bold]conductor gate respond --port {port_hint} --choice <value>[/bold]."
+        styled(
+            "[yellow]This workflow contains steps that wait for "
+            "you[/yellow] (human_gate / questions). Resolve them from "
+            "the dashboard above, or run [bold]conductor gate respond "
+            "--port {} --choice <value>[/bold].",
+            port_hint,
+        )
     )
 
 
@@ -287,6 +291,8 @@ def run(
     workflow: Annotated[
         str,
         typer.Argument(
+            # Not wrapped for markup safety: Typer renders its own help text
+            # through its own console, not conductor's.
             help="Workflow file path or registry reference (name[@registry][@version]).",
         ),
     ],
@@ -518,11 +524,13 @@ def run(
                 print_loaded_instructions=print_loaded_instructions,
             )
             if is_verbose():
-                console.print(f"[bold cyan]Dashboard:[/bold cyan] {launch.url}")
-                console.print(f"[dim]Child stderr log: {launch.stderr_log}[/dim]")
+                console.print(styled("[bold cyan]Dashboard:[/bold cyan] {}", launch.url))
+                console.print(styled("[dim]Child stderr log: {}[/dim]", launch.stderr_log))
                 console.print(
-                    "[dim]Workflow running in background. Dashboard auto-shuts down after "
-                    "workflow completes and all clients disconnect.[/dim]"
+                    Text.from_markup(
+                        "[dim]Workflow running in background. Dashboard auto-shuts down after "
+                        "workflow completes and all clients disconnect.[/dim]"
+                    )
                 )
                 if notify_gate:
                     _print_web_bg_human_gate_notice(launch.url)
@@ -569,11 +577,15 @@ def run(
         except (TypeError, ValueError) as json_exc:
             logger.exception("Failed to serialise terminate output")
             console.print(
-                f"[yellow]Warning:[/yellow] could not serialise terminate output: {json_exc}"
+                styled(
+                    "[yellow]Warning:[/yellow] could not serialise terminate output: {}", json_exc
+                )
             )
-        console.print(f"[red]Workflow terminated[/red] at '{e.terminated_by}': {e.reason}")
+        console.print(
+            styled("[red]Workflow terminated[/red] at '{}': {}", e.terminated_by, e.reason)
+        )
         if e.suggestion:
-            console.print(f"[dim]Suggestion: {e.suggestion}[/dim]")
+            console.print(styled("[dim]Suggestion: {}[/dim]", e.suggestion))
         raise typer.Exit(code=1) from None
     except Exception as e:
         print_error(e)
@@ -585,6 +597,8 @@ def validate(
     workflow: Annotated[
         str,
         typer.Argument(
+            # Not wrapped for markup safety: Typer renders its own help text
+            # through its own console, not conductor's.
             help="Workflow file path or registry reference (name[@registry][@version]).",
         ),
     ],
@@ -631,6 +645,8 @@ def show(
     workflow: Annotated[
         str,
         typer.Argument(
+            # Not wrapped for markup safety: Typer renders its own help text
+            # through its own console, not conductor's.
             help="Workflow file path or registry reference (name[@registry][@version]).",
         ),
     ],
@@ -656,7 +672,9 @@ def show(
             assert ref.path is not None
             workflow_path = ref.path
             if not workflow_path.exists():
-                console.print(f"[bold red]Error:[/bold red] Workflow file not found: {workflow}")
+                console.print(
+                    styled("[bold red]Error:[/bold red] Workflow file not found: {}", workflow)
+                )
                 raise typer.Exit(code=1)
         else:
             workflow_path = resolve_and_fetch(ref)
@@ -669,20 +687,20 @@ def show(
 
         config = load_workflow_config(workflow_path)
     except Exception as e:
-        console.print(f"[bold red]Error:[/bold red] Failed to parse workflow: {e}")
+        console.print(styled("[bold red]Error:[/bold red] Failed to parse workflow: {}", e))
         raise typer.Exit(code=1) from None
 
     wf = config.workflow
-    output_console.print(f"[bold]Name:[/bold]        {wf.name}")
+    output_console.print(styled("[bold]Name:[/bold]        {}", wf.name))
     if wf.description:
-        output_console.print(f"[bold]Description:[/bold] {wf.description}")
-    output_console.print(f"[bold]Entry point:[/bold] {wf.entry_point}")
-    output_console.print(f"[bold]Source:[/bold]      {workflow_path}")
+        output_console.print(styled("[bold]Description:[/bold] {}", wf.description))
+    output_console.print(styled("[bold]Entry point:[/bold] {}", wf.entry_point))
+    output_console.print(styled("[bold]Source:[/bold]      {}", workflow_path))
 
     if ref.kind == "registry":
-        output_console.print(f"[bold]Registry:[/bold]    {ref.registry_name}")
+        output_console.print(styled("[bold]Registry:[/bold]    {}", ref.registry_name))
         if ref.ref:
-            output_console.print(f"[bold]Version:[/bold]     {ref.ref}")
+            output_console.print(styled("[bold]Version:[/bold]     {}", ref.ref))
 
     from rich.table import Table
 
@@ -746,9 +764,9 @@ def show(
     ref_str = workflow if ref.kind == "registry" else str(workflow_path)
     if inputs:
         input_args = " ".join(f'--input {name}="..."' for name in inputs)
-        output_console.print(f"\n[dim]conductor run {ref_str} {input_args}[/dim]")
+        output_console.print(styled("\n[dim]conductor run {} {}[/dim]", ref_str, input_args))
     else:
-        output_console.print(f"\n[dim]conductor run {ref_str}[/dim]")
+        output_console.print(styled("\n[dim]conductor run {}[/dim]", ref_str))
 
 
 @app.command(rich_help_panel="Run & Recover")
@@ -756,6 +774,8 @@ def resume(
     workflow: Annotated[
         str | None,
         typer.Argument(
+            # Not wrapped for markup safety: Typer renders its own help text
+            # through its own console, not conductor's.
             help=(
                 "Workflow file path or registry reference (name[@registry][@version]). "
                 "Finds the latest checkpoint for this workflow."
@@ -878,12 +898,16 @@ def resume(
     # Validate arguments
     if workflow is None and from_checkpoint is None:
         console.print(
-            "[bold red]Error:[/bold red] "
-            "Provide a workflow file or use --from to specify a checkpoint."
+            Text.from_markup(
+                "[bold red]Error:[/bold red] "
+                "Provide a workflow file or use --from to specify a checkpoint."
+            )
         )
         console.print(
-            "[dim]Usage: conductor resume workflow.yaml "
-            "or conductor resume --from <checkpoint.json>[/dim]"
+            Text.from_markup(
+                "[dim]Usage: conductor resume workflow.yaml "
+                "or conductor resume --from <checkpoint.json>[/dim]"
+            )
         )
         raise typer.Exit(code=1)
 
@@ -905,7 +929,7 @@ def resume(
                 resolved_workflow = ref.path.resolve()
                 if not resolved_workflow.exists():
                     console.print(
-                        f"[bold red]Error:[/bold red] Workflow file not found: {workflow}"
+                        styled("[bold red]Error:[/bold red] Workflow file not found: {}", workflow)
                     )
                     raise typer.Exit(code=1)
             else:
@@ -920,7 +944,7 @@ def resume(
         resolved_checkpoint = from_checkpoint.resolve()
         if not resolved_checkpoint.exists():
             console.print(
-                f"[bold red]Error:[/bold red] Checkpoint file not found: {from_checkpoint}"
+                styled("[bold red]Error:[/bold red] Checkpoint file not found: {}", from_checkpoint)
             )
             raise typer.Exit(code=1)
 
@@ -977,11 +1001,13 @@ def resume(
                 metadata=cli_metadata,
             )
             if is_verbose():
-                console.print(f"[bold cyan]Dashboard:[/bold cyan] {launch.url}")
-                console.print(f"[dim]Child stderr log: {launch.stderr_log}[/dim]")
+                console.print(styled("[bold cyan]Dashboard:[/bold cyan] {}", launch.url))
+                console.print(styled("[dim]Child stderr log: {}[/dim]", launch.stderr_log))
                 console.print(
-                    "[dim]Resumed workflow running in background. Dashboard auto-shuts down "
-                    "after workflow completes and all clients disconnect.[/dim]"
+                    Text.from_markup(
+                        "[dim]Resumed workflow running in background. Dashboard auto-shuts down "
+                        "after workflow completes and all clients disconnect.[/dim]"
+                    )
                 )
                 if notify_gate:
                     _print_web_bg_human_gate_notice(launch.url)
@@ -1017,11 +1043,15 @@ def resume(
         except (TypeError, ValueError) as json_exc:
             logger.exception("Failed to serialise terminate output")
             console.print(
-                f"[yellow]Warning:[/yellow] could not serialise terminate output: {json_exc}"
+                styled(
+                    "[yellow]Warning:[/yellow] could not serialise terminate output: {}", json_exc
+                )
             )
-        console.print(f"[red]Workflow terminated[/red] at '{e.terminated_by}': {e.reason}")
+        console.print(
+            styled("[red]Workflow terminated[/red] at '{}': {}", e.terminated_by, e.reason)
+        )
         if e.suggestion:
-            console.print(f"[dim]Suggestion: {e.suggestion}[/dim]")
+            console.print(styled("[dim]Suggestion: {}[/dim]", e.suggestion))
         raise typer.Exit(code=1) from None
     except Exception as e:
         print_error(e)
@@ -1039,8 +1069,10 @@ def checkpoints(
 ) -> None:
     """Deprecated alias for 'conductor checkpoint list'."""
     console.print(
-        "[yellow]Warning:[/yellow] 'conductor checkpoints' is deprecated and will "
-        "be removed in a future release. Use 'conductor checkpoint list' instead."
+        Text.from_markup(
+            "[yellow]Warning:[/yellow] 'conductor checkpoints' is deprecated and will "
+            "be removed in a future release. Use 'conductor checkpoint list' instead."
+        )
     )
     from conductor.cli.checkpoint import _list_checkpoints_impl
 
@@ -1095,8 +1127,8 @@ def replay(
 
         await dashboard.start()
         if is_verbose():
-            console.print(f"\n[bold green]▶ Replay dashboard:[/] {dashboard.url}\n")
-            console.print("[dim]Press Ctrl+C to exit[/dim]\n")
+            console.print(styled("\n[bold green]▶ Replay dashboard:[/] {}\n", dashboard.url))
+            console.print(Text.from_markup("[dim]Press Ctrl+C to exit[/dim]\n"))
 
         try:
             await asyncio.Event().wait()
@@ -1109,7 +1141,7 @@ def replay(
         asyncio.run(_run_replay())
     except KeyboardInterrupt:
         if is_verbose():
-            console.print("\n[dim]Replay stopped.[/dim]")
+            console.print(Text.from_markup("\n[dim]Replay stopped.[/dim]"))
 
 
 @app.command(rich_help_panel="Run & Recover")
@@ -1168,12 +1200,14 @@ def status(
         return
 
     if not running:
-        console.print("[dim]No background workflows are currently running.[/dim]")
+        console.print(Text.from_markup("[dim]No background workflows are currently running.[/dim]"))
         return
 
     _print_running_list(running, console, show_url=True)
     console.print(
-        f"\n[dim]{len(running)} running. Use 'conductor stop --port <PORT>' to stop one.[/dim]"
+        styled(
+            "\n[dim]{} running. Use 'conductor stop --port <PORT>' to stop one.[/dim]", len(running)
+        )
     )
 
 
@@ -1211,7 +1245,7 @@ def stop(
     running = read_pid_files()
 
     if not running:
-        console.print("[dim]No background workflows are currently running.[/dim]")
+        console.print(Text.from_markup("[dim]No background workflows are currently running.[/dim]"))
         return
 
     if all_workflows:
@@ -1225,9 +1259,9 @@ def stop(
         match = [e for e in running if e["port"] == port]
         if not match:
             console.print(
-                f"[bold red]Error:[/bold red] No background workflow found on port {port}."
+                styled("[bold red]Error:[/bold red] No background workflow found on port {}.", port)
             )
-            console.print("[dim]Running workflows:[/dim]")
+            console.print(Text.from_markup("[dim]Running workflows:[/dim]"))
             _print_running_list(running, console)
             raise typer.Exit(code=1)
         _stop_process(match[0], console)
@@ -1241,9 +1275,16 @@ def stop(
         remove_pid_file(entry["port"])
     else:
         console.print(
-            f"[bold yellow]Multiple background workflows running ({len(running)}).[/bold yellow]"
+            styled(
+                "[bold yellow]Multiple background workflows running ({}).[/bold yellow]",
+                len(running),
+            )
         )
-        console.print("[dim]Specify --port to stop a specific one, or --all to stop all.[/dim]\n")
+        console.print(
+            Text.from_markup(
+                "[dim]Specify --port to stop a specific one, or --all to stop all.[/dim]\n"
+            )
+        )
         _print_running_list(running, console)
 
 
@@ -1267,16 +1308,29 @@ def _stop_process(entry: dict, con: Console) -> None:
         else:
             os.kill(pid, signal.SIGTERM)
         con.print(
-            f"[green]Stopped[/green] workflow [cyan]'{workflow}'[/cyan] (PID {pid}, port {port})"
+            styled(
+                "[green]Stopped[/green] workflow [cyan]'{}'[/cyan] (PID {}, port {})",
+                workflow,
+                pid,
+                port,
+            )
         )
     except ProcessLookupError:
         con.print(
-            f"[dim]Process already exited:[/dim] workflow '{workflow}' (PID {pid}, port {port})"
+            styled(
+                "[dim]Process already exited:[/dim] workflow '{}' (PID {}, port {})",
+                workflow,
+                pid,
+                port,
+            )
         )
     except PermissionError:
         con.print(
-            f"[bold red]Permission denied:[/bold red] could not stop PID {pid}. "
-            f"Try running with elevated privileges."
+            styled(
+                "[bold red]Permission denied:[/bold red] could not stop PID "
+                "{}. Try running with elevated privileges.",
+                pid,
+            )
         )
     except OSError as exc:
         # Defensive catch (companion to the fix for issue #166): on Windows,
@@ -1289,8 +1343,13 @@ def _stop_process(entry: dict, con: Console) -> None:
             "Unexpected OSError stopping PID %s; treating as already exited", pid, exc_info=True
         )
         con.print(
-            f"[yellow]Could not signal PID {pid} ({exc}); "
-            f"removing PID file for workflow '{workflow}' anyway.[/yellow]"
+            styled(
+                "[yellow]Could not signal PID {} ({}); removing PID file for "
+                "workflow '{}' anyway.[/yellow]",
+                pid,
+                exc,
+                workflow,
+            )
         )
 
 
@@ -1372,8 +1431,10 @@ def gate_respond(
 ) -> None:
     """Deprecated alias for 'conductor gate respond'."""
     console.print(
-        "[yellow]Warning:[/yellow] 'conductor gate-respond' is deprecated and will "
-        "be removed in a future release. Use 'conductor gate respond' instead."
+        Text.from_markup(
+            "[yellow]Warning:[/yellow] 'conductor gate-respond' is deprecated and will "
+            "be removed in a future release. Use 'conductor gate respond' instead."
+        )
     )
     from conductor.cli.gate import _gate_respond_impl
 

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -291,9 +291,13 @@ def run(
     workflow: Annotated[
         str,
         typer.Argument(
-            # Not wrapped for markup safety: Typer renders its own help text
-            # through its own console, not conductor's.
-            help="Workflow file path or registry reference (name[@registry][@version]).",
+            # Typer renders help through rich (``rich_markup_mode="rich"``),
+            # so this string *is* markup-parsed and the console convention
+            # does not reach it. ``[@registry]`` starts with ``@``, which rich
+            # reads as a tag and deletes -- the syntax this line documents was
+            # missing from ``--help`` entirely. Escaped rather than wrapped in
+            # ``Text``: typer takes a ``str`` here (#406).
+            help=r"Workflow file path or registry reference (name\[@registry]\[@version]).",
         ),
     ],
     provider: Annotated[
@@ -597,9 +601,13 @@ def validate(
     workflow: Annotated[
         str,
         typer.Argument(
-            # Not wrapped for markup safety: Typer renders its own help text
-            # through its own console, not conductor's.
-            help="Workflow file path or registry reference (name[@registry][@version]).",
+            # Typer renders help through rich (``rich_markup_mode="rich"``),
+            # so this string *is* markup-parsed and the console convention
+            # does not reach it. ``[@registry]`` starts with ``@``, which rich
+            # reads as a tag and deletes -- the syntax this line documents was
+            # missing from ``--help`` entirely. Escaped rather than wrapped in
+            # ``Text``: typer takes a ``str`` here (#406).
+            help=r"Workflow file path or registry reference (name\[@registry]\[@version]).",
         ),
     ],
 ) -> None:
@@ -645,9 +653,13 @@ def show(
     workflow: Annotated[
         str,
         typer.Argument(
-            # Not wrapped for markup safety: Typer renders its own help text
-            # through its own console, not conductor's.
-            help="Workflow file path or registry reference (name[@registry][@version]).",
+            # Typer renders help through rich (``rich_markup_mode="rich"``),
+            # so this string *is* markup-parsed and the console convention
+            # does not reach it. ``[@registry]`` starts with ``@``, which rich
+            # reads as a tag and deletes -- the syntax this line documents was
+            # missing from ``--help`` entirely. Escaped rather than wrapped in
+            # ``Text``: typer takes a ``str`` here (#406).
+            help=r"Workflow file path or registry reference (name\[@registry]\[@version]).",
         ),
     ],
 ) -> None:
@@ -774,10 +786,10 @@ def resume(
     workflow: Annotated[
         str | None,
         typer.Argument(
-            # Not wrapped for markup safety: Typer renders its own help text
-            # through its own console, not conductor's.
+            # Escaped, not wrapped: typer renders help through rich, so an
+            # unescaped ``[@registry]`` is parsed as a tag and deleted (#406).
             help=(
-                "Workflow file path or registry reference (name[@registry][@version]). "
+                r"Workflow file path or registry reference (name\[@registry]\[@version]). "
                 "Finds the latest checkpoint for this workflow."
             ),
         ),

--- a/src/conductor/cli/checkpoint.py
+++ b/src/conductor/cli/checkpoint.py
@@ -6,11 +6,13 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
-console = Console(stderr=True)
-output_console = Console()
+from conductor.console import make_console, styled
+
+console = make_console(stderr=True)
+output_console = make_console()
 
 checkpoint_app = typer.Typer(
     name="checkpoint",
@@ -56,7 +58,9 @@ def _list_checkpoints_impl(workflow: Path | None) -> None:
     if workflow is not None:
         resolved_workflow = workflow.resolve()
         if not resolved_workflow.exists():
-            console.print(f"[bold red]Error:[/bold red] Workflow file not found: {workflow}")
+            console.print(
+                styled("[bold red]Error:[/bold red] Workflow file not found: {}", workflow)
+            )
             raise typer.Exit(code=1)
 
     checkpoint_list = CheckpointManager.list_checkpoints(resolved_workflow)
@@ -64,10 +68,10 @@ def _list_checkpoints_impl(workflow: Path | None) -> None:
     if not checkpoint_list:
         if resolved_workflow:
             output_console.print(
-                f"[dim]No checkpoints found for workflow: {resolved_workflow.name}[/dim]"
+                styled("[dim]No checkpoints found for workflow: {}[/dim]", resolved_workflow.name)
             )
         else:
-            output_console.print("[dim]No checkpoints found.[/dim]")
+            output_console.print(Text.from_markup("[dim]No checkpoints found.[/dim]"))
         return
 
     table = Table(title="Workflow Checkpoints", show_lines=True)
@@ -93,4 +97,4 @@ def _list_checkpoints_impl(workflow: Path | None) -> None:
         table.add_row(workflow_name, timestamp, trigger, agent, error_type, file_path)
 
     output_console.print(table)
-    output_console.print(f"\n[dim]Total: {len(checkpoint_list)} checkpoint(s)[/dim]")
+    output_console.print(styled("\n[dim]Total: {} checkpoint(s)[/dim]", len(checkpoint_list)))

--- a/src/conductor/cli/doctor.py
+++ b/src/conductor/cli/doctor.py
@@ -14,9 +14,10 @@ import logging
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
-from rich.markup import escape
 from rich.table import Table
+from rich.text import Text
 
+from conductor.console import join, styled
 from conductor.providers.capabilities import known_provider_names
 from conductor.providers.diagnostics import (
     ALL_SECTIONS,
@@ -34,9 +35,9 @@ if TYPE_CHECKING:
     from conductor.providers.diagnostics import Section
 
 
-_CHECK = "[green]✓[/green]"
-_CROSS = "[red]✗[/red]"
-_DASH = "[dim]—[/dim]"
+_CHECK = Text.from_markup("[green]✓[/green]")
+_CROSS = Text.from_markup("[red]✗[/red]")
+_DASH = Text.from_markup("[dim]—[/dim]")
 _OPTIONAL_MARK = "○"
 """Neutral glyph for an absent *optional* credential — deliberately not the
 red ``✗`` used for a genuinely missing required credential (issue #319)."""
@@ -74,15 +75,21 @@ def run_doctor(
 
     if section is not None and section not in ALL_SECTIONS:
         err_console.print(
-            f"[bold red]Error:[/bold red] Unknown section {section!r}. "
-            f"Choose from: {', '.join(ALL_SECTIONS)}."
+            styled(
+                "[bold red]Error:[/bold red] Unknown section {!r}. Choose from: {}.",
+                section,
+                ", ".join(ALL_SECTIONS),
+            )
         )
         return 1
 
     if provider is not None and provider not in known_provider_names():
         err_console.print(
-            f"[bold red]Error:[/bold red] Unknown provider {provider!r}. "
-            f"Known providers: {', '.join(known_provider_names())}."
+            styled(
+                "[bold red]Error:[/bold red] Unknown provider {!r}. Known providers: {}.",
+                provider,
+                ", ".join(known_provider_names()),
+            )
         )
         return 1
 
@@ -174,13 +181,13 @@ def _render_env(env: EnvDiagnostic, console: Console) -> None:
     table.add_row("Platform", env.platform)
 
     if not env.update_checked:
-        update = "[dim]check skipped (CONDUCTOR_NO_UPDATE_CHECK)[/dim]"
+        update = Text.from_markup("[dim]check skipped (CONDUCTOR_NO_UPDATE_CHECK)[/dim]")
     elif env.update_available is None:
-        update = "[dim]unavailable (offline?)[/dim]"
+        update = Text.from_markup("[dim]unavailable (offline?)[/dim]")
     elif env.update_available:
-        update = f"[yellow]v{env.latest_version} available[/yellow]"
+        update = styled("[yellow]v{} available[/yellow]", env.latest_version)
     else:
-        update = "[green]up to date[/green]"
+        update = Text.from_markup("[green]up to date[/green]")
     table.add_row("Update", update)
 
     console.print(table)
@@ -222,16 +229,16 @@ def _render_providers(
     console.print(table)
 
 
-def _tier_cell(tier: str | None) -> str:
+def _tier_cell(tier: str | None) -> Text:
     """Format the tier cell."""
     if tier is None:
         return _DASH
     if tier == "experimental":
-        return "[yellow]experimental[/yellow]"
-    return tier
+        return Text.from_markup("[yellow]experimental[/yellow]")
+    return Text(tier)
 
 
-def _credentials_cell(diag: ProviderDiagnostic) -> str:
+def _credentials_cell(diag: ProviderDiagnostic) -> Text:
     """Format credential env-var presence (presence only, never values).
 
     A present credential is a green ``✓``. An absent credential renders as a
@@ -243,29 +250,29 @@ def _credentials_cell(diag: ProviderDiagnostic) -> str:
     """
     if not diag.credential_env_vars:
         return _DASH
-    lines: list[str] = []
+    lines: list[Text] = []
     for cred in diag.credential_env_vars:
         if cred.present:
-            lines.append(f"{_CHECK} {cred.name}")
+            lines.append(styled("{} {}", _CHECK, cred.name))
         elif diag.credentials_optional:
-            lines.append(f"[dim]{_OPTIONAL_MARK} {cred.name}[/dim]")
+            lines.append(styled("[dim]{} {}[/dim]", _OPTIONAL_MARK, cred.name))
         else:
-            lines.append(f"[dim]{_CROSS} {cred.name}[/dim]")
-    return "\n".join(lines)
+            lines.append(styled("[dim]{} {}[/dim]", _CROSS, cred.name))
+    return join("\n", lines)
 
 
-def _connection_cell(diag: ProviderDiagnostic) -> str:
+def _connection_cell(diag: ProviderDiagnostic) -> Text:
     """Format the connection-check result cell."""
     if not diag.checked or diag.connection_ok is None:
         return _DASH
     if diag.connection_ok:
-        return f"{_CHECK} connected"
+        return styled("{} connected", _CHECK)
     if diag.connection_error:
-        return f"{_CROSS} [dim]{escape(diag.connection_error)}[/dim]"
-    return f"{_CROSS} [dim]connection failed[/dim]"
+        return styled("{} [dim]{}[/dim]", _CROSS, diag.connection_error)
+    return styled("{} [dim]connection failed[/dim]", _CROSS)
 
 
-def _models_cell(diag: ProviderDiagnostic) -> str:
+def _models_cell(diag: ProviderDiagnostic) -> Text:
     """Format the models cell in the Providers summary table.
 
     Shows a count/status only — per-model reasoning-effort and
@@ -274,40 +281,40 @@ def _models_cell(diag: ProviderDiagnostic) -> str:
     models is ``None`` (not enumerated), ``(none)`` for an empty list.
     """
     if diag.models_error:
-        return f"{_CROSS} [dim]{escape(diag.models_error)}[/dim]"
+        return styled("{} [dim]{}[/dim]", _CROSS, diag.models_error)
     if diag.models is None:
-        return "[dim]n/a[/dim]"
+        return Text.from_markup("[dim]n/a[/dim]")
     count = len(diag.models)
     if not count:
-        return "[dim](none)[/dim]"
-    return f"{_CHECK} {count} model{'s' if count != 1 else ''}"
+        return Text.from_markup("[dim](none)[/dim]")
+    return styled("{} {} model{}", _CHECK, count, "s" if count != 1 else "")
 
 
-def _format_tokens(value: int | None) -> str:
+def _format_tokens(value: int | None) -> Text:
     """Format a token-limit value with grouped digits, or ``—`` when unknown."""
     if value is None:
         return _DASH
-    return f"{value:,}"
+    return Text(f"{value:,}")
 
 
-def _efforts_cell(model: ModelDiagnostic) -> str:
+def _efforts_cell(model: ModelDiagnostic) -> Text:
     """Format the supported-reasoning-efforts cell.
 
     ``n/a`` when unknown (``None``), ``none`` for a definitive empty list
     (e.g. a non-thinking Claude model), otherwise a comma-separated list.
     """
     if model.supported_reasoning_efforts is None:
-        return "[dim]n/a[/dim]"
+        return Text.from_markup("[dim]n/a[/dim]")
     if not model.supported_reasoning_efforts:
-        return "[dim]none[/dim]"
-    return ", ".join(escape(effort) for effort in model.supported_reasoning_efforts)
+        return Text.from_markup("[dim]none[/dim]")
+    return Text(", ".join(model.supported_reasoning_efforts))
 
 
-def _default_effort_cell(model: ModelDiagnostic) -> str:
+def _default_effort_cell(model: ModelDiagnostic) -> Text:
     """Format the default-reasoning-effort cell."""
     if model.default_reasoning_effort is None:
         return _DASH
-    return escape(model.default_reasoning_effort)
+    return Text(model.default_reasoning_effort)
 
 
 def _render_models(providers: list[ProviderDiagnostic], console: Console) -> None:
@@ -331,7 +338,7 @@ def _render_models(providers: list[ProviderDiagnostic], console: Console) -> Non
 
         for model in diag.models:
             table.add_row(
-                escape(model.id),
+                model.id,
                 _efforts_cell(model),
                 _default_effort_cell(model),
                 _format_tokens(model.max_prompt_tokens),
@@ -345,10 +352,12 @@ def _render_models(providers: list[ProviderDiagnostic], console: Console) -> Non
 def _render_registries(registries: RegistryDiagnostic, console: Console) -> None:
     """Render the registries section."""
     if registries.error is not None:
-        console.print(f"{_CROSS} [dim]failed to load registries: {escape(registries.error)}[/dim]")
+        console.print(
+            styled("{} [dim]failed to load registries: {}[/dim]", _CROSS, registries.error)
+        )
         return
     if not registries.registries:
-        console.print("[dim]No registries configured.[/dim]")
+        console.print(Text.from_markup("[dim]No registries configured.[/dim]"))
         return
 
     table = Table(title="Registries", show_lines=False)
@@ -359,9 +368,9 @@ def _render_registries(registries: RegistryDiagnostic, console: Console) -> None
 
     for reg in registries.registries:
         table.add_row(
-            escape(reg.name),
-            escape(reg.type),
-            escape(reg.source),
+            reg.name,
+            reg.type,
+            reg.source,
             _CHECK if reg.is_default else _DASH,
         )
 

--- a/src/conductor/cli/doctor.py
+++ b/src/conductor/cli/doctor.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 from rich.table import Table
 from rich.text import Text
 
-from conductor.console import join, styled
+from conductor.console import MarkupFreeConsole, join, styled
 from conductor.providers.capabilities import known_provider_names
 from conductor.providers.diagnostics import (
     ALL_SECTIONS,
@@ -50,8 +50,8 @@ def run_doctor(
     check: bool,
     models: bool,
     as_json: bool,
-    console: Console,
-    err_console: Console,
+    console: MarkupFreeConsole,
+    err_console: MarkupFreeConsole,
 ) -> int:
     """Gather and render diagnostics, returning a process exit code.
 
@@ -195,7 +195,7 @@ def _render_env(env: EnvDiagnostic, console: Console) -> None:
 
 def _render_providers(
     providers: list[ProviderDiagnostic],
-    console: Console,
+    console: MarkupFreeConsole,
     *,
     check: bool,
     models: bool,

--- a/src/conductor/cli/gate.py
+++ b/src/conductor/cli/gate.py
@@ -7,9 +7,11 @@ from typing import Annotated, Any
 
 import httpx
 import typer
-from rich.console import Console
+from rich.text import Text
 
-console = Console(stderr=True)
+from conductor.console import make_console, styled
+
+console = make_console(stderr=True)
 
 gate_app = typer.Typer(
     name="gate",
@@ -99,7 +101,9 @@ def _gate_respond_impl(
             resp.raise_for_status()
             status = resp.json()
             if not status.get("waiting"):
-                console.print(f"[yellow]No gate is currently waiting on port {port}.[/yellow]")
+                console.print(
+                    styled("[yellow]No gate is currently waiting on port {}.[/yellow]", port)
+                )
                 raise typer.Exit(code=1)
             agent = status["agent_name"]
             # Echo the staleness token back. A questions node presents every
@@ -109,12 +113,17 @@ def _gate_respond_impl(
             prompt_id = status.get("prompt_id")
         except httpx.ConnectError:
             console.print(
-                f"[bold red]Error:[/bold red] Cannot connect to dashboard on port {port}. "
-                "Is the workflow running with --web or --web-bg?"
+                styled(
+                    "[bold red]Error:[/bold red] Cannot connect to dashboard on "
+                    "port {}. Is the workflow running with --web or --web-bg?",
+                    port,
+                )
             )
             raise typer.Exit(code=1) from None
         except httpx.HTTPError as exc:
-            console.print(f"[bold red]Error:[/bold red] Failed to query gate status: {exc}")
+            console.print(
+                styled("[bold red]Error:[/bold red] Failed to query gate status: {}", exc)
+            )
             raise typer.Exit(code=1) from None
 
     # Build request body
@@ -140,34 +149,47 @@ def _gate_respond_impl(
         resp = httpx.post(f"{base_url}/api/gate-respond", json=body, headers=headers, timeout=10)
     except httpx.ConnectError:
         console.print(
-            f"[bold red]Error:[/bold red] Cannot connect to dashboard on port {port}. "
-            "Is the workflow running with --web or --web-bg?"
+            styled(
+                "[bold red]Error:[/bold red] Cannot connect to dashboard on "
+                "port {}. Is the workflow running with --web or --web-bg?",
+                port,
+            )
         )
         raise typer.Exit(code=1) from None
     except httpx.HTTPError as exc:
-        console.print(f"[bold red]Error:[/bold red] Request failed: {exc}")
+        console.print(styled("[bold red]Error:[/bold red] Request failed: {}", exc))
         raise typer.Exit(code=1) from None
 
     if resp.status_code == 403:
         console.print(
-            "[bold red]Error:[/bold red] Authentication failed. "
-            "Provide a valid token with --token or CONDUCTOR_GATE_TOKEN env var."
+            Text.from_markup(
+                "[bold red]Error:[/bold red] Authentication failed. "
+                "Provide a valid token with --token or CONDUCTOR_GATE_TOKEN env var."
+            )
         )
         raise typer.Exit(code=1)
     if resp.status_code == 409:
         detail = resp.json().get("error", "Gate is not waiting for this response")
-        console.print(f"[bold red]Error:[/bold red] {detail}")
+        console.print(styled("[bold red]Error:[/bold red] {}", detail))
         raise typer.Exit(code=1)
     if resp.status_code == 422:
         detail = resp.json().get("error", "Validation error")
-        console.print(f"[bold red]Error:[/bold red] {detail}")
+        console.print(styled("[bold red]Error:[/bold red] {}", detail))
         raise typer.Exit(code=1)
     if resp.status_code != 200:
         console.print(
-            f"[bold red]Error:[/bold red] Unexpected response ({resp.status_code}): {resp.text}"
+            styled(
+                "[bold red]Error:[/bold red] Unexpected response ({}): {}",
+                resp.status_code,
+                resp.text,
+            )
         )
         raise typer.Exit(code=1)
 
     console.print(
-        f"[green]Gate resolved:[/green] agent=[cyan]{agent}[/cyan] choice=[cyan]{choice}[/cyan]"
+        styled(
+            "[green]Gate resolved:[/green] agent=[cyan]{}[/cyan] choice=[cyan]{}[/cyan]",
+            agent,
+            choice,
+        )
     )

--- a/src/conductor/cli/plugin.py
+++ b/src/conductor/cli/plugin.py
@@ -17,11 +17,13 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
-console = Console(stderr=True)
-output_console = Console()
+from conductor.console import make_console, styled
+
+console = make_console(stderr=True)
+output_console = make_console()
 
 plugin_app = typer.Typer(
     name="plugin",
@@ -37,12 +39,12 @@ def _load(workflow: Path):  # noqa: ANN202  (WorkflowConfig, imported lazily)
 
     resolved = workflow.resolve()
     if not resolved.is_file():
-        console.print(f"[bold red]Error:[/bold red] Workflow file not found: {workflow}")
+        console.print(styled("[bold red]Error:[/bold red] Workflow file not found: {}", workflow))
         raise typer.Exit(code=1)
     try:
         return load_workflow(resolved), resolved
     except ConductorError as exc:
-        console.print(f"[bold red]Error:[/bold red] {exc}")
+        console.print(styled("[bold red]Error:[/bold red] {}", exc))
         raise typer.Exit(code=1) from None
 
 
@@ -64,13 +66,13 @@ def _resolve(config, workflow_path: Path, *, allow_network: bool, strict: bool =
                 declared,
                 base_dir=workflow_path.parent,
                 allow_network=allow_network,
-                on_warning=lambda message: console.print(f"[yellow]⚠[/yellow] {message}"),
+                on_warning=lambda message: console.print(styled("[yellow]⚠[/yellow] {}", message)),
             )
         except (PluginError, OSError) as exc:
             # OSError too: the cache is created during acquisition, so an
             # unwritable home or a full disk surfaces here as a bare
             # PermissionError and would otherwise print a raw traceback.
-            console.print(f"[bold red]Error:[/bold red] {exc}")
+            console.print(styled("[bold red]Error:[/bold red] {}", exc))
             raise typer.Exit(code=1) from None
 
     resolved: dict = {}
@@ -81,11 +83,13 @@ def _resolve(config, workflow_path: Path, *, allow_network: bool, strict: bool =
                     {name: entry},
                     base_dir=workflow_path.parent,
                     allow_network=allow_network,
-                    on_warning=lambda message: console.print(f"[yellow]⚠[/yellow] {message}"),
+                    on_warning=lambda message: console.print(
+                        styled("[yellow]⚠[/yellow] {}", message)
+                    ),
                 )
             )
         except (PluginError, OSError) as exc:
-            console.print(f"[yellow]⚠[/yellow] {name}: {exc}")
+            console.print(styled("[yellow]⚠[/yellow] {}: {}", name, exc))
     return resolved
 
 
@@ -127,7 +131,7 @@ def fetch_plugins(
     for name, entry in sources.items():
         detail = entry.source.describe()
         if entry.sha:
-            detail = f"{detail} @ [cyan]{entry.sha[:12]}[/cyan]"
+            detail = styled("{} @ [cyan]{}[/cyan]", detail, entry.sha[:12])
         if entry.source.is_local:
             state = "local"
         elif entry.stale:
@@ -135,16 +139,26 @@ def fetch_plugins(
         else:
             state = "fetched" if entry.fetched else "cached"
         mark = "[yellow]⚠[/yellow]" if entry.stale else "[green]✓[/green]"
+        # Assembled in one ``styled`` call rather than an f-string: an
+        # f-string renders a ``Text`` as its plain form, which would drop the
+        # ✓/⚠ colour that is the whole point of the marker column on a
+        # command CI gates on.
         output_console.print(
-            f"  {mark} {name} — {detail} — {state}, {len(entry.marketplace.plugins)} plugin(s)"
+            styled(
+                "  " + mark + " {} — {} — {}, {} plugin(s)",
+                name,
+                detail,
+                state,
+                len(entry.marketplace.plugins),
+            )
         )
     stale = sum(1 for entry in sources.values() if entry.stale)
-    summary = f"\n{len(sources)} source(s) ready ({fetched} newly fetched)"
+    summary = Text(f"\n{len(sources)} source(s) ready ({fetched} newly fetched)")
     if stale:
         # The command exists to acquire; a row it could not verify must not
         # read as a green light, least of all in the CI step that gates on it.
-        summary += f", [yellow]{stale} not re-checked[/yellow]"
-    output_console.print(f"{summary}.")
+        summary += styled(", [yellow]{} not re-checked[/yellow]", stale)
+    output_console.print(summary + ".")
 
 
 @plugin_app.command("list")
@@ -246,17 +260,17 @@ def _list_enabled_plugins(config, workflow_path: Path, sources) -> None:  # noqa
             PluginDef(name=name, skills=skills, agents=agents_on, mcp=mcp)
             for name, skills, agents_on, mcp in key
         ]
-        output_console.print(f"\n[bold]Agents:[/bold] {', '.join(agents)}")
+        output_console.print(styled("\n[bold]Agents:[/bold] {}", ", ".join(agents)))
         try:
             resolved = resolve_plugins(
                 entries,
                 base_dir=workflow_path.parent,
                 marketplaces=marketplaces,
                 declared_sources=declared_names,
-                on_warning=lambda message: console.print(f"[yellow]⚠[/yellow] {message}"),
+                on_warning=lambda message: console.print(styled("[yellow]⚠[/yellow] {}", message)),
             )
         except (PluginError, SkillError, OSError) as exc:
-            output_console.print(f"  [yellow]⚠[/yellow] {exc}")
+            output_console.print(styled("  [yellow]⚠[/yellow] {}", exc))
             continue
 
         for plugin in resolved:
@@ -265,20 +279,26 @@ def _list_enabled_plugins(config, workflow_path: Path, sources) -> None:  # noqa
                 f"{len(plugin.agents)} agent(s), "
                 f"{len(plugin.mcp_servers)} MCP server(s)"
             )
-            output_console.print(f"  [cyan]•[/cyan] {plugin.source} — {parts}")
-            output_console.print(f"    [dim]{plugin.root}[/dim]")
+            output_console.print(styled("  [cyan]•[/cyan] {} — {}", plugin.source, parts))
+            output_console.print(styled("    [dim]{}[/dim]", plugin.root))
             if plugin.agents:
                 names = ", ".join(item.qualified_name for item in plugin.agents)
-                output_console.print(f"    [dim]agents: {names}[/dim]")
+                output_console.print(styled("    [dim]agents: {}[/dim]", names))
             if plugin.mcp_servers:
-                output_console.print(f"    [dim]mcp: {', '.join(sorted(plugin.mcp_servers))}[/dim]")
+                output_console.print(
+                    styled("    [dim]mcp: {}[/dim]", ", ".join(sorted(plugin.mcp_servers)))
+                )
             if plugin.disabled:
                 output_console.print(
-                    f"    [dim]disabled by this workflow: {', '.join(plugin.disabled)}[/dim]"
+                    styled(
+                        "    [dim]disabled by this workflow: {}[/dim]", ", ".join(plugin.disabled)
+                    )
                 )
             if plugin.dropped:
                 output_console.print(
-                    f"    [dim]not loaded: {', '.join(f'{d}/' for d in plugin.dropped)}[/dim]"
+                    styled(
+                        "    [dim]not loaded: {}[/dim]", ", ".join(f"{d}/" for d in plugin.dropped)
+                    )
                 )
 
 

--- a/src/conductor/cli/plugin.py
+++ b/src/conductor/cli/plugin.py
@@ -138,14 +138,20 @@ def fetch_plugins(
             state = "cached (ref not re-checked)"
         else:
             state = "fetched" if entry.fetched else "cached"
-        mark = "[yellow]⚠[/yellow]" if entry.stale else "[green]✓[/green]"
-        # Assembled in one ``styled`` call rather than an f-string: an
-        # f-string renders a ``Text`` as its plain form, which would drop the
-        # ✓/⚠ colour that is the whole point of the marker column on a
-        # command CI gates on.
+        # Passed as a value rather than concatenated into the template: the
+        # template is meant to be a conductor literal, and building it from a
+        # variable is the shape that becomes an injection site the day the
+        # variable holds runtime data. ``styled`` splices a pre-styled
+        # ``Text`` with its spans intact, which is what it is for.
+        mark = (
+            Text.from_markup("[yellow]⚠[/yellow]")
+            if entry.stale
+            else Text.from_markup("[green]✓[/green]")
+        )
         output_console.print(
             styled(
-                "  " + mark + " {} — {} — {}, {} plugin(s)",
+                "  {} {} — {} — {}, {} plugin(s)",
+                mark,
                 name,
                 detail,
                 state,

--- a/src/conductor/cli/registry.py
+++ b/src/conductor/cli/registry.py
@@ -6,9 +6,10 @@ from typing import Annotated
 
 import httpx
 import typer
-from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
+from conductor.console import make_console, styled
 from conductor.registry.cache import clear_cache, prune_temp_dirs
 from conductor.registry.config import (
     RegistryEntry,
@@ -32,8 +33,8 @@ registry_app = typer.Typer(
     no_args_is_help=True,
 )
 
-console = Console(stderr=True)
-output_console = Console()
+console = make_console(stderr=True)
+output_console = make_console()
 
 
 @registry_app.command("list")
@@ -50,7 +51,7 @@ def list_registries(
         else:
             _list_registry_workflows(name)
     except RegistryError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
+        console.print(styled("[bold red]Error:[/bold red] {}", e))
         raise typer.Exit(code=1) from None
 
 
@@ -60,7 +61,9 @@ def _list_all_registries() -> None:
 
     if not config.registries:
         output_console.print("No registries configured.")
-        output_console.print("Run [bold]conductor registry add <name> <source>[/bold] to add one.")
+        output_console.print(
+            Text.from_markup("Run [bold]conductor registry add <name> <source>[/bold] to add one.")
+        )
         return
 
     table = Table(title="Configured Registries")
@@ -98,7 +101,9 @@ def _list_registry_workflows(name: str) -> None:
     if tags_line is not None:
         output_console.print(f"\nLatest tags: {tags_line}")
 
-    output_console.print("\n[dim]Use 'conductor show <workflow>' to see inputs and details.[/dim]")
+    output_console.print(
+        Text.from_markup("\n[dim]Use 'conductor show <workflow>' to see inputs and details.[/dim]")
+    )
 
 
 def _format_latest_tags(entry: RegistryEntry) -> str | None:
@@ -154,7 +159,7 @@ def add(
         if default:
             output_console.print(f"Set '{name}' as the default registry.")
     except RegistryError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
+        console.print(styled("[bold red]Error:[/bold red] {}", e))
         raise typer.Exit(code=1) from None
 
 
@@ -167,7 +172,7 @@ def remove(
         remove_registry(name)
         output_console.print(f"Registry '{name}' removed.")
     except RegistryError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
+        console.print(styled("[bold red]Error:[/bold red] {}", e))
         raise typer.Exit(code=1) from None
 
 
@@ -187,7 +192,7 @@ def set_default(
         save_config(config)
         output_console.print(f"Default registry set to '{name}'.")
     except RegistryError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
+        console.print(styled("[bold red]Error:[/bold red] {}", e))
         raise typer.Exit(code=1) from None
 
 
@@ -242,7 +247,7 @@ def update(
                 load_index(entry)
                 output_console.print(f"Registry '{reg_name}' updated.")
     except RegistryError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
+        console.print(styled("[bold red]Error:[/bold red] {}", e))
         raise typer.Exit(code=1) from None
 
 
@@ -258,15 +263,15 @@ def show(
         entry = get_registry(name)
         _show_registry(name, entry)
     except RegistryError as e:
-        console.print(f"[bold red]Error:[/bold red] {e}")
+        console.print(styled("[bold red]Error:[/bold red] {}", e))
         raise typer.Exit(code=1) from None
 
 
 def _show_registry(name: str, entry: RegistryEntry) -> None:
     """Show a registry's details and its workflows."""
-    output_console.print(f"[bold]Registry:[/bold]  {name}")
-    output_console.print(f"[bold]Type:[/bold]      {entry.type.value}")
-    output_console.print(f"[bold]Source:[/bold]    {entry.source}")
+    output_console.print(styled("[bold]Registry:[/bold]  {}", name))
+    output_console.print(styled("[bold]Type:[/bold]      {}", entry.type.value))
+    output_console.print(styled("[bold]Source:[/bold]    {}", entry.source))
     output_console.print()
 
     index = load_index(entry)
@@ -287,4 +292,6 @@ def _show_registry(name: str, entry: RegistryEntry) -> None:
     if tags_line is not None:
         output_console.print(f"\nLatest tags: {tags_line}")
 
-    output_console.print("\n[dim]Use 'conductor show <workflow>' to see inputs and details.[/dim]")
+    output_console.print(
+        Text.from_markup("\n[dim]Use 'conductor show <workflow>' to see inputs and details.[/dim]")
+    )

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -22,8 +22,10 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 from conductor.config.loader import load_config
+from conductor.console import _MarkupFreeConsole, join, make_console, styled
 from conductor.engine.workflow import ExecutionPlan, WorkflowEngine
 from conductor.exceptions import WorkflowTerminated
 from conductor.mcp_auth import resolve_mcp_server_config
@@ -52,17 +54,21 @@ logger = logging.getLogger(__name__)
 # silently bypass ``--silent`` if used on this instance. All current call
 # sites in this module use only ``.print``; if you introduce a new one,
 # either route it through ``.print`` or extend this subclass.
-class _SilentAwareConsole(Console):
+class _SilentAwareConsole(_MarkupFreeConsole):
     """``Console`` that honors ``--silent`` at the print level.
 
     The instance is locked to ``stderr=True`` to preserve the contract that
     ``--silent`` runs emit JSON on stdout with nothing else; routing gated
     output to stdout would corrupt that channel.
+
+    It is also locked to ``markup=False``, matching ``make_console``: this
+    console renders workflow, agent and for-each iteration names, so a plain
+    string must not be parsed as styling (#406). Style with ``styled``.
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        # Lock stderr=True; everything else (highlight, width, etc.) is
-        # caller-tunable.
+        # Lock stderr=True and markup=False; everything else (highlight,
+        # width, etc.) is caller-tunable.
         kwargs.pop("stderr", None)
         super().__init__(stderr=True, **kwargs)
 
@@ -141,25 +147,28 @@ def close_file_logging() -> None:
         _file_handle = None
 
 
-def verbose_log(message: str, style: str = "dim") -> None:
+def verbose_log(message: str | Text, style: str = "dim") -> None:
     """Log a message if verbose mode is enabled.
 
     Args:
-        message: The message to log.
+        message: The message to log. A ``str`` is treated as literal text; a
+            ``Text`` (e.g. from ``styled``) keeps its styling. Accepting both
+            matters because an f-string renders a ``Text`` as its plain form,
+            silently discarding the styling a caller went out of its way to
+            build (#406).
         style: Rich style for the message.
     """
     from conductor.cli.app import is_verbose
 
+    # ``Text`` not an f-string for a plain ``str``: ``message`` is
+    # agent-supplied, and interpolating it into markup makes a bracketed token
+    # like ``[/nestedType]`` a closing tag and raises MarkupError (#382).
+    # ``style=`` does not disable markup parsing, so it is not a substitute.
+    renderable = message if isinstance(message, Text) else Text(message)
     if is_verbose():
-        # ``Text`` not an f-string: ``message`` is agent-supplied, and
-        # interpolating it into markup makes a bracketed token like
-        # ``[/nestedType]`` a closing tag and raises MarkupError (#382).
-        # ``style=`` does not disable markup parsing, so it is not a substitute.
-        from rich.text import Text
-
-        _verbose_console.print(Text(message), style=style)
+        _verbose_console.print(renderable, style=style)
     if _file_console is not None:
-        _file_console.print(message)
+        _file_console.print(renderable)
 
 
 def _describe_provider(provider: ProviderSettings) -> str:
@@ -351,17 +360,31 @@ def verbose_log_section(title: str, content: str) -> None:
         # ``[/nestedType]`` in ordinary technical prose would raise MarkupError
         # and kill the run (#382). ``Text`` rather than ``escape``: escaping is
         # not byte-exact for input that already contains a backslash before a
-        # bracket (``\[0-9\]+`` renders as ``[0-9\]+``). ``title`` is
-        # conductor-controlled, so it keeps its styling.
+        # bracket (``\[0-9\]+`` renders as ``[0-9\]+``).
+        #
+        # ``title`` is *not* conductor-controlled, as this comment used to
+        # claim. Its only non-constant caller passes ``Prompt for '<agent>'``,
+        # and inside a for-each group the engine rewrites that name to
+        # ``<agent>[<key>]`` where the key comes from the source item -- so a
+        # key of ``task1`` erased the iteration identity the qualified name
+        # exists to carry, and one of ``/etc/x`` killed the run from a logging
+        # call (#406). ``Panel`` parses its title with ``Text.from_markup``
+        # regardless of the console's ``markup=False``, so this has to be a
+        # ``Text``, not an f-string.
         _verbose_console.print(
-            Panel(Text(content), title=f"[cyan]{title}[/cyan]", border_style="dim")
+            Panel(
+                Text(content),
+                title=styled("[cyan]{}[/cyan]", title),
+                border_style="dim",
+            )
         )
 
     # File always gets full untruncated content
     if _file_console is not None:
         # Deliberately not escaped: ``_file_console`` has ``markup=False``, so
-        # escaping here would write literal backslashes into the log.
-        _file_console.print(Panel(content, title=title, border_style="dim"))
+        # escaping here would write literal backslashes into the log. The title
+        # still needs wrapping -- ``markup=False`` does not reach it.
+        _file_console.print(Panel(content, title=Text(title), border_style="dim"))
 
 
 def verbose_log_timing(operation: str, elapsed: float) -> None:
@@ -374,7 +397,7 @@ def verbose_log_timing(operation: str, elapsed: float) -> None:
     from conductor.cli.app import is_verbose
 
     if is_verbose():
-        _verbose_console.print(f"[dim]⏱ {operation}: {elapsed:.2f}s[/dim]")
+        _verbose_console.print(styled("[dim]⏱ {}: {:.2f}s[/dim]", operation, elapsed))
     if _file_console is not None:
         _file_console.print(f"⏱ {operation}: {elapsed:.2f}s")
 
@@ -862,25 +885,29 @@ def _maybe_print_experimental_banner(data: dict[str, Any]) -> None:
                 exc,
             )
 
-        header_bits = [f"[bold]{provider_name}[/bold]"]
+        header_bits = [styled("[bold]{}[/bold]", provider_name)]
         if pin:
-            header_bits.append(f"([dim]{pin}[/dim])")
+            header_bits.append(styled("([dim]{}[/dim])", pin))
         if maintainer:
-            header_bits.append(f"maintained by [dim]{maintainer}[/dim]")
-        header = " ".join(header_bits)
+            header_bits.append(styled("maintained by [dim]{}[/dim]", maintainer))
+        header = join(" ", header_bits)
 
-        body_lines = [f"⚠ Experimental provider in use: {header}"]
+        body_lines = [styled("⚠ Experimental provider in use: {}", header)]
         if limitations:
-            body_lines.append("Limitations: " + ", ".join(limitations) + ".")
-        body_lines.append("See [link]docs/providers/experimental.md[/link] for stability policy.")
+            body_lines.append(Text("Limitations: " + ", ".join(limitations) + "."))
+        body_lines.append(
+            Text.from_markup(
+                "See [link]docs/providers/experimental.md[/link] for stability policy."
+            )
+        )
 
-        # ``Text.from_markup`` rather than a markup-bearing string: this panel
-        # goes to both consoles, and ``_file_console`` has ``markup=False``, so
-        # a raw string would write ``[bold]``/``[dim]`` tags literally into the
-        # log instead of styling them. Resolving the markup once here renders
-        # identically on both sinks.
+        # Built as ``Text`` rather than a markup-bearing string: this panel
+        # goes to both consoles, and both have ``markup=False``, so a raw
+        # string would write ``[bold]``/``[dim]`` tags literally instead of
+        # styling them. Resolving the markup once here renders identically on
+        # both sinks.
         panel = Panel(
-            Text.from_markup("\n".join(body_lines)),
+            join("\n", body_lines),
             border_style="yellow",
             expand=False,
         )
@@ -1164,7 +1191,7 @@ def display_usage_summary(usage_data: dict[str, Any], console: Console | None = 
 
     _print()
     _print("=" * 60, style="dim")
-    _print("[bold cyan]Token Usage Summary[/bold cyan]")
+    _print(Text.from_markup("[bold cyan]Token Usage Summary[/bold cyan]"))
 
     # Token totals
     total_input = usage_data.get("total_input_tokens", 0)
@@ -1176,7 +1203,7 @@ def display_usage_summary(usage_data: dict[str, Any], console: Console | None = 
         _print(f"  Output: {total_output:,} tokens", style="dim")
         _print(f"  Total:  {total_tokens:,} tokens", style="dim")
     else:
-        _print("  [dim]No token data available[/dim]")
+        _print(Text.from_markup("  [dim]No token data available[/dim]"))
 
     # Cost breakdown
     total_cost = usage_data.get("total_cost_usd")
@@ -1195,7 +1222,7 @@ def display_usage_summary(usage_data: dict[str, Any], console: Console | None = 
 
     if total_cost is not None and total_cost > 0:
         _print()
-        _print("[bold cyan]Cost Breakdown:[/bold cyan]")
+        _print(Text.from_markup("[bold cyan]Cost Breakdown:[/bold cyan]"))
 
         for agent in agents:
             agent_cost = agent.get("cost_usd")
@@ -1209,16 +1236,26 @@ def display_usage_summary(usage_data: dict[str, Any], console: Console | None = 
         if unpriced_count:
             # Partial total: flag it so a silently-undercounted number is not
             # presented as complete (see #265).
-            _print(f"  [bold]Total: ~${total_cost:.4f}[/bold][yellow]{_unpriced_suffix()}[/yellow]")
-            _print("  [dim]Partial total — some agents' models had no available pricing.[/dim]")
+            _print(
+                styled(
+                    "  [bold]Total: ~${:.4f}[/bold][yellow]{}[/yellow]",
+                    total_cost,
+                    _unpriced_suffix(),
+                )
+            )
+            _print(
+                Text.from_markup(
+                    "  [dim]Partial total — some agents' models had no available pricing.[/dim]"
+                )
+            )
         else:
-            _print(f"  [bold]Total: ${total_cost:.4f}[/bold]")
+            _print(styled("  [bold]Total: ${:.4f}[/bold]", total_cost))
     elif total_tokens > 0:
         _print()
         if unpriced_count:
-            _print(f"  [dim]Cost data unavailable{_unpriced_suffix()}[/dim]")
+            _print(styled("  [dim]Cost data unavailable{}[/dim]", _unpriced_suffix()))
         else:
-            _print("  [dim]Cost data unavailable (unknown model pricing)[/dim]")
+            _print(Text.from_markup("  [dim]Cost data unavailable (unknown model pricing)[/dim]"))
 
     _print("=" * 60, style="dim")
 
@@ -1570,6 +1607,11 @@ def _print_loaded_instructions(detailed: list[DiscoveredInstruction]) -> None:
     from conductor.config.instructions import ALWAYS_ON_SCOPE
 
     if not detailed:
+        # Plain strings on the builtin ``print``: this goes to stderr as a
+        # grep label, not through a Rich console. Wrapping it in
+        # ``Text.from_markup`` would delete the ``[workspace-instructions]``
+        # prefix outright — it starts with a lowercase letter, so Rich reads
+        # it as a style tag, and ``print`` then renders the Text's plain form.
         print("[workspace-instructions] 0 files discovered from CWD.", file=sys.stderr)
         return
     print(
@@ -1636,7 +1678,9 @@ async def run_workflow_async(
             init_file_logging(log_file)
         except OSError as e:
             _verbose_console.print(
-                f"[bold yellow]Warning:[/bold yellow] Cannot open log file {log_file}: {e}"
+                styled(
+                    "[bold yellow]Warning:[/bold yellow] Cannot open log file {}: {}", log_file, e
+                )
             )
 
     # Always create event emitter and JSONL log subscriber
@@ -1661,11 +1705,16 @@ async def run_workflow_async(
             from conductor.cli.app import is_verbose
 
             if is_verbose():
-                _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
+                _verbose_console.print(
+                    styled("[bold cyan]Dashboard:[/bold cyan] {}", dashboard.url)
+                )
         except Exception as e:
             _verbose_console.print(
-                f"[bold yellow]Warning:[/bold yellow] "
-                f"Dashboard failed to start: {e}. Continuing without dashboard."
+                styled(
+                    "[bold yellow]Warning:[/bold yellow] Dashboard failed to "
+                    "start: {}. Continuing without dashboard.",
+                    e,
+                )
             )
             dashboard = None
 
@@ -1804,7 +1853,9 @@ async def run_workflow_async(
             try:
                 if listener is not None:
                     await listener.start()
-                    _verbose_console.print("[dim]Press Esc to interrupt and provide guidance[/dim]")
+                    _verbose_console.print(
+                        Text.from_markup("[dim]Press Esc to interrupt and provide guidance[/dim]")
+                    )
 
                 result = await _run_with_stop_signal(engine, inputs, dashboard)
             except WorkflowTerminated as exc:
@@ -1855,14 +1906,17 @@ async def run_workflow_async(
 
                     if is_verbose():
                         banner = (
-                            "[bold yellow]Workflow terminated.[/bold yellow]"
+                            Text.from_markup("[bold yellow]Workflow terminated.[/bold yellow]")
                             if terminate_exc is not None
-                            else "[bold green]Workflow complete.[/bold green]"
+                            else Text.from_markup("[bold green]Workflow complete.[/bold green]")
                         )
                         _verbose_console.print(
-                            f"\n{banner} "
-                            f"Dashboard still running at {dashboard.url} — "
-                            f"press [bold]Ctrl+C[/bold] to exit."
+                            styled(
+                                "\n{} Dashboard still running at {} — press "
+                                "[bold]Ctrl+C[/bold] to exit.",
+                                banner,
+                                dashboard.url,
+                            )
                         )
                     with contextlib.suppress(asyncio.CancelledError):
                         await asyncio.Event().wait()
@@ -1887,25 +1941,27 @@ async def run_workflow_async(
         # Close JSONL event log and report path
         if event_log_subscriber is not None:
             event_log_subscriber.close()
-            _verbose_console.print(f"[dim]Event log written to: {event_log_subscriber.path}[/dim]")
+            _verbose_console.print(
+                styled("[dim]Event log written to: {}[/dim]", event_log_subscriber.path)
+            )
 
         # Report log file path to stderr and close file logging
         if log_file is not None and _file_console is not None:
-            _verbose_console.print(f"[dim]Log written to: {log_file}[/dim]")
+            _verbose_console.print(styled("[dim]Log written to: {}[/dim]", log_file))
         close_file_logging()
 
 
-def format_routes(routes: list[dict[str, Any]]) -> str:
+def format_routes(routes: list[dict[str, Any]]) -> Text:
     """Format routes for display in the dry-run table.
 
     Args:
         routes: List of route dictionaries with 'to', 'when', and 'is_conditional' keys.
 
     Returns:
-        Formatted string representation of routes.
+        Formatted representation of routes.
     """
     if not routes:
-        return "[dim]$end[/dim]"
+        return Text.from_markup("[dim]$end[/dim]")
 
     parts = []
     for route in routes:
@@ -1914,10 +1970,10 @@ def format_routes(routes: list[dict[str, Any]]) -> str:
             # Truncate long conditions
             if len(condition) > 40:
                 condition = condition[:37] + "..."
-            parts.append(f"→ {route['to']} [dim](if {condition})[/dim]")
+            parts.append(styled("→ {} [dim](if {})[/dim]", route["to"], condition))
         else:
             parts.append(f"→ {route['to']}")
-    return "\n".join(parts) if parts else "[dim]$end[/dim]"
+    return join("\n", parts) if parts else Text.from_markup("[dim]$end[/dim]")
 
 
 def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) -> None:
@@ -1930,17 +1986,21 @@ def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) 
         plan: The execution plan to display.
         console: Optional Rich console. Creates one if not provided.
     """
-    output_console = console if console is not None else Console()
+    output_console = console if console is not None else make_console()
 
     # Header panel with workflow metadata
     timeout_display = f"{plan.timeout_seconds}s" if plan.timeout_seconds else "unlimited"
-    header_content = (
-        f"[bold]Workflow:[/bold] {plan.workflow_name}\n"
-        f"[bold]Entry Point:[/bold] {plan.entry_point}\n"
-        f"[bold]Max Iterations:[/bold] {plan.max_iterations}\n"
-        f"[bold]Timeout:[/bold] {timeout_display}"
+    header_content = styled(
+        "[bold]Workflow:[/bold] {}\n[bold]Entry Point:[/bold] "
+        "{}\n[bold]Max Iterations:[/bold] {}\n[bold]Timeout:[/bold] {}",
+        plan.workflow_name,
+        plan.entry_point,
+        plan.max_iterations,
+        timeout_display,
     )
-    output_console.print(Panel(header_content, title="[cyan]Execution Plan (Dry Run)[/cyan]"))
+    output_console.print(
+        Panel(header_content, title=Text.from_markup("[cyan]Execution Plan (Dry Run)[/cyan]"))
+    )
 
     # Steps table
     table = Table(title="Agent Sequence", show_lines=True)
@@ -1952,13 +2012,15 @@ def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) 
 
     for i, step in enumerate(plan.steps, 1):
         routes_str = format_routes(step.routes)
-        loop_marker = " [yellow](loop target)[/yellow]" if step.is_loop_target else ""
+        loop_marker = (
+            Text.from_markup(" [yellow](loop target)[/yellow]") if step.is_loop_target else ""
+        )
 
         # Handle parallel groups differently
         if step.agent_type == "parallel_group":
             # Show parallel group with failure mode
             failure_mode_display = step.failure_mode or "fail_fast"
-            model_info = f"[dim]{failure_mode_display}[/dim]"
+            model_info = styled("[dim]{}[/dim]", failure_mode_display)
 
             table.add_row(
                 str(i),
@@ -1970,12 +2032,12 @@ def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) 
 
             # Add a detail row showing which agents execute in parallel
             if step.parallel_agents:
-                agents_display = ", ".join(
-                    f"[cyan]{agent}[/cyan]" for agent in step.parallel_agents
+                agents_display = join(
+                    ", ", (styled("[cyan]{}[/cyan]", agent) for agent in step.parallel_agents)
                 )
                 table.add_row(
                     "",
-                    f"[dim]  ⚡ {agents_display}[/dim]",
+                    styled("[dim]  ⚡ {}[/dim]", agents_display),
                     "",
                     "",
                     "",
@@ -1985,7 +2047,7 @@ def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) 
                 str(i),
                 f"{step.agent_name}{loop_marker}",
                 step.agent_type,
-                step.model or "[dim]default[/dim]",
+                step.model or Text.from_markup("[dim]default[/dim]"),
                 routes_str,
             )
 
@@ -1999,15 +2061,15 @@ def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) 
     )
 
     summary_parts = [
-        f"[dim]Total steps:[/dim] {len(plan.steps)}",
-        f"[dim]Loop targets:[/dim] {sum(1 for s in plan.steps if s.is_loop_target)}",
+        styled("[dim]Total steps:[/dim] {}", len(plan.steps)),
+        styled("[dim]Loop targets:[/dim] {}", sum(1 for s in plan.steps if s.is_loop_target)),
     ]
 
     if parallel_group_count > 0:
-        summary_parts.append(f"[dim]Parallel groups:[/dim] {parallel_group_count}")
-        summary_parts.append(f"[dim]Parallel agents:[/dim] {total_parallel_agents}")
+        summary_parts.append(styled("[dim]Parallel groups:[/dim] {}", parallel_group_count))
+        summary_parts.append(styled("[dim]Parallel agents:[/dim] {}", total_parallel_agents))
 
-    output_console.print(" | ".join(summary_parts))
+    output_console.print(join(" | ", summary_parts))
 
 
 def build_dry_run_plan(workflow_path: Path) -> ExecutionPlan:
@@ -2094,13 +2156,19 @@ def _print_resume_instructions(engine: WorkflowEngine) -> None:
         return
 
     _verbose_console.print()
-    _verbose_console.print(f"[bold yellow]Workflow state saved to:[/bold yellow] {checkpoint_path}")
     _verbose_console.print(
-        f"[bold yellow]Resume with:[/bold yellow] conductor resume --from {checkpoint_path}"
+        styled("[bold yellow]Workflow state saved to:[/bold yellow] {}", checkpoint_path)
+    )
+    _verbose_console.print(
+        styled(
+            "[bold yellow]Resume with:[/bold yellow] conductor resume --from {}", checkpoint_path
+        )
     )
     if engine.workflow_path is not None:
         _verbose_console.print(
-            f"[dim]Or resume latest checkpoint:[/dim] conductor resume {engine.workflow_path}"
+            styled(
+                "[dim]Or resume latest checkpoint:[/dim] conductor resume {}", engine.workflow_path
+            )
         )
     _verbose_console.print()
 
@@ -2167,7 +2235,9 @@ async def resume_workflow_async(
             init_file_logging(log_file)
         except OSError as e:
             _verbose_console.print(
-                f"[bold yellow]Warning:[/bold yellow] Cannot open log file {log_file}: {e}"
+                styled(
+                    "[bold yellow]Warning:[/bold yellow] Cannot open log file {}: {}", log_file, e
+                )
             )
 
     # Always create event emitter and JSONL log subscriber (parity with run)
@@ -2210,9 +2280,11 @@ async def resume_workflow_async(
         current_hash = CheckpointManager.compute_workflow_hash(resolved_workflow_path)
         if current_hash != cp.workflow_hash:
             _verbose_console.print(
-                "[bold yellow]⚠ Warning:[/bold yellow] "
-                "Workflow file has changed since checkpoint was created. "
-                "Resume may produce unexpected results."
+                Text.from_markup(
+                    "[bold yellow]⚠ Warning:[/bold yellow] "
+                    "Workflow file has changed since checkpoint was created. "
+                    "Resume may produce unexpected results."
+                )
             )
 
         # Log checkpoint details
@@ -2395,11 +2467,16 @@ async def resume_workflow_async(
                     from conductor.cli.app import is_verbose
 
                     if is_verbose():
-                        _verbose_console.print(f"[bold cyan]Dashboard:[/bold cyan] {dashboard.url}")
+                        _verbose_console.print(
+                            styled("[bold cyan]Dashboard:[/bold cyan] {}", dashboard.url)
+                        )
                 except Exception as e:
                     _verbose_console.print(
-                        f"[bold yellow]Warning:[/bold yellow] "
-                        f"Dashboard failed to start: {e}. Continuing without dashboard."
+                        styled(
+                            "[bold yellow]Warning:[/bold yellow] Dashboard failed to "
+                            "start: {}. Continuing without dashboard.",
+                            e,
+                        )
                     )
                     # Drop the dashboard everywhere it's been wired up.
                     # The engine + DialogHandler captured it at construction
@@ -2416,7 +2493,9 @@ async def resume_workflow_async(
             try:
                 if listener is not None:
                     await listener.start()
-                    _verbose_console.print("[dim]Press Esc to interrupt and provide guidance[/dim]")
+                    _verbose_console.print(
+                        Text.from_markup("[dim]Press Esc to interrupt and provide guidance[/dim]")
+                    )
 
                 result = await _resume_with_stop_signal(engine, cp.current_agent, dashboard)
             except WorkflowTerminated as exc:
@@ -2467,14 +2546,17 @@ async def resume_workflow_async(
 
                     if is_verbose():
                         banner = (
-                            "[bold yellow]Workflow terminated.[/bold yellow]"
+                            Text.from_markup("[bold yellow]Workflow terminated.[/bold yellow]")
                             if terminate_exc is not None
-                            else "[bold green]Workflow complete.[/bold green]"
+                            else Text.from_markup("[bold green]Workflow complete.[/bold green]")
                         )
                         _verbose_console.print(
-                            f"\n{banner} "
-                            f"Dashboard still running at {dashboard.url} — "
-                            f"press [bold]Ctrl+C[/bold] to exit."
+                            styled(
+                                "\n{} Dashboard still running at {} — press "
+                                "[bold]Ctrl+C[/bold] to exit.",
+                                banner,
+                                dashboard.url,
+                            )
                         )
                     with contextlib.suppress(asyncio.CancelledError):
                         await asyncio.Event().wait()
@@ -2497,11 +2579,13 @@ async def resume_workflow_async(
         # Close JSONL event log and report path
         if event_log_subscriber is not None:
             event_log_subscriber.close()
-            _verbose_console.print(f"[dim]Event log written to: {event_log_subscriber.path}[/dim]")
+            _verbose_console.print(
+                styled("[dim]Event log written to: {}[/dim]", event_log_subscriber.path)
+            )
 
         # Report log file path to stderr and close file logging
         if log_file is not None and _file_console is not None:
-            _verbose_console.print(f"[dim]Log written to: {log_file}[/dim]")
+            _verbose_console.print(styled("[dim]Log written to: {}[/dim]", log_file))
         close_file_logging()
 
 
@@ -2564,9 +2648,19 @@ async def _prefetch_plugin_sources(config: Any, workflow_path: Path) -> dict[str
         if entry.stale:
             # This line says the run used a plugin version nobody could
             # verify, so it gets the marker rather than reading as one more
-            # startup progress line.
-            detail = f"{detail} [yellow]⚠ cached; ref not re-checked[/yellow]"
-        verbose_log(f"  {name}: {detail} — {len(entry.marketplace.plugins)} plugin(s)")
+            # startup progress line. Assembled in one ``styled`` call: an
+            # f-string would render the Text as its plain form and drop the
+            # yellow that makes it stand out.
+            verbose_log(
+                styled(
+                    "  {}: {} [yellow]⚠ cached; ref not re-checked[/yellow] — {} plugin(s)",
+                    name,
+                    detail,
+                    len(entry.marketplace.plugins),
+                )
+            )
+        else:
+            verbose_log(f"  {name}: {detail} — {len(entry.marketplace.plugins)} plugin(s)")
     return marketplaces_from(resolved)
 
 

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -25,7 +25,7 @@ from rich.table import Table
 from rich.text import Text
 
 from conductor.config.loader import load_config
-from conductor.console import _MarkupFreeConsole, join, make_console, styled
+from conductor.console import MarkupFreeConsole, join, make_console, styled
 from conductor.engine.workflow import ExecutionPlan, WorkflowEngine
 from conductor.exceptions import WorkflowTerminated
 from conductor.mcp_auth import resolve_mcp_server_config
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # silently bypass ``--silent`` if used on this instance. All current call
 # sites in this module use only ``.print``; if you introduce a new one,
 # either route it through ``.print`` or extend this subclass.
-class _SilentAwareConsole(_MarkupFreeConsole):
+class _SilentAwareConsole(MarkupFreeConsole):
     """``Console`` that honors ``--silent`` at the print level.
 
     The instance is locked to ``stderr=True`` to preserve the contract that
@@ -224,8 +224,6 @@ def verbose_log_agent_start(agent_name: str, iteration: int) -> None:
         agent_name: Name of the agent being executed.
         iteration: Current iteration number (1-indexed).
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -270,8 +268,6 @@ def verbose_log_agent_complete(
         input_tokens: Input tokens used (if available).
         output_tokens: Output tokens generated (if available).
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -310,8 +306,6 @@ def verbose_log_route(target: str) -> None:
     Args:
         target: The routing target.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -344,8 +338,6 @@ def verbose_log_section(title: str, content: str) -> None:
         title: Section title.
         content: Section content.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_full, is_verbose
 
     # Sections are detail-level: show on console only in FULL mode
@@ -409,8 +401,6 @@ def verbose_log_parallel_start(group_name: str, agent_count: int) -> None:
         group_name: Name of the parallel group.
         agent_count: Number of agents in the group.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -449,8 +439,6 @@ def verbose_log_parallel_agent_complete(
         tokens: Tokens used (if any).
         cost_usd: Estimated cost in USD (if available).
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -491,8 +479,6 @@ def verbose_log_parallel_agent_failed(
         exception_type: Type of exception.
         message: Error message.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -529,8 +515,6 @@ def verbose_log_agent_timeout(
         elapsed: Elapsed time in seconds.
         timeout_seconds: Configured timeout limit.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -567,8 +551,6 @@ def verbose_log_budget_exceeded(
         budget_mode: Active mode (``audit`` or ``enforce``).
         current_agent: Agent executing when the budget was exceeded.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -603,8 +585,6 @@ def verbose_log_parallel_summary(
         failure_count: Number of agents that failed.
         total_elapsed: Total elapsed time in seconds.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -653,8 +633,6 @@ def verbose_log_for_each_start(
         max_concurrent: Maximum concurrent executions.
         failure_mode: Failure mode (fail_fast, continue_on_error, all_or_nothing).
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -693,8 +671,6 @@ def verbose_log_for_each_item_complete(
         tokens: Tokens used (if any).
         cost_usd: Estimated cost in USD (if available).
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -733,8 +709,6 @@ def verbose_log_for_each_item_failed(
         exception_type: Type of exception.
         message: Error message.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -773,8 +747,6 @@ def verbose_log_for_each_summary(
         failure_count: Number of items that failed.
         total_elapsed: Total elapsed time in seconds.
     """
-    from rich.text import Text
-
     from conductor.cli.app import is_verbose
 
     should_console = is_verbose()
@@ -848,7 +820,6 @@ def _maybe_print_experimental_banner(data: dict[str, Any]) -> None:
     )
 
     from rich.panel import Panel
-    from rich.text import Text
 
     for provider_name, meta in providers.items():
         if not isinstance(meta, dict):
@@ -1973,7 +1944,9 @@ def format_routes(routes: list[dict[str, Any]]) -> Text:
             parts.append(styled("→ {} [dim](if {})[/dim]", route["to"], condition))
         else:
             parts.append(f"→ {route['to']}")
-    return join("\n", parts) if parts else Text.from_markup("[dim]$end[/dim]")
+    # ``parts`` cannot be empty: ``routes`` is non-empty past the guard above
+    # and every iteration appends.
+    return join("\n", parts)
 
 
 def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) -> None:
@@ -2012,6 +1985,10 @@ def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) 
 
     for i, step in enumerate(plan.steps, 1):
         routes_str = format_routes(step.routes)
+        # Interpolated via ``styled`` rather than an f-string at the two call
+        # sites below: an f-string renders a ``Text`` as its plain form, which
+        # would silently drop the yellow that makes a loop target stand out
+        # from the agent names around it (#406).
         loop_marker = (
             Text.from_markup(" [yellow](loop target)[/yellow]") if step.is_loop_target else ""
         )
@@ -2024,7 +2001,7 @@ def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) 
 
             table.add_row(
                 str(i),
-                f"{step.agent_name}{loop_marker}",
+                styled("{}{}", step.agent_name, loop_marker),
                 step.agent_type,
                 model_info,
                 routes_str,
@@ -2045,7 +2022,7 @@ def display_execution_plan(plan: ExecutionPlan, console: Console | None = None) 
         else:
             table.add_row(
                 str(i),
-                f"{step.agent_name}{loop_marker}",
+                styled("{}{}", step.agent_name, loop_marker),
                 step.agent_type,
                 step.model or Text.from_markup("[dim]default[/dim]"),
                 routes_str,

--- a/src/conductor/cli/update.py
+++ b/src/conductor/cli/update.py
@@ -26,8 +26,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from rich.console import Console
+from rich.text import Text
 
 from conductor import __version__
+from conductor.console import styled
 
 logger = logging.getLogger(__name__)
 
@@ -304,10 +306,14 @@ def _print_hint(console: Console, remote_version: str) -> None:
         remote_version: The newer version available.
     """
     console.print(
-        f"💡 Conductor v{remote_version} available "
-        f"(you have v{__version__}). "
-        f"Run [bold]'conductor update'[/bold] to see how, "
-        f"or [bold]'conductor update --apply'[/bold] to upgrade in one step.",
+        styled(
+            "💡 Conductor v{} available (you have v{}). Run "
+            "[bold]'conductor update'[/bold] to see how, or "
+            "[bold]'conductor update --apply'[/bold] to upgrade in one "
+            "step.",
+            remote_version,
+            __version__,
+        ),
         style="yellow",
     )
 
@@ -397,16 +403,21 @@ def _spawn_installer_and_exit(console: Console) -> None:
 
         if not spawned:
             assert last_error is not None
-            console.print(f"[bold red]Could not spawn installer:[/bold red] {last_error}")
+            console.print(styled("[bold red]Could not spawn installer:[/bold red] {}", last_error))
             console.print(
-                f"Run this manually in a new shell:  [bold cyan]{_install_command()}[/bold cyan]"
+                styled(
+                    "Run this manually in a new shell:  [bold cyan]{}[/bold cyan]",
+                    _install_command(),
+                )
             )
             raise SystemExit(1) from None
 
         console.print(
-            "[green]Installer launched in a new console window.[/green] "
-            "This conductor process will now exit so file locks release. "
-            "Watch the new window for progress."
+            Text.from_markup(
+                "[green]Installer launched in a new console window.[/green] "
+                "This conductor process will now exit so file locks release. "
+                "Watch the new window for progress."
+            )
         )
         # Exit immediately so the venv we live in becomes deletable.
         raise SystemExit(0)
@@ -415,7 +426,9 @@ def _spawn_installer_and_exit(console: Console) -> None:
     # so its output streams directly to this terminal.
     sh_command = f"curl -sSfL {_INSTALL_SH_URL} | sh"
     console.print(
-        "[green]Replacing conductor with installer…[/green] (install script output follows)"
+        Text.from_markup(
+            "[green]Replacing conductor with installer…[/green] (install script output follows)"
+        )
     )
     # os.execvpe replaces the current process image, so we need to flush
     # any buffered Rich output first.
@@ -423,8 +436,8 @@ def _spawn_installer_and_exit(console: Console) -> None:
     try:
         os.execvpe("sh", ["sh", "-c", sh_command], env)
     except OSError as e:
-        console.print(f"[bold red]Could not exec installer:[/bold red] {e}")
-        console.print(f"Run this manually:  [bold cyan]{_install_command()}[/bold cyan]")
+        console.print(styled("[bold red]Could not exec installer:[/bold red] {}", e))
+        console.print(styled("Run this manually:  [bold cyan]{}[/bold cyan]", _install_command()))
         raise SystemExit(1) from None
 
 
@@ -447,23 +460,29 @@ def run_update(console: Console, force: bool = False, apply: bool = False) -> No
     """
     del force  # accepted for backward compatibility; ignored
 
-    console.print("[bold]Checking for updates…[/bold]")
+    console.print(Text.from_markup("[bold]Checking for updates…[/bold]"))
 
     result = fetch_latest_version()
     if result is None:
-        console.print("[bold red]Error:[/bold red] Could not reach GitHub to check for updates.")
+        console.print(
+            Text.from_markup(
+                "[bold red]Error:[/bold red] Could not reach GitHub to check for updates."
+            )
+        )
         return
 
     version, _tag_name, _url = result
     current = __version__
 
     if not is_newer(version, current):
-        console.print(f"[green]Already up to date[/green] (v{current}).")
+        console.print(styled("[green]Already up to date[/green] (v{}).", current))
         # Refresh the cache so the hint stops nagging.
         write_cache(version, _tag_name, _url)
         return
 
-    console.print(f"[bold]Conductor v{version}[/bold] is available (you have v{current}).")
+    console.print(
+        styled("[bold]Conductor v{}[/bold] is available (you have v{}).", version, current)
+    )
     console.print()
 
     if apply:
@@ -472,16 +491,22 @@ def run_update(console: Console, force: bool = False, apply: bool = False) -> No
         return  # pragma: no cover - _spawn_installer_and_exit never returns
 
     cmd = _install_command()
-    console.print("To upgrade, run this in a [bold]new shell[/bold] (not inside conductor):")
+    console.print(
+        Text.from_markup("To upgrade, run this in a [bold]new shell[/bold] (not inside conductor):")
+    )
     console.print()
-    console.print(f"  [bold cyan]{cmd}[/bold cyan]")
+    console.print(styled("  [bold cyan]{}[/bold cyan]", cmd))
     console.print()
     console.print(
-        "[dim]Or re-run with [bold]--apply[/bold] to launch the installer "
-        "automatically (conductor will exit so file locks release).[/dim]"
+        Text.from_markup(
+            "[dim]Or re-run with [bold]--apply[/bold] to launch the installer "
+            "automatically (conductor will exit so file locks release).[/dim]"
+        )
     )
     console.print(
-        "[dim]The install script handles file-lock safety, retries, and "
-        "post-install verification. It is the single supported upgrade path "
-        "on all platforms.[/dim]"
+        Text.from_markup(
+            "[dim]The install script handles file-lock safety, retries, and "
+            "post-install verification. It is the single supported upgrade path "
+            "on all platforms.[/dim]"
+        )
     )

--- a/src/conductor/cli/validate.py
+++ b/src/conductor/cli/validate.py
@@ -12,8 +12,10 @@ from typing import TYPE_CHECKING, Any
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 from conductor.config.loader import load_config
+from conductor.console import make_console, styled
 from conductor.exceptions import ConductorError
 
 if TYPE_CHECKING:
@@ -36,7 +38,7 @@ def validate_workflow(
     Returns:
         A tuple of (is_valid, config_or_none).
     """
-    output_console = console if console is not None else Console()
+    output_console = console if console is not None else make_console()
 
     try:
         config = load_config(workflow_path)
@@ -48,8 +50,8 @@ def validate_workflow(
         # Unexpected error
         output_console.print(
             Panel(
-                f"[bold red]Unexpected Error[/bold red]\n\n{e}",
-                title="[red]Validation Failed[/red]",
+                styled("[bold red]Unexpected Error[/bold red]\n\n{}", e),
+                title=Text.from_markup("[red]Validation Failed[/red]"),
                 border_style="red",
             )
         )
@@ -62,7 +64,7 @@ def validate_workflow(
         warnings = validate_workflow_config(config, workflow_path=workflow_path)
         if warnings:
             for warning in warnings:
-                output_console.print(f"  [yellow]⚠[/yellow] {warning}")
+                output_console.print(styled("  [yellow]⚠[/yellow] {}", warning))
     except ConductorError as e:
         display_validation_error(e, workflow_path, output_console)
         return False, None
@@ -134,21 +136,23 @@ def _report_plugins(
                 # entries that need it, and the validator said it once.
                 continue
             except (PluginError, SkillError, OSError) as exc:
-                console.print(f"  [yellow]⚠[/yellow] Plugin source {name!r} is unusable: {exc}")
+                console.print(
+                    styled("  [yellow]⚠[/yellow] Plugin source {!r} is unusable: {}", name, exc)
+                )
 
     # Printed before resolution is attempted: what a source resolved to is
     # worth seeing even when an entry referencing a *different* source
     # cannot be resolved, and this listing is the only place the resolved
     # commit appears.
     if sources:
-        console.print(f"  [dim]Plugin sources: {len(sources)} declared[/dim]")
+        console.print(styled("  [dim]Plugin sources: {} declared[/dim]", len(sources)))
         for name, entry in sources.items():
             detail = entry.source.describe()
             if entry.sha:
                 detail = f"{detail} @ {entry.sha[:12]}"
             if entry.stale:
                 detail = f"{detail} (cached; ref not re-checked)"
-            console.print(f"    [dim]• {name} — {detail}[/dim]")
+            console.print(styled("    [dim]• {} — {}[/dim]", name, detail))
 
     # Resolved one entry at a time, for the same reason the sources above
     # are: ``resolve_plugins`` is all-or-nothing, so one entry whose source
@@ -171,24 +175,26 @@ def _report_plugins(
             # the reader scrolls past. This arm is reachable through ordinary
             # configuration — see the docstring — so it is not merely
             # defensive.
-            console.print(f"  [yellow]⚠[/yellow] Plugin {entry.name!r}: {exc}")
+            console.print(styled("  [yellow]⚠[/yellow] Plugin {!r}: {}", entry.name, exc))
 
-    console.print(f"  [dim]Plugins: {len(resolved)} enabled[/dim]")
+    console.print(styled("  [dim]Plugins: {} enabled[/dim]", len(resolved)))
     for plugin in resolved:
         parts = [
             f"{len(plugin.skills)} skill(s)",
             f"{len(plugin.agents)} agent(s)",
             f"{len(plugin.mcp_servers)} MCP server(s)",
         ]
-        console.print(f"    [dim]• {plugin.name} — {', '.join(parts)} — {plugin.root}[/dim]")
+        console.print(
+            styled("    [dim]• {} — {} — {}[/dim]", plugin.name, ", ".join(parts), plugin.root)
+        )
         if plugin.agents:
             names = ", ".join(item.qualified_name for item in plugin.agents)
-            console.print(f"      [dim]agents: {names}[/dim]")
+            console.print(styled("      [dim]agents: {}[/dim]", names))
         if plugin.mcp_servers:
-            console.print(f"      [dim]mcp: {', '.join(sorted(plugin.mcp_servers))}[/dim]")
+            console.print(styled("      [dim]mcp: {}[/dim]", ", ".join(sorted(plugin.mcp_servers))))
         if plugin.disabled:
             console.print(
-                f"      [dim]disabled by this workflow: {', '.join(plugin.disabled)}[/dim]"
+                styled("      [dim]disabled by this workflow: {}[/dim]", ", ".join(plugin.disabled))
             )
 
 
@@ -245,7 +251,7 @@ def _report_skill_discovery(
         if message in seen:
             return
         seen.add(message)
-        console.print(f"  [yellow]⚠[/yellow] {message}")
+        console.print(styled("  [yellow]⚠[/yellow] {}", message))
 
     try:
         resolved = resolve_effective_skills(
@@ -256,30 +262,35 @@ def _report_skill_discovery(
             on_warning=_forward,
         )
     except Exception as exc:  # pragma: no cover - defensive; a report must not crash
-        console.print(f"  [yellow]⚠[/yellow] Skill discovery could not be summarized: {exc}")
+        console.print(
+            styled("  [yellow]⚠[/yellow] Skill discovery could not be summarized: {}", exc)
+        )
         return
 
     found = [skill for skill in resolved if skill.discovered]
     sources = ", ".join(discovery.sources)
     if not found:
-        console.print(f"  [dim]Skill discovery ({sources}): no skills found[/dim]")
+        console.print(styled("  [dim]Skill discovery ({}): no skills found[/dim]", sources))
         return
 
-    console.print(f"  [dim]Skill discovery ({sources}): {len(found)} skill(s)[/dim]")
+    console.print(styled("  [dim]Skill discovery ({}): {} skill(s)[/dim]", sources, len(found)))
     for skill in found:
-        console.print(f"    [dim]• {skill.name} — {skill.source}[/dim]")
+        console.print(styled("    [dim]• {} — {}[/dim]", skill.name, skill.source))
 
     try:
         content = load_skill_content([(skill.name, skill.directory) for skill in resolved])
     except Exception as exc:
-        console.print(f"  [yellow]⚠[/yellow] Skill content could not be measured: {exc}")
+        console.print(styled("  [yellow]⚠[/yellow] Skill content could not be measured: {}", exc))
         return
     size = len(content.encode("utf-8"))
     # Covers declared skills too, since an eager-injection provider would
     # be sent the whole set — the budget it is compared against is total.
     console.print(
-        f"    [dim]Total if eagerly injected: {size:,} bytes "
-        f"(~{size // BYTES_PER_TOKEN_ESTIMATE:,} tokens)[/dim]"
+        styled(
+            "    [dim]Total if eagerly injected: {:,} bytes (~{:,} tokens)[/dim]",
+            size,
+            size // BYTES_PER_TOKEN_ESTIMATE,
+        )
     )
 
 
@@ -302,17 +313,17 @@ def display_validation_error(
     if error.suggestion:
         error_msg = error_msg.replace(f"\n\n💡 Suggestion: {error.suggestion}", "")
 
-    content = f"[bold red]{error_type}[/bold red]\n\n"
-    content += f"[dim]File:[/dim] {workflow_path}\n\n"
+    content = styled("[bold red]{}[/bold red]\n\n", error_type)
+    content += styled("[dim]File:[/dim] {}\n\n", workflow_path)
     content += f"{error_msg}"
 
     if error.suggestion:
-        content += f"\n\n[yellow]💡 Suggestion:[/yellow] {error.suggestion}"
+        content += styled("\n\n[yellow]💡 Suggestion:[/yellow] {}", error.suggestion)
 
     console.print(
         Panel(
             content,
-            title="[red]Validation Failed[/red]",
+            title=Text.from_markup("[red]Validation Failed[/red]"),
             border_style="red",
         )
     )
@@ -397,7 +408,7 @@ def display_validation_success(
     console.print(
         Panel(
             table,
-            title="[green]Validation Successful[/green]",
+            title=Text.from_markup("[green]Validation Successful[/green]"),
             border_style="green",
         )
     )
@@ -412,7 +423,11 @@ def display_validation_success(
 
         for agent in config.agents:
             agent_type = agent.type or "agent"
-            model = agent.model or config.workflow.runtime.default_model or "[dim]default[/dim]"
+            model = (
+                agent.model
+                or config.workflow.runtime.default_model
+                or Text.from_markup("[dim]default[/dim]")
+            )
 
             if agent.routes:
                 route_targets = [r.to for r in agent.routes]
@@ -420,7 +435,7 @@ def display_validation_success(
                 if len(route_targets) > 3:
                     routes_str += f" (+{len(route_targets) - 3} more)"
             else:
-                routes_str = "[dim]none[/dim]"
+                routes_str = Text.from_markup("[dim]none[/dim]")
 
             agent_table.add_row(agent.name, agent_type, model, routes_str)
 

--- a/src/conductor/cli/validate.py
+++ b/src/conductor/cli/validate.py
@@ -9,13 +9,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
 from conductor.config.loader import load_config
-from conductor.console import make_console, styled
+from conductor.console import MarkupFreeConsole, make_console, styled
 from conductor.exceptions import ConductorError
 
 if TYPE_CHECKING:
@@ -24,7 +23,7 @@ if TYPE_CHECKING:
 
 def validate_workflow(
     workflow_path: Path,
-    console: Console | None = None,
+    console: MarkupFreeConsole | None = None,
 ) -> tuple[bool, WorkflowConfig | None]:
     """Validate a workflow YAML file.
 
@@ -78,7 +77,7 @@ def validate_workflow(
 def _report_plugins(
     config: WorkflowConfig,
     workflow_path: Path,
-    console: Console,
+    console: MarkupFreeConsole,
 ) -> None:
     """Print what each enabled plugin actually contributes.
 
@@ -201,7 +200,7 @@ def _report_plugins(
 def _report_skill_discovery(
     config: WorkflowConfig,
     workflow_path: Path,
-    console: Console,
+    console: MarkupFreeConsole,
     already_reported: list[str],
 ) -> None:
     """Print what ``runtime.skill_discovery`` puts in effect on this machine.
@@ -297,7 +296,7 @@ def _report_skill_discovery(
 def display_validation_error(
     error: ConductorError,
     workflow_path: Path,
-    console: Console,
+    console: MarkupFreeConsole,
 ) -> None:
     """Display a validation error with Rich formatting.
 
@@ -332,7 +331,7 @@ def display_validation_error(
 def display_validation_success(
     config: WorkflowConfig,
     workflow_path: Path,
-    console: Console,
+    console: MarkupFreeConsole,
 ) -> None:
     """Display validation success with workflow summary.
 

--- a/src/conductor/console.py
+++ b/src/conductor/console.py
@@ -1,0 +1,279 @@
+"""Markup-safe console primitives.
+
+Rich parses a plain ``str`` as console markup, so any runtime value
+interpolated into a printed string is parsed as if it were conductor's own
+styling. In rich, a bracketed token is a tag when its **first character** is
+a lowercase letter, ``#``, ``/`` or ``@``, which splits the behaviour three
+ways and only one of them is loud:
+
+===================  ==================  =====================================
+first character      example             result
+===================  ==================  =====================================
+digit / uppercase    ``[0]``             rendered literally
+lowercase, ``#``,    ``[task1]``         **silently deleted**
+``@``
+``/``                ``[/etc/x]``        **MarkupError, out of the print call**
+===================  ==================  =====================================
+
+Conductor renders workflow and agent names, plugin and marketplace metadata
+read out of cloned third-party repositories, exception strings and gate
+payloads. All of them can contain a bracketed token, so this module exists to
+keep the two apart:
+
+* :func:`make_console` builds every console with ``markup=False``, which
+  inverts the default — a plain string is literal unless it asks to be
+  styled. This covers plain prints, ``Panel`` bodies, ``Table`` cells,
+  headers, titles and captions, and ``Rule`` titles.
+* :func:`styled` is the one way to opt back in. The template is conductor's
+  own literal and is parsed; interpolated values are inserted verbatim and
+  never reach the parser.
+
+``markup=False`` is necessary but not sufficient. ``Panel(title=)``,
+``Panel(subtitle=)`` and ``Prompt``/``Confirm``/``IntPrompt`` prompts call
+``Text.from_markup`` unconditionally (``rich/panel.py``, ``rich/prompt.py``),
+so the console setting never reaches them. Pass those a :class:`~rich.text.Text`
+— :func:`styled` returns one — rather than an f-string.
+
+``rich.markup.escape`` is deliberately not used. It is not byte-exact: the
+parser treats ``\\[`` as an escaped bracket, so ``\\[0-9\\]+`` — an ordinary
+regex — renders as ``[0-9\\]+`` whether or not it was escaped first. Building
+a :class:`~rich.text.Text` avoids the parser entirely and is exact.
+
+See issues #382, #387 and #406.
+"""
+
+from __future__ import annotations
+
+import string
+from collections.abc import Iterable
+from typing import Any
+
+from rich.console import Console, HighlighterType
+from rich.text import Span, Text
+
+# Placeholder filler. Runs of this character stand in for interpolated values
+# while the template is parsed, and are overwritten afterwards.
+#
+# One filler character per character of the final value is written, so the
+# spans rich computes over the parsed template already cover the value's full
+# width and stay valid through the substitution. That is what makes nested
+# styling around a placeholder correct; reading ``spans[0].style`` and
+# re-applying it — the obvious alternative — collapses ``[bold][red]{}[/red]``
+# to a single style.
+_FILLER = "\x00"
+
+_FORMATTER = string.Formatter()
+
+
+def _highlighted(highlighter: HighlighterType, text: Text) -> Text:
+    """Apply *highlighter* to *text* the way rich does for a plain string.
+
+    ``Console.render_str`` highlights the plain characters first and copies
+    the markup-derived spans on top, so conductor's own styling wins where the
+    two overlap. Reproducing that order keeps a ``Text`` rendering identically
+    to the markup string it replaced.
+    """
+    out = highlighter(text.plain)
+    out.copy_styles(text)
+    out.justify = text.justify
+    out.overflow = text.overflow
+    out.no_wrap = text.no_wrap
+    out.end = text.end
+    out.style = text.style
+    return out
+
+
+class _MarkupFreeConsole(Console):
+    """A ``Console`` that never parses markup but still highlights.
+
+    ``markup=False`` is the point of the class. The highlighting is what keeps
+    it a pure safety change: rich applies its ``ReprHighlighter`` to a plain
+    ``str`` but not to a ``Text``, so replacing a markup string with a
+    ``styled`` call would otherwise silently drop the colour rich gives
+    numbers, paths and quoted values across the whole CLI.
+
+    Only top-level ``Text`` arguments are highlighted, matching rich's own
+    behaviour of highlighting only the strings passed directly to ``print``.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        # Captured rather than read back off the instance: the attribute rich
+        # stores it in is private, and ``rich`` is pinned only ``>=13.0.0``.
+        self._conductor_highlight: bool = bool(kwargs.get("highlight", True))
+        kwargs.pop("markup", None)
+        super().__init__(markup=False, **kwargs)
+
+    def print(self, *objects: Any, **kwargs: Any) -> None:
+        highlight = kwargs.get("highlight")
+        if highlight is None:
+            highlight = self._conductor_highlight
+        if highlight and self.highlighter is not None:
+            objects = tuple(
+                _highlighted(self.highlighter, obj) if type(obj) is Text else obj for obj in objects
+            )
+        super().print(*objects, **kwargs)
+
+
+def make_console(**kwargs: Any) -> Console:
+    """Build a ``Console`` that does not parse markup.
+
+    ``markup`` is locked to ``False``: this is the inverted default that keeps
+    an interpolated runtime value from being read as styling. Style output
+    with :func:`styled` (or any ``Text``/renderable), not with markup in a
+    plain string.
+
+    Args:
+        **kwargs: Forwarded to ``rich.console.Console``. Passing ``markup``
+            is an error rather than an override — a console that parses
+            markup is the defect this module exists to prevent.
+
+    Returns:
+        A configured ``Console``.
+
+    Raises:
+        TypeError: If ``markup`` is passed.
+    """
+    if "markup" in kwargs:
+        raise TypeError(
+            "make_console() does not accept 'markup': consoles are markup-free by "
+            "design so interpolated runtime values cannot be parsed as styling. "
+            "Use styled() to style conductor's own text."
+        )
+    return _MarkupFreeConsole(**kwargs)
+
+
+def join(separator: str | Text, parts: Iterable[str | Text]) -> Text:
+    """Join a mix of plain strings and pre-styled ``Text`` into one ``Text``.
+
+    ``Text.join`` requires every part to already be a ``Text``, but the usual
+    shape here is a ``content_lines`` list holding some conductor-styled
+    fragments and some plain runtime values. Plain strings are treated as
+    literal text, so a bracketed token in one is never parsed as styling.
+
+    Args:
+        separator: Placed between parts. A plain string is literal.
+        parts: The fragments to join.
+
+    Returns:
+        The joined ``Text``.
+    """
+    sep = separator if isinstance(separator, Text) else Text(separator)
+    return sep.join(part if isinstance(part, Text) else Text(part) for part in parts)
+
+
+def styled(template: str, /, *args: object, **kwargs: object) -> Text:
+    """Render conductor's own markup with values inserted as literal text.
+
+    ``template`` is a conductor-authored literal, so its ``[tag]`` markup is
+    parsed as styling. The interpolated values are not: they are inserted
+    verbatim, so a value containing ``[/etc/x]`` can neither raise
+    ``MarkupError`` nor be silently deleted.
+
+    Field syntax is ``str.format``'s, so positional, auto-numbered and named
+    fields, conversions (``!r``, ``!s``, ``!a``) and format specs all work,
+    and ``{{``/``}}`` are literal braces.
+
+    A value that is already a ``Text`` is spliced in with its own styling
+    intact, so pre-styled fragments compose::
+
+        CHECK = styled("[green]✓[/green]")
+        styled("{} {}", CHECK, provider_name)
+
+    A format spec is not applied to a ``Text`` value — there is nothing
+    meaningful to round or align.
+
+    Examples::
+
+        styled("[bold red]Error:[/bold red] {} not found", path)
+        styled("{name} took {secs:.2f}s", name=agent.name, secs=elapsed)
+        styled("[green]Validation Successful[/green]")
+
+    Args:
+        template: Conductor-authored text, optionally containing rich markup
+            and ``str.format`` fields.
+        *args: Positional values for the template's fields.
+        **kwargs: Named values for the template's fields.
+
+    Returns:
+        A ``Text`` carrying the template's styling, safe to print on any
+        console and to pass as a ``Panel`` title or a prompt.
+
+    Raises:
+        ValueError: If the template contains a NUL character, which the
+            placeholder machinery reserves.
+        rich.errors.MarkupError: If the *template* is malformed. That is a
+            conductor bug rather than bad input — values never reach the
+            parser.
+        IndexError: If the template references a missing positional field.
+        KeyError: If the template references a missing named field.
+    """
+    marked: list[str] = []
+    values: list[str | Text] = []
+    auto_index = 0
+
+    if _FILLER in template:
+        # The substitution below locates each value by searching for its
+        # filler run, so a filler character in the template's own literal
+        # text would capture the search and shift every later value. Templates
+        # are conductor-authored literals, so this is a bug in the caller.
+        raise ValueError("styled() template must not contain a NUL character")
+
+    for literal, field, spec, conversion in _FORMATTER.parse(template):
+        marked.append(literal)
+        if field is None:
+            continue
+
+        if field == "":
+            value = args[auto_index]
+            auto_index += 1
+        elif field.isdigit():
+            value = args[int(field)]
+        else:
+            value = kwargs[field]
+
+        if conversion:
+            value = _FORMATTER.convert_field(value, conversion)
+
+        rendered: str | Text = value if isinstance(value, Text) else format(value, spec or "")
+        values.append(rendered)
+        marked.append(_FILLER * len(rendered.plain if isinstance(rendered, Text) else rendered))
+
+    text = Text.from_markup("".join(marked))
+    if not values:
+        return text
+
+    # Locate each value by its filler run rather than by a precomputed offset:
+    # a value may itself contain the filler character, and an empty value
+    # leaves no filler to find. The template is guaranteed filler-free above,
+    # and ``cursor`` advances past each substituted value, so a filler inside
+    # a value cannot be mistaken for the next placeholder.
+    plain = list(text.plain)
+    spans = list(text.spans)
+    cursor = 0
+    for value in values:
+        body = value.plain if isinstance(value, Text) else value
+        if not body:
+            continue
+        start = plain.index(_FILLER, cursor)
+        plain[start : start + len(body)] = list(body)
+        if isinstance(value, Text):
+            # Re-anchor the fragment's own styling at its position in the
+            # result. Its base ``style`` covers the whole fragment and is
+            # added first, so a narrower span of its own still wins.
+            if value.style:
+                spans.append(Span(start, start + len(body), value.style))
+            spans.extend(
+                Span(start + span.start, start + span.end, span.style) for span in value.spans
+            )
+        cursor = start + len(body)
+
+    return Text(
+        "".join(plain),
+        style=text.style,
+        justify=text.justify,
+        overflow=text.overflow,
+        no_wrap=text.no_wrap,
+        end=text.end,
+        tab_size=text.tab_size,
+        spans=spans,
+    )

--- a/src/conductor/console.py
+++ b/src/conductor/console.py
@@ -79,42 +79,88 @@ def _highlighted(highlighter: HighlighterType, text: Text) -> Text:
     out.overflow = text.overflow
     out.no_wrap = text.no_wrap
     out.end = text.end
+    out.tab_size = text.tab_size
     out.style = text.style
     return out
 
 
-class _MarkupFreeConsole(Console):
+_MARKUP_KWARG_ERROR = (
+    "markup is not overridable: consoles are markup-free by design so an "
+    "interpolated runtime value cannot be parsed as styling. Use styled() to "
+    "style conductor's own text."
+)
+
+
+class MarkupFreeConsole(Console):
     """A ``Console`` that never parses markup but still highlights.
 
-    ``markup=False`` is the point of the class. The highlighting is what keeps
-    it a pure safety change: rich applies its ``ReprHighlighter`` to a plain
-    ``str`` but not to a ``Text``, so replacing a markup string with a
-    ``styled`` call would otherwise silently drop the colour rich gives
-    numbers, paths and quoted values across the whole CLI.
+    ``markup=False`` is the point of the class, and it is not overridable —
+    passing ``markup`` to the constructor, to ``print`` or to ``log`` raises
+    ``TypeError`` rather than being honoured or silently dropped. Rich accepts
+    a per-call ``markup=`` that overrides the instance setting, so without
+    that refusal a single call site could reopen both original failure modes
+    (a silently deleted ``[task1]``, a ``MarkupError`` from ``[/etc/x]``) —
+    and it is the obvious-looking fix for the visible ``[green]`` that
+    forgetting :func:`styled` now produces.
+
+    The highlighting is what keeps this a pure safety change: rich applies its
+    ``ReprHighlighter`` to a plain ``str`` but not to a ``Text``, so replacing
+    a markup string with a :func:`styled` call would otherwise silently drop
+    the colour rich gives numbers, paths and quoted values across the CLI.
 
     Only top-level ``Text`` arguments are highlighted, matching rich's own
     behaviour of highlighting only the strings passed directly to ``print``.
+
+    Subclass this rather than ``Console`` so the refusal is inherited (see
+    ``cli/run.py::_SilentAwareConsole``); prefer :func:`make_console` when a
+    subclass is not needed.
     """
 
     def __init__(self, **kwargs: Any) -> None:
+        if kwargs.pop("markup", False):
+            raise TypeError(_MARKUP_KWARG_ERROR)
         # Captured rather than read back off the instance: the attribute rich
         # stores it in is private, and ``rich`` is pinned only ``>=13.0.0``.
-        self._conductor_highlight: bool = bool(kwargs.get("highlight", True))
-        kwargs.pop("markup", None)
+        self._conductor_highlight: bool = kwargs.get("highlight") is not False
         super().__init__(markup=False, **kwargs)
 
     def print(self, *objects: Any, **kwargs: Any) -> None:
+        # Rejects a *truthy* markup only. ``Console.input`` forwards
+        # ``markup=`` to ``print`` unconditionally, so rejecting the kwarg's
+        # mere presence would make ``Prompt.ask(..., console=self)`` raise --
+        # and a redundant ``markup=False`` restates the guarantee rather than
+        # defeating it.
+        if kwargs.pop("markup", False):
+            raise TypeError(_MARKUP_KWARG_ERROR)
         highlight = kwargs.get("highlight")
         if highlight is None:
             highlight = self._conductor_highlight
         if highlight and self.highlighter is not None:
             objects = tuple(
-                _highlighted(self.highlighter, obj) if type(obj) is Text else obj for obj in objects
+                # ``type(...) is Text`` rather than ``isinstance``: a Text
+                # subclass would come back from ``_highlighted`` as a plain
+                # Text, silently losing its type.
+                _highlighted(self.highlighter, obj) if type(obj) is Text else obj
+                for obj in objects
             )
         super().print(*objects, **kwargs)
 
+    def log(self, *objects: Any, **kwargs: Any) -> None:
+        if kwargs.pop("markup", False):
+            raise TypeError(_MARKUP_KWARG_ERROR)
+        super().log(*objects, **kwargs)
 
-def make_console(**kwargs: Any) -> Console:
+    def input(self, prompt: Any = "", **kwargs: Any) -> str:
+        # ``Console.input`` defaults ``markup=True`` independent of the
+        # instance and forwards it to ``print``, so the prompt would be parsed
+        # even here. Forced off rather than refused: this is the method
+        # ``Prompt.ask`` calls, and rejecting it would make every prompt that
+        # passes ``console=`` unusable.
+        kwargs["markup"] = False
+        return super().input(prompt, **kwargs)
+
+
+def make_console(**kwargs: Any) -> MarkupFreeConsole:
     """Build a ``Console`` that does not parse markup.
 
     ``markup`` is locked to ``False``: this is the inverted default that keeps
@@ -122,24 +168,22 @@ def make_console(**kwargs: Any) -> Console:
     with :func:`styled` (or any ``Text``/renderable), not with markup in a
     plain string.
 
+    The concrete return type is deliberate — it is the one place the guarantee
+    can enter the type system, so a parameter annotated
+    ``MarkupFreeConsole`` cannot be handed a markup-parsing console.
+
     Args:
         **kwargs: Forwarded to ``rich.console.Console``. Passing ``markup``
             is an error rather than an override — a console that parses
             markup is the defect this module exists to prevent.
 
     Returns:
-        A configured ``Console``.
+        A configured :class:`MarkupFreeConsole`.
 
     Raises:
         TypeError: If ``markup`` is passed.
     """
-    if "markup" in kwargs:
-        raise TypeError(
-            "make_console() does not accept 'markup': consoles are markup-free by "
-            "design so interpolated runtime values cannot be parsed as styling. "
-            "Use styled() to style conductor's own text."
-        )
-    return _MarkupFreeConsole(**kwargs)
+    return MarkupFreeConsole(**kwargs)
 
 
 def join(separator: str | Text, parts: Iterable[str | Text]) -> Text:
@@ -169,18 +213,20 @@ def styled(template: str, /, *args: object, **kwargs: object) -> Text:
     verbatim, so a value containing ``[/etc/x]`` can neither raise
     ``MarkupError`` nor be silently deleted.
 
-    Field syntax is ``str.format``'s, so positional, auto-numbered and named
-    fields, conversions (``!r``, ``!s``, ``!a``) and format specs all work,
-    and ``{{``/``}}`` are literal braces.
+    Field syntax is ``str.format``'s — positional, auto-numbered, named,
+    dotted and indexed fields, conversions (``!r``, ``!s``, ``!a``) and format
+    specs, with ``{{``/``}}`` as literal braces. Mixing automatic and manual
+    numbering is not diagnosed the way ``str.format`` diagnoses it.
 
     A value that is already a ``Text`` is spliced in with its own styling
     intact, so pre-styled fragments compose::
 
-        CHECK = styled("[green]✓[/green]")
+        CHECK = Text.from_markup("[green]✓[/green]")
         styled("{} {}", CHECK, provider_name)
 
-    A format spec is not applied to a ``Text`` value — there is nothing
-    meaningful to round or align.
+    A format spec or conversion on a ``Text`` value is an error rather than a
+    silent no-op: both would flatten it back to plain characters, discarding
+    the styling the caller passed a ``Text`` to keep.
 
     Examples::
 
@@ -199,8 +245,10 @@ def styled(template: str, /, *args: object, **kwargs: object) -> Text:
         console and to pass as a ``Panel`` title or a prompt.
 
     Raises:
-        ValueError: If the template contains a NUL character, which the
-            placeholder machinery reserves.
+        ValueError: If the template contains a NUL character (reserved by the
+            placeholder machinery), if a field sits inside a markup tag so the
+            parser consumes it, or if a format spec or conversion is applied
+            to a ``Text`` value (which would discard its styling).
         rich.errors.MarkupError: If the *template* is malformed. That is a
             conductor bug rather than bad input — values never reach the
             parser.
@@ -223,18 +271,31 @@ def styled(template: str, /, *args: object, **kwargs: object) -> Text:
         if field is None:
             continue
 
+        # ``get_field`` rather than hand-rolled resolution so dotted and
+        # indexed fields (``{p.name}``, ``{d[0]}``) work and a missing field
+        # raises the standard IndexError/KeyError with the standard message.
         if field == "":
-            value = args[auto_index]
+            field = str(auto_index)
             auto_index += 1
-        elif field.isdigit():
-            value = args[int(field)]
+        value, _ = _FORMATTER.get_field(field, args, kwargs)
+
+        if isinstance(value, Text):
+            # A spec would have nothing meaningful to align and a conversion
+            # would call ``str()`` on it, flattening away exactly the styling
+            # the caller passed a ``Text`` to preserve. Refuse rather than
+            # silently drop it — that flattening is this module's own bug.
+            if spec or conversion:
+                raise ValueError(
+                    f"styled() cannot apply a format spec or conversion to a Text value "
+                    f"(field {field!r} in {template!r}): it would discard the value's "
+                    f"styling. Pass the Text without a spec, or pass a str."
+                )
+            rendered: str | Text = value
         else:
-            value = kwargs[field]
+            if conversion:
+                value = _FORMATTER.convert_field(value, conversion)
+            rendered = format(value, spec or "")
 
-        if conversion:
-            value = _FORMATTER.convert_field(value, conversion)
-
-        rendered: str | Text = value if isinstance(value, Text) else format(value, spec or "")
         values.append(rendered)
         marked.append(_FILLER * len(rendered.plain if isinstance(rendered, Text) else rendered))
 
@@ -254,7 +315,18 @@ def styled(template: str, /, *args: object, **kwargs: object) -> Text:
         body = value.plain if isinstance(value, Text) else value
         if not body:
             continue
-        start = plain.index(_FILLER, cursor)
+        try:
+            start = plain.index(_FILLER, cursor)
+        except ValueError:
+            # The parser consumed the placeholder, which happens when a field
+            # sits inside a tag (``styled("[link={}]x[/link]", url)``). The
+            # bare "'\x00' is not in list" names an internal detail and tells
+            # the reader nothing about the template that caused it.
+            raise ValueError(
+                f"styled() template put a field inside a markup tag, so the markup "
+                f"parser consumed the value: {template!r}. Build the tag from a "
+                f"conductor literal instead of interpolating into it."
+            ) from None
         plain[start : start + len(body)] = list(body)
         if isinstance(value, Text):
             # Re-anchor the fragment's own styling at its position in the

--- a/src/conductor/gates/dialog.py
+++ b/src/conductor/gates/dialog.py
@@ -15,13 +15,12 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from rich.console import Console
 from rich.markdown import Markdown as RichMarkdown
 from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.text import Text
 
-from conductor.console import make_console, styled
+from conductor.console import MarkupFreeConsole, make_console, styled
 from conductor.executor.linkify import linkify_markdown
 
 if TYPE_CHECKING:
@@ -149,7 +148,7 @@ class DialogHandler:
 
     def __init__(
         self,
-        console: Console | None = None,
+        console: MarkupFreeConsole | None = None,
         skip_dialogs: bool = False,
         emitter: WorkflowEventEmitter | None = None,
         web_dashboard: WebDashboard | None = None,

--- a/src/conductor/gates/dialog.py
+++ b/src/conductor/gates/dialog.py
@@ -21,6 +21,7 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.text import Text
 
+from conductor.console import make_console, styled
 from conductor.executor.linkify import linkify_markdown
 
 if TYPE_CHECKING:
@@ -161,7 +162,7 @@ class DialogHandler:
             emitter: Optional event emitter for dialog events.
             web_dashboard: Optional web dashboard for web-based dialog input.
         """
-        self.console = console or Console()
+        self.console = console or make_console()
         self.skip_dialogs = skip_dialogs
         self.emitter = emitter
         self.web_dashboard = web_dashboard
@@ -309,7 +310,10 @@ class DialogHandler:
                     exc_info=True,
                 )
                 self.console.print(
-                    "[dim red]  (Agent response failed — you can continue or type 'done')[/dim red]"
+                    Text.from_markup(
+                        "[dim red]  (Agent response failed — you can continue "
+                        "or type 'done')[/dim red]"
+                    )
                 )
                 continue
 
@@ -335,7 +339,7 @@ class DialogHandler:
 
                 # Ask user if they approve
                 approval = await self._get_user_input(
-                    prompt_text="[bold]Continue?[/bold] ([green]yes[/green]/no)"
+                    prompt_text=styled("[bold]Continue?[/bold] ([green]yes[/green]/no)")
                 )
                 if approval is None or approval.lower() in ("yes", "y", ""):
                     self._display_dialog_end(dismissed_by="agent_approved")
@@ -600,13 +604,14 @@ class DialogHandler:
         self.console.print()
         self.console.print(
             Panel(
-                Text.from_markup(
-                    f"[bold]Agent '{agent.name}'[/bold] would like to discuss "
-                    f"its output with you.\n"
-                    f"[dim]Type your responses below. Say [bold]done[/bold] or "
-                    f"[bold]/done[/bold] when finished.[/dim]"
+                styled(
+                    "[bold]Agent '{}'[/bold] would like to discuss "
+                    "its output with you.\n"
+                    "[dim]Type your responses below. Say [bold]done[/bold] or "
+                    "[bold]/done[/bold] when finished.[/dim]",
+                    agent.name,
                 ),
-                title="[bold magenta]Dialog Mode[/bold magenta]",
+                title=Text.from_markup("[bold magenta]Dialog Mode[/bold magenta]"),
                 border_style="magenta",
             )
         )
@@ -626,7 +631,7 @@ class DialogHandler:
         self.console.print(
             Panel(
                 RichMarkdown(f"```json\n{output_display}\n```"),
-                title="[bold cyan]Agent Output (Full Context)[/bold cyan]",
+                title=Text.from_markup("[bold cyan]Agent Output (Full Context)[/bold cyan]"),
                 border_style="cyan",
                 expand=True,
             )
@@ -638,7 +643,7 @@ class DialogHandler:
         self.console.print(
             Panel(
                 RichMarkdown(question_display),
-                title=f"[bold yellow]{agent.name}[/bold yellow]",
+                title=styled("[bold yellow]{}[/bold yellow]", agent.name),
                 border_style="yellow",
             )
         )
@@ -656,7 +661,7 @@ class DialogHandler:
     def _display_continue_proposal(self) -> None:
         """Display the agent's proposal to continue."""
         self.console.print()
-        msg = (
+        msg = Text.from_markup(
             "[bold magenta]  ↳ The agent believes it has enough "
             "information to continue.[/bold magenta]"
         )
@@ -667,14 +672,22 @@ class DialogHandler:
         self.console.print()
         if dismissed_by == "user":
             self.console.print(
-                "[dim magenta]  ✓ Dialog ended by user — agent resuming.[/dim magenta]"
+                Text.from_markup(
+                    "[dim magenta]  ✓ Dialog ended by user — agent resuming.[/dim magenta]"
+                )
             )
         elif dismissed_by == "agent_approved":
-            self.console.print("[dim magenta]  ✓ Agent continuing — dialog complete.[/dim magenta]")
+            self.console.print(
+                Text.from_markup(
+                    "[dim magenta]  ✓ Agent continuing — dialog complete.[/dim magenta]"
+                )
+            )
         elif dismissed_by == "declined":
             self.console.print(
-                "[dim magenta]  ✓ Dialog declined — agent will do"
-                " its best and continue.[/dim magenta]"
+                Text.from_markup(
+                    "[dim magenta]  ✓ Dialog declined — agent will do"
+                    " its best and continue.[/dim magenta]"
+                )
             )
         self.console.print()
 
@@ -685,13 +698,17 @@ class DialogHandler:
             "engage" if the user wants to chat, "decline" to skip.
         """
         self.console.print()
-        self.console.print("[bold]How would you like to proceed?[/bold]")
-        self.console.print("  [cyan][1][/cyan] Discuss this with the agent")
-        self.console.print("  [cyan][2][/cyan] Do your best and continue [dim](skip dialog)[/dim]")
+        self.console.print(Text.from_markup("[bold]How would you like to proceed?[/bold]"))
+        self.console.print(Text.from_markup("  [cyan][1][/cyan] Discuss this with the agent"))
+        self.console.print(
+            Text.from_markup(
+                "  [cyan][2][/cyan] Do your best and continue [dim](skip dialog)[/dim]"
+            )
+        )
 
         def _ask() -> str:
             return Prompt.ask(
-                "\n[bold]Select[/bold]",
+                Text.from_markup("\n[bold]Select[/bold]"),
                 choices=["1", "2"],
                 default="1",
                 show_choices=True,
@@ -702,19 +719,27 @@ class DialogHandler:
 
     async def _get_user_input(
         self,
-        prompt_text: str = "[bold magenta]You[/bold magenta]",
+        prompt_text: Text | None = None,
     ) -> str | None:
         """Get user input from the terminal.
 
         Runs in a thread to avoid blocking the event loop.
 
+        Args:
+            prompt_text: Pre-styled prompt. ``Text`` rather than ``str``
+                because ``Prompt`` parses a ``str`` prompt with
+                ``Text.from_markup`` regardless of the console's
+                ``markup=False`` (#406), so the type keeps a caller from
+                passing an interpolated f-string here.
+
         Returns:
             User input text, or None on EOF/error.
         """
+        prompt = styled("[bold magenta]You[/bold magenta]") if prompt_text is None else prompt_text
         try:
 
             def _ask() -> str:
-                return Prompt.ask(prompt_text)
+                return Prompt.ask(prompt)
 
             return await asyncio.to_thread(_ask)
         except (EOFError, KeyboardInterrupt):

--- a/src/conductor/gates/human.py
+++ b/src/conductor/gates/human.py
@@ -12,13 +12,12 @@ import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from rich.console import Console
 from rich.markdown import Markdown as RichMarkdown
 from rich.panel import Panel
 from rich.prompt import IntPrompt, Prompt
 from rich.text import Text
 
-from conductor.console import join, make_console, styled
+from conductor.console import MarkupFreeConsole, join, make_console, styled
 from conductor.exceptions import HumanGateError
 from conductor.executor.linkify import linkify_markdown
 from conductor.executor.template import TemplateRenderer
@@ -223,7 +222,7 @@ class HumanGateHandler:
 
     def __init__(
         self,
-        console: Console | None = None,
+        console: MarkupFreeConsole | None = None,
         skip_gates: bool = False,
     ) -> None:
         """Initialize the HumanGateHandler.
@@ -537,7 +536,7 @@ class MaxIterationsHandler:
 
     def __init__(
         self,
-        console: Console | None = None,
+        console: MarkupFreeConsole | None = None,
         skip_gates: bool = False,
     ) -> None:
         """Initialize the MaxIterationsHandler.

--- a/src/conductor/gates/human.py
+++ b/src/conductor/gates/human.py
@@ -16,7 +16,9 @@ from rich.console import Console
 from rich.markdown import Markdown as RichMarkdown
 from rich.panel import Panel
 from rich.prompt import IntPrompt, Prompt
+from rich.text import Text
 
+from conductor.console import join, make_console, styled
 from conductor.exceptions import HumanGateError
 from conductor.executor.linkify import linkify_markdown
 from conductor.executor.template import TemplateRenderer
@@ -233,7 +235,7 @@ class HumanGateHandler:
                 (auto-selecting would invent an answer) are still presented,
                 so such callers must short-circuit before reaching here.
         """
-        self.console = console or Console()
+        self.console = console or make_console()
         self.skip_gates = skip_gates
         self.renderer = TemplateRenderer()
 
@@ -368,7 +370,9 @@ class HumanGateHandler:
         """
         for choice in gate_prompt.choices:
             if choice.value == gate_prompt.auto_select:
-                self.console.print(f"\n[dim]Auto-selecting: {choice.label} (--skip-gates)[/dim]")
+                self.console.print(
+                    styled("\n[dim]Auto-selecting: {} (--skip-gates)[/dim]", choice.label)
+                )
                 return GateResponse(
                     value=choice.value,
                     label=choice.label,
@@ -402,16 +406,16 @@ class HumanGateHandler:
         self.console.print(
             Panel(
                 RichMarkdown(prompt_text),
-                title="[bold cyan]Decision Required[/bold cyan]",
+                title=Text.from_markup("[bold cyan]Decision Required[/bold cyan]"),
                 border_style="cyan",
             )
         )
 
         # Display options as numbered list
         self.console.print()
-        self.console.print("[bold]Options:[/bold]")
+        self.console.print(Text.from_markup("[bold]Options:[/bold]"))
         for i, choice in enumerate(choices, 1):
-            self.console.print(f"  [cyan][{i}][/cyan] {choice.label}")
+            self.console.print(styled("  [cyan][{}][/cyan] {}", i, choice.label))
 
         # Get user selection — run in thread to avoid blocking the event loop
         # (blocking here prevents the web dashboard from updating)
@@ -420,7 +424,7 @@ class HumanGateHandler:
 
             def _ask_choice() -> str:
                 return Prompt.ask(
-                    "\n[bold]Select option[/bold]",
+                    Text.from_markup("\n[bold]Select option[/bold]"),
                     choices=valid_choices,
                     show_choices=True,
                 )
@@ -430,11 +434,11 @@ class HumanGateHandler:
                 index = int(choice_input) - 1
                 if 0 <= index < len(choices):
                     selected = choices[index]
-                    self.console.print(f"\n[green]Selected:[/green] {selected.label}")
+                    self.console.print(styled("\n[green]Selected:[/green] {}", selected.label))
                     return selected
             except ValueError:
                 pass
-            self.console.print("[red]Invalid selection. Please try again.[/red]")
+            self.console.print(Text.from_markup("[red]Invalid selection. Please try again.[/red]"))
 
     async def _collect_additional_input(
         self, field_name: str, multiline: bool = False
@@ -453,7 +457,7 @@ class HumanGateHandler:
             Dictionary with the field name and collected value.
         """
         self.console.print()
-        self.console.print(f"[bold]Please provide {field_name}:[/bold]")
+        self.console.print(styled("[bold]Please provide {}:[/bold]", field_name))
 
         # Without a TTY, fall back: _read_multiline treats EOF as "submit" and
         # would return "" instantly on a DEVNULL stdin, letting the CLI arm win
@@ -463,7 +467,10 @@ class HumanGateHandler:
             return {field_name: value}
 
         def _ask_value() -> str:
-            return Prompt.ask(f"  {field_name}")
+            # ``field_name`` comes from the workflow YAML, and ``Prompt``
+            # parses its prompt with ``Text.from_markup`` regardless of the
+            # console's ``markup=False`` -- so this has to be a ``Text``.
+            return Prompt.ask(styled("  {}", field_name))
 
         value = await read_on_daemon_thread(_ask_value)
         return {field_name: value}
@@ -479,8 +486,11 @@ class HumanGateHandler:
             newlines are preserved.
         """
         self.console.print(
-            f"  [dim]Enter your answer. Finish with '{MULTILINE_SENTINEL}' on its own line"
-            f" (or {_eof_key_hint()}).[/dim]"
+            styled(
+                "  [dim]Enter your answer. Finish with '{}' on its own line (or {}).[/dim]",
+                MULTILINE_SENTINEL,
+                _eof_key_hint(),
+            )
         )
         lines: list[str] = []
         while True:
@@ -536,7 +546,7 @@ class MaxIterationsHandler:
             console: Rich console for output. Creates one if not provided.
             skip_gates: If True, auto-stops without prompting (for automation).
         """
-        self.console = console or Console()
+        self.console = console or make_console()
         self.skip_gates = skip_gates
 
     async def handle_limit_reached(
@@ -561,7 +571,11 @@ class MaxIterationsHandler:
         """
         # In skip_gates mode, auto-stop without prompting
         if self.skip_gates:
-            self.console.print("\n[dim]Max iterations reached. Auto-stopping (--skip-gates)[/dim]")
+            self.console.print(
+                Text.from_markup(
+                    "\n[dim]Max iterations reached. Auto-stopping (--skip-gates)[/dim]"
+                )
+            )
             return MaxIterationsPromptResult(
                 continue_execution=False,
                 additional_iterations=0,
@@ -575,14 +589,14 @@ class MaxIterationsHandler:
 
         if additional > 0:
             self.console.print(
-                f"\n[green]Continuing with {additional} additional iteration(s)[/green]"
+                styled("\n[green]Continuing with {} additional iteration(s)[/green]", additional)
             )
             return MaxIterationsPromptResult(
                 continue_execution=True,
                 additional_iterations=additional,
             )
         else:
-            self.console.print("\n[yellow]Stopping workflow execution[/yellow]")
+            self.console.print(Text.from_markup("\n[yellow]Stopping workflow execution[/yellow]"))
             return MaxIterationsPromptResult(
                 continue_execution=False,
                 additional_iterations=0,
@@ -623,14 +637,16 @@ class MaxIterationsHandler:
         if len(agent_history) >= 3:
             last_agents = agent_history[-3:]
             if len(set(last_agents)) <= 2:
-                content_lines.append("[yellow]This may indicate a loop between agents.[/yellow]")
+                content_lines.append(
+                    Text.from_markup("[yellow]This may indicate a loop between agents.[/yellow]")
+                )
 
         # Create and display the panel
         self.console.print()
         self.console.print(
             Panel(
-                "\n".join(content_lines),
-                title="[bold yellow]Max Iterations Reached[/bold yellow]",
+                join("\n", content_lines),
+                title=Text.from_markup("[bold yellow]Max Iterations Reached[/bold yellow]"),
                 border_style="yellow",
             )
         )
@@ -646,7 +662,9 @@ class MaxIterationsHandler:
 
             def _ask_int() -> int:
                 return IntPrompt.ask(
-                    "[bold]How many more iterations would you like to allow?[/bold]",
+                    Text.from_markup(
+                        "[bold]How many more iterations would you like to allow?[/bold]"
+                    ),
                     default=0,
                 )
 

--- a/src/conductor/gates/interrupt.py
+++ b/src/conductor/gates/interrupt.py
@@ -12,9 +12,11 @@ from dataclasses import dataclass
 from enum import Enum
 
 from rich.console import Console
-from rich.markup import escape
 from rich.panel import Panel
 from rich.prompt import IntPrompt, Prompt
+from rich.text import Text
+
+from conductor.console import join, make_console, styled
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +90,7 @@ class InterruptHandler:
             console: Rich console for output. Creates one if not provided.
             skip_gates: If True, auto-selects cancel without prompting.
         """
-        self.console = console or Console()
+        self.console = console or make_console()
         self.skip_gates = skip_gates
 
     async def handle_interrupt(
@@ -115,7 +117,9 @@ class InterruptHandler:
             InterruptResult with the user's selected action and any data.
         """
         if self.skip_gates:
-            self.console.print("\n[dim]Interrupt received. Auto-cancelling (--skip-gates)[/dim]")
+            self.console.print(
+                Text.from_markup("\n[dim]Interrupt received. Auto-cancelling (--skip-gates)[/dim]")
+            )
             logger.debug("Interrupt auto-cancelled due to skip_gates mode")
             return InterruptResult(action=InterruptAction.CANCEL)
 
@@ -143,8 +147,8 @@ class InterruptHandler:
             accumulated_guidance: List of previously provided guidance entries.
         """
         content_lines = [
-            f"[bold]Current Agent:[/bold] {current_agent}",
-            f"[bold]Iteration:[/bold] {iteration}",
+            styled("[bold]Current Agent:[/bold] {}", current_agent),
+            styled("[bold]Iteration:[/bold] {}", iteration),
         ]
 
         # Add output preview if available
@@ -153,29 +157,29 @@ class InterruptHandler:
             if len(last_output_preview) > _OUTPUT_PREVIEW_MAX_LENGTH:
                 truncated += "..."
             content_lines.append("")
-            content_lines.append("[bold]Last Output Preview:[/bold]")
-            content_lines.append(f"  {escape(truncated)}")
+            content_lines.append(Text.from_markup("[bold]Last Output Preview:[/bold]"))
+            content_lines.append(f"  {truncated}")
 
         # Add accumulated guidance if any
         if accumulated_guidance:
             content_lines.append("")
-            content_lines.append("[bold]Previous Guidance:[/bold]")
+            content_lines.append(Text.from_markup("[bold]Previous Guidance:[/bold]"))
             for i, guidance in enumerate(accumulated_guidance, 1):
-                content_lines.append(f"  {i}. {escape(guidance)}")
+                content_lines.append(f"  {i}. {guidance}")
 
         # Add action options
         content_lines.append("")
-        content_lines.append("[bold]Actions:[/bold]")
-        content_lines.append("  [cyan][1][/cyan] Continue with guidance")
-        content_lines.append("  [cyan][2][/cyan] Skip to agent...")
-        content_lines.append("  [cyan][3][/cyan] Stop workflow")
-        content_lines.append("  [cyan][4][/cyan] Cancel (resume as-is)")
+        content_lines.append(Text.from_markup("[bold]Actions:[/bold]"))
+        content_lines.append(Text.from_markup("  [cyan][1][/cyan] Continue with guidance"))
+        content_lines.append(Text.from_markup("  [cyan][2][/cyan] Skip to agent..."))
+        content_lines.append(Text.from_markup("  [cyan][3][/cyan] Stop workflow"))
+        content_lines.append(Text.from_markup("  [cyan][4][/cyan] Cancel (resume as-is)"))
 
         self.console.print()
         self.console.print(
             Panel(
-                "\n".join(content_lines),
-                title="[bold yellow]Workflow Interrupted[/bold yellow]",
+                join("\n", content_lines),
+                title=Text.from_markup("[bold yellow]Workflow Interrupted[/bold yellow]"),
                 border_style="yellow",
             )
         )
@@ -192,7 +196,7 @@ class InterruptHandler:
         while True:
             try:
                 choice = IntPrompt.ask(
-                    "\n[bold]Select action[/bold]",
+                    Text.from_markup("\n[bold]Select action[/bold]"),
                     choices=["1", "2", "3", "4"],
                     show_choices=True,
                 )
@@ -207,10 +211,12 @@ class InterruptHandler:
                     return result
                 # If None, re-prompt (user cancelled skip selection)
             elif choice == 3:
-                self.console.print("\n[yellow]Stopping workflow execution[/yellow]")
+                self.console.print(
+                    Text.from_markup("\n[yellow]Stopping workflow execution[/yellow]")
+                )
                 return InterruptResult(action=InterruptAction.STOP)
             elif choice == 4:
-                self.console.print("\n[green]Resuming workflow[/green]")
+                self.console.print(Text.from_markup("\n[green]Resuming workflow[/green]"))
                 return InterruptResult(action=InterruptAction.CANCEL)
 
     async def _collect_guidance(self) -> InterruptResult:
@@ -221,16 +227,20 @@ class InterruptHandler:
         """
         self.console.print()
         try:
-            guidance = Prompt.ask("[bold]Enter guidance for subsequent agents[/bold]")
+            guidance = Prompt.ask(
+                Text.from_markup("[bold]Enter guidance for subsequent agents[/bold]")
+            )
         except (KeyboardInterrupt, EOFError):
             return InterruptResult(action=InterruptAction.CANCEL)
 
         if not guidance.strip():
-            self.console.print("[yellow]No guidance provided. Resuming as-is.[/yellow]")
+            self.console.print(
+                Text.from_markup("[yellow]No guidance provided. Resuming as-is.[/yellow]")
+            )
             return InterruptResult(action=InterruptAction.CANCEL)
 
         guidance = guidance.strip()
-        self.console.print(f"\n[green]Guidance added:[/green] {guidance}")
+        self.console.print(styled("\n[green]Guidance added:[/green] {}", guidance))
         return InterruptResult(action=InterruptAction.CONTINUE, guidance=guidance)
 
     async def _collect_skip_target(self, available_agents: list[str]) -> InterruptResult | None:
@@ -246,19 +256,21 @@ class InterruptHandler:
             InterruptResult with SKIP action and target, or None if user cancels.
         """
         if not available_agents:
-            self.console.print("[red]No agents available to skip to.[/red]")
+            self.console.print(Text.from_markup("[red]No agents available to skip to.[/red]"))
             return None
 
         # Display available agents
         self.console.print()
-        self.console.print("[bold]Available agents:[/bold]")
+        self.console.print(Text.from_markup("[bold]Available agents:[/bold]"))
         for i, agent_name in enumerate(available_agents, 1):
-            self.console.print(f"  [cyan][{i}][/cyan] {agent_name}")
+            self.console.print(styled("  [cyan][{}][/cyan] {}", i, agent_name))
 
         while True:
             try:
                 target = Prompt.ask(
-                    "\n[bold]Enter agent name or number (or 'back' to go back)[/bold]"
+                    Text.from_markup(
+                        "\n[bold]Enter agent name or number (or 'back' to go back)[/bold]"
+                    )
                 )
             except (KeyboardInterrupt, EOFError):
                 return None
@@ -273,17 +285,20 @@ class InterruptHandler:
                 index = int(target) - 1
                 if 0 <= index < len(available_agents):
                     selected = available_agents[index]
-                    self.console.print(f"\n[green]Skipping to agent:[/green] {selected}")
+                    self.console.print(styled("\n[green]Skipping to agent:[/green] {}", selected))
                     return InterruptResult(action=InterruptAction.SKIP, skip_target=selected)
             except ValueError:
                 pass
 
             # Allow selection by name
             if target in available_agents:
-                self.console.print(f"\n[green]Skipping to agent:[/green] {target}")
+                self.console.print(styled("\n[green]Skipping to agent:[/green] {}", target))
                 return InterruptResult(action=InterruptAction.SKIP, skip_target=target)
 
             self.console.print(
-                f"[red]Agent '{target}' not found. "
-                f"Available agents: {', '.join(available_agents)}[/red]"
+                styled(
+                    "[red]Agent '{}' not found. Available agents: {}[/red]",
+                    target,
+                    ", ".join(available_agents),
+                )
             )

--- a/src/conductor/gates/interrupt.py
+++ b/src/conductor/gates/interrupt.py
@@ -11,12 +11,11 @@ import logging
 from dataclasses import dataclass
 from enum import Enum
 
-from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import IntPrompt, Prompt
 from rich.text import Text
 
-from conductor.console import join, make_console, styled
+from conductor.console import MarkupFreeConsole, join, make_console, styled
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +80,7 @@ class InterruptHandler:
 
     def __init__(
         self,
-        console: Console | None = None,
+        console: MarkupFreeConsole | None = None,
         skip_gates: bool = False,
     ) -> None:
         """Initialize the InterruptHandler.

--- a/src/conductor/providers/claude_agent_sdk.py
+++ b/src/conductor/providers/claude_agent_sdk.py
@@ -1339,15 +1339,16 @@ def _log_event_verbose(event_type: str, data: dict[str, Any], full_mode: bool) -
     braces — kept in case a caller invokes the helper directly without
     going through ``execute()``.
     """
-    from rich.console import Console
     from rich.text import Text
+
+    from conductor.console import make_console
 
     try:
         from conductor.cli.run import _file_console
     except ImportError:
         _file_console = None
 
-    console = Console(stderr=True, highlight=False)
+    console = make_console(stderr=True, highlight=False)
 
     def _print(renderable: Any) -> None:
         console.print(renderable)

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -1795,12 +1795,12 @@ class CopilotProvider(AgentProvider):
                 event icon so concurrent parallel/for-each iterations can be
                 distinguished in interleaved logs.
         """
-        from rich.console import Console
         from rich.text import Text
 
         from conductor.cli.run import _file_console
+        from conductor.console import make_console
 
-        console = Console(stderr=True, highlight=False)
+        console = make_console(stderr=True, highlight=False)
 
         def _print(renderable: Any) -> None:
             console.print(renderable)
@@ -2037,10 +2037,11 @@ class CopilotProvider(AgentProvider):
             agent_name: Optional agent identifier used to attribute the
                 recovery message to a specific concurrent agent.
         """
-        from rich.console import Console
         from rich.text import Text
 
-        console = Console(stderr=True, highlight=False)
+        from conductor.console import make_console
+
+        console = make_console(stderr=True, highlight=False)
 
         text = Text()
         text.append("    ├─ ", style="dim")

--- a/tests/test_cli/test_doctor.py
+++ b/tests/test_cli/test_doctor.py
@@ -17,6 +17,7 @@ from rich.console import Console
 from typer.testing import CliRunner
 
 from conductor.cli.app import app
+from conductor.console import make_console
 from conductor.providers.diagnostics import (
     CredentialEnvVar,
     DoctorReport,
@@ -46,10 +47,15 @@ def _no_update_check(monkeypatch: pytest.MonkeyPatch) -> None:
     Rich table cells, which would break substring assertions on the rendered
     output. Pinning both consoles to a fixed width makes rendering
     deterministic regardless of the environment.
+
+    ``make_console`` rather than a bare ``Console``: the production consoles
+    are markup-free (#406), and substituting a markup-parsing one here would
+    make the markup-safety tests below assert against a console the CLI never
+    uses — which is exactly the bug they exist to catch.
     """
     monkeypatch.setenv("CONDUCTOR_NO_UPDATE_CHECK", "1")
-    monkeypatch.setattr(_app_module, "output_console", Console(width=200))
-    monkeypatch.setattr(_app_module, "console", Console(stderr=True, width=200))
+    monkeypatch.setattr(_app_module, "output_console", make_console(width=200))
+    monkeypatch.setattr(_app_module, "console", make_console(stderr=True, width=200))
 
 
 def _prov(

--- a/tests/test_cli/test_markup_guards.py
+++ b/tests/test_cli/test_markup_guards.py
@@ -1,0 +1,576 @@
+"""Static guards that keep new call sites markup-safe (issue #406).
+
+The behavioural tests next door prove the *current* call sites are correct.
+They cannot prove the next one will be, and that is the actual defect here:
+#382 was fixed in one file, #387 fixed ``cli/run.py`` thoroughly and still
+left ``Panel(title=)`` in the function it changed, and two commands written
+that same week — ``conductor status`` (#389) and ``conductor plugin list``
+(#398) — were written against the unfixed pattern in files the fix never
+touched.
+
+So the convention is enforced by reading the source. Four rules, each closing
+a hole the previous one leaves open:
+
+A. Every ``Console`` is built by ``make_console`` (or explicitly passes
+   ``markup=False``). This is what makes a plain string literal by default.
+B. ``Panel(title=/subtitle=)`` and ``Prompt``/``Confirm``/``IntPrompt``
+   prompts are handed a ``Text``, never an interpolated string. Rich parses
+   those with ``Text.from_markup`` unconditionally, so rule A never reaches
+   them.
+C. ``Text.from_markup`` is never given an f-string, because the interpolated
+   value would be parsed.
+D. No bare string literal containing markup reaches a print/cell sink. Under
+   rule A such a literal renders its tags as visible text, so this rule is
+   what makes the conversion verifiable rather than eyeballed.
+
+A failure names file and line, and the fix is always one of: wrap in
+``styled(...)``, wrap in ``Text.from_markup(...)`` when there is nothing to
+interpolate, or build the console with ``make_console``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "conductor"
+
+# rich treats a bracketed token as a tag when its first character is a
+# lowercase letter, '#', '/' or '@' (rich.markup.RE_TAGS).
+MARKUP_RE = re.compile(r"\[[a-z#/@][^\[]*?\]")
+
+PRINT_SINKS = {"print", "log", "rule"}
+# Local fan-out helpers that forward to a console. Named explicitly because a
+# rule keyed on the callee name cannot otherwise tell them from any other
+# function; add new ones here.
+HELPER_SINKS = {"_print", "verbose_log"}
+CELL_SINKS = {"add_row", "add_column"}
+PROMPT_CLASSES = {"Prompt", "Confirm", "IntPrompt", "FloatPrompt"}
+
+# Calls whose result is already a ``Text`` and so never reaches the parser.
+SAFE_WRAPPERS = {"styled", "join", "Text", "from_markup", "assemble", "make_console"}
+
+# ``typer`` renders its own help text through its own console, so these are
+# outside this convention entirely.
+TYPER_TEXT_KWARGS = {"help", "epilog", "rich_help_panel", "short_help"}
+
+
+def _python_files() -> list[Path]:
+    return sorted(p for p in SRC.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(SRC.parent.parent))
+
+
+def _callee(node: ast.Call) -> str | None:
+    fn = node.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr
+    if isinstance(fn, ast.Name):
+        return fn.id
+    return None
+
+
+def _is_safe_wrapper(node: ast.AST) -> bool:
+    return isinstance(node, ast.Call) and _callee(node) in SAFE_WRAPPERS
+
+
+def _annotation_is_text(node: ast.AST | None) -> bool:
+    """Is this annotation ``Text`` or a union containing only ``Text``/``None``?"""
+    if node is None:
+        return False
+    if isinstance(node, ast.Name):
+        return node.id == "Text"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "Text"
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return any(_annotation_is_text(side) for side in (node.left, node.right))
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value.replace(" ", "").split("|")[0] == "Text"
+    return False
+
+
+def _safe_text_names(scope: ast.AST) -> set[str]:
+    """Names in *scope* that provably hold a ``Text``.
+
+    A purely syntactic rule sees a bare ``Name`` as opaque and flags it, which
+    would push a real call site onto an allowlist — and an allowlist is what
+    lets the next one in. Instead, resolve the two forms that actually occur:
+    a parameter annotated ``Text``, and a local assigned from a safe wrapper
+    (including a conditional between them). Anything else stays flagged.
+    """
+    safe: set[str] = set()
+
+    for node in ast.walk(scope):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            args = node.args
+            for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
+                if _annotation_is_text(arg.annotation):
+                    safe.add(arg.arg)
+
+    def _value_is_safe(value: ast.AST) -> bool:
+        if _is_safe_wrapper(value):
+            return True
+        if isinstance(value, ast.IfExp):
+            return _value_is_safe(value.body) and _value_is_safe(value.orelse)
+        if isinstance(value, ast.Name):
+            return value.id in safe
+        return False
+
+    # Two passes: an assignment may reference a name defined by a later branch.
+    for _ in range(2):
+        for node in ast.walk(scope):
+            if isinstance(node, ast.Assign) and _value_is_safe(node.value):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        safe.add(target.id)
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and (
+                    _annotation_is_text(node.annotation) or _value_is_safe(node.value or ast.Pass())
+                )
+            ):
+                safe.add(node.target.id)
+    return safe
+
+
+def _is_dynamic(node: ast.AST, safe_names: frozenset[str] = frozenset()) -> bool:
+    """Does this argument carry a runtime value that would reach the parser?"""
+    if _is_safe_wrapper(node):
+        return False
+    if isinstance(node, ast.JoinedStr):
+        return any(isinstance(v, ast.FormattedValue) for v in node.values)
+    if isinstance(node, ast.Constant):
+        return False
+    if isinstance(node, ast.Name) and node.id in safe_names:
+        return False
+    if isinstance(node, ast.IfExp):
+        return _is_dynamic(node.body, safe_names) or _is_dynamic(node.orelse, safe_names)
+    return isinstance(node, ast.Name | ast.Attribute | ast.Call | ast.Subscript | ast.BinOp)
+
+
+def _literal_markup(node: ast.AST) -> bool:
+    """Is this a bare string literal carrying rich markup?"""
+    if isinstance(node, ast.JoinedStr):
+        return any(
+            isinstance(v, ast.Constant) and isinstance(v.value, str) and MARKUP_RE.search(v.value)
+            for v in node.values
+        )
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return bool(MARKUP_RE.search(node.value))
+    return False
+
+
+def _docstring_ids(tree: ast.AST) -> set[int]:
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            first = node.body[0] if node.body else None
+            if (
+                isinstance(first, ast.Expr)
+                and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)
+            ):
+                out.add(id(first.value))
+    return out
+
+
+def _report(violations: list[str], remedy: str) -> str:
+    listing = "\n".join(f"  {v}" for v in violations)
+    return f"{len(violations)} markup-unsafe call site(s):\n{listing}\n\n{remedy}"
+
+
+class TestRuleAConsolesAreMarkupFree:
+    """Every ``Console`` inverts the default, or none of the rest holds."""
+
+    def test_no_bare_console_construction(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            if path.name == "console.py" and path.parent == SRC:
+                continue  # the factory itself
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or _callee(node) != "Console":
+                    continue
+                explicit = any(
+                    kw.arg == "markup"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is False
+                    for kw in node.keywords
+                )
+                if not explicit:
+                    violations.append(f"{_rel(path)}:{node.lineno}: Console(...)")
+        assert not violations, _report(
+            violations,
+            "Build consoles with conductor.console.make_console() so an "
+            "interpolated runtime value is never parsed as styling.",
+        )
+
+    def test_console_subclasses_lock_markup_off(self) -> None:
+        """A subclass bypasses ``make_console`` and must lock it itself."""
+        from conductor.cli.run import _SilentAwareConsole
+
+        console = _SilentAwareConsole(markup=True)
+        with console.capture() as captured:
+            console.print("keep [dim] this")
+        # ``markup=True`` must be ignored, not honoured.
+        assert "[dim]" in captured.get()
+
+
+class TestRuleBBypassSinksReceiveText:
+    """``Panel`` titles and prompts parse markup whatever the console says."""
+
+    def test_panel_titles_are_not_interpolated_strings(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            safe = frozenset(_safe_text_names(tree))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or _callee(node) != "Panel":
+                    continue
+                for kw in node.keywords:
+                    if kw.arg in {"title", "subtitle"} and _is_dynamic(kw.value, safe):
+                        violations.append(f"{_rel(path)}:{node.lineno}: Panel({kw.arg}=...)")
+        assert not violations, _report(
+            violations,
+            "rich calls Text.from_markup on a Panel title regardless of the "
+            "console's markup=False, so pass styled(...) or Text(...).",
+        )
+
+    def test_prompts_are_not_interpolated_strings(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            safe = frozenset(_safe_text_names(tree))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                is_ask = (
+                    isinstance(fn, ast.Attribute)
+                    and fn.attr == "ask"
+                    and isinstance(fn.value, ast.Name)
+                    and fn.value.id in PROMPT_CLASSES
+                )
+                if not is_ask or not node.args:
+                    continue
+                if _is_dynamic(node.args[0], safe):
+                    violations.append(f"{_rel(path)}:{node.lineno}: {fn.value.id}.ask(...)")
+        assert not violations, _report(
+            violations,
+            "rich calls Text.from_markup on a prompt regardless of the "
+            "console's markup=False, so pass styled(...) or Text(...).",
+        )
+
+
+class TestRuleCFromMarkupTakesOnlyLiterals:
+    """``Text.from_markup`` always parses, so it must never see a value."""
+
+    def test_from_markup_is_never_given_an_f_string(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            safe = frozenset(_safe_text_names(tree))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or _callee(node) != "from_markup":
+                    continue
+                if node.args and _is_dynamic(node.args[0], safe):
+                    violations.append(f"{_rel(path)}:{node.lineno}: Text.from_markup(...)")
+        assert not violations, _report(
+            violations,
+            "Use styled('<template>', value) — it parses the template but "
+            "inserts the value as literal text.",
+        )
+
+
+class TestRuleDNoUnwrappedMarkupAtASink:
+    """Under rule A a markup literal at a sink prints its tags verbatim.
+
+    This is the rule that makes the conversion checkable: it fails for every
+    site that was missed, rather than leaving it to be noticed in output.
+    """
+
+    def test_no_markup_string_literal_reaches_a_sink(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            docstrings = _docstring_ids(tree)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = _callee(node)
+                if name not in PRINT_SINKS | HELPER_SINKS | CELL_SINKS:
+                    continue
+                # The *builtin* ``print`` is rule E's job: a markup literal
+                # there is correct, because nothing parses it. A bare-Name
+                # call to anything else (``_print``, a console fan-out
+                # helper) still routes to a console and stays covered here.
+                if isinstance(node.func, ast.Name) and node.func.id == "print":
+                    continue
+                args: list[ast.AST] = list(node.args)
+                args += [
+                    kw.value for kw in node.keywords if kw.arg not in {"style", *TYPER_TEXT_KWARGS}
+                ]
+                for arg in args:
+                    if id(arg) in docstrings:
+                        continue
+                    if _literal_markup(arg):
+                        violations.append(f"{_rel(path)}:{node.lineno}: {name}(...)")
+        assert not violations, _report(
+            violations,
+            "Wrap in styled('<template>', ...) — or Text.from_markup('...') "
+            "when there is nothing to interpolate.",
+        )
+
+
+class TestRuleENoTextThroughBuiltinPrint:
+    """A Rich ``Text`` handed to the *builtin* ``print`` is a silent data loss.
+
+    ``print`` renders it via ``str(Text)``, which is its plain form: any
+    styling is discarded, and — worse — any text rich already consumed as a
+    tag is simply gone. That is not hypothetical. Converting call sites for
+    this issue wrapped a stderr log label in ``Text.from_markup``, and because
+    ``[workspace-instructions]`` starts with a lowercase letter rich read it
+    as a style tag and deleted it, leaving ``" 0 files discovered from CWD."``.
+    The existing test passed, because it asserted on a substring after the
+    prefix.
+
+    Rules A–D all cleared that site: the callee is named ``print`` and the
+    argument is a ``SAFE_WRAPPERS`` call, which is exactly right at a Rich
+    console and exactly wrong here.
+    """
+
+    def test_builtin_print_is_not_given_a_text(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                # A bare Name callee is the builtin; ``console.print`` is an
+                # Attribute and is governed by rules A and D instead.
+                if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                    continue
+                if node.func.id != "print":
+                    continue
+                for arg in node.args:
+                    if isinstance(arg, ast.Call) and _callee(arg) in SAFE_WRAPPERS:
+                        violations.append(f"{_rel(path)}:{node.lineno}: print({_callee(arg)}(...))")
+        assert not violations, _report(
+            violations,
+            "The builtin print() renders a Text as its plain form, dropping "
+            "styling and any text rich parsed as a tag. Pass a plain string, "
+            "or print through a console built by make_console().",
+        )
+
+
+class TestTheGuardsActuallyDetectViolations:
+    """Negative controls.
+
+    A static check that silently matches nothing is worse than no check: it
+    reports "all clear" forever. Each rule is run against a snippet that
+    violates it, and one that does not.
+    """
+
+    @staticmethod
+    def _violations_in(source: str, rule: str) -> list[str]:
+        tree = ast.parse(source)
+        docstrings = _docstring_ids(tree)
+        found: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _callee(node)
+            if rule == "A" and name == "Console":
+                if not any(
+                    kw.arg == "markup"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is False
+                    for kw in node.keywords
+                ):
+                    found.append(f"line {node.lineno}")
+            elif rule == "B" and name == "Panel":
+                for kw in node.keywords:
+                    if kw.arg in {"title", "subtitle"} and _is_dynamic(kw.value):
+                        found.append(f"line {node.lineno}")
+            elif rule == "C" and name == "from_markup":
+                if node.args and _is_dynamic(node.args[0]):
+                    found.append(f"line {node.lineno}")
+            elif rule == "D" and name in PRINT_SINKS | HELPER_SINKS | CELL_SINKS:
+                if isinstance(node.func, ast.Name) and node.func.id == "print":
+                    continue
+                for arg in list(node.args) + [k.value for k in node.keywords if k.arg != "style"]:
+                    if id(arg) not in docstrings and _literal_markup(arg):
+                        found.append(f"line {node.lineno}")
+            elif rule == "E" and isinstance(node.func, ast.Name) and node.func.id == "print":
+                for arg in node.args:
+                    if isinstance(arg, ast.Call) and _callee(arg) in SAFE_WRAPPERS:
+                        found.append(f"line {node.lineno}")
+        return found
+
+    def test_rule_a_flags_a_bare_console(self) -> None:
+        assert self._violations_in("c = Console(stderr=True)", "A")
+
+    def test_rule_a_accepts_an_explicit_opt_out(self) -> None:
+        assert not self._violations_in("c = Console(stderr=True, markup=False)", "A")
+
+    def test_rule_b_flags_an_interpolated_title(self) -> None:
+        assert self._violations_in('Panel(body, title=f"[cyan]{name}[/cyan]")', "B")
+
+    def test_rule_b_flags_a_bare_name_title(self) -> None:
+        assert self._violations_in("Panel(body, title=agent_name)", "B")
+
+    def test_rule_b_accepts_styled(self) -> None:
+        assert not self._violations_in('Panel(body, title=styled("[cyan]{}[/cyan]", name))', "B")
+
+    def test_rule_b_accepts_a_constant_title(self) -> None:
+        """Conductor's own literal title is parsed as intended."""
+        assert not self._violations_in('Panel(body, title="[cyan]Plan[/cyan]")', "B")
+
+    def test_rule_c_flags_an_f_string(self) -> None:
+        assert self._violations_in('Text.from_markup(f"[b]{x}[/b]")', "C")
+
+    def test_rule_c_accepts_a_literal(self) -> None:
+        assert not self._violations_in('Text.from_markup("[b]hi[/b]")', "C")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            'console.print("[red]boom[/red]")',
+            'console.print(f"[red]{err}[/red]")',
+            'table.add_row("[dim]x[/dim]")',
+            'console.log("[green]ok[/green]")',
+        ],
+    )
+    def test_rule_d_flags_unwrapped_markup(self, snippet: str) -> None:
+        assert self._violations_in(snippet, "D")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            'console.print(styled("[red]{}[/red]", err))',
+            'console.print(Text.from_markup("[red]boom[/red]"))',
+            'console.print(f"plain {value}")',
+            "table.add_row(name, str(count))",
+            'console.print("[0] not a tag")',
+            # The builtin print does not parse markup; rule E governs it.
+            'print("[workspace-instructions] 0 files", file=sys.stderr)',
+        ],
+    )
+    def test_rule_d_accepts_safe_sites(self, snippet: str) -> None:
+        assert not self._violations_in(snippet, "D")
+
+    def test_rule_d_still_covers_a_console_fanout_helper(self) -> None:
+        """``_print`` is a bare Name too, but it routes to a console."""
+        assert self._violations_in('_print("[bold cyan]Token Usage Summary[/bold cyan]")', "D")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            'print(Text.from_markup("[b]x[/b]"), file=sys.stderr)',
+            'print(styled("[b]{}[/b]", x))',
+            'print(Text("plain"))',
+        ],
+    )
+    def test_rule_e_flags_text_through_builtin_print(self, snippet: str) -> None:
+        assert self._violations_in(snippet, "E")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            'print("[workspace-instructions] 0 files", file=sys.stderr)',
+            'print(f"  {path}", file=sys.stderr)',
+            'console.print(styled("[b]{}[/b]", x))',
+        ],
+    )
+    def test_rule_e_accepts_safe_sites(self, snippet: str) -> None:
+        assert not self._violations_in(snippet, "E")
+
+
+class TestSafeNameResolution:
+    """``_safe_text_names`` must resolve narrowly, or rule B goes blind.
+
+    It exists so a real ``Text``-typed local is not pushed onto an allowlist.
+    If it over-accepts, every bare name becomes invisible to rule B and the
+    guard silently stops working.
+    """
+
+    def test_text_annotated_parameter_is_safe(self) -> None:
+        src = "def f(prompt: Text) -> None:\n    Prompt.ask(prompt)\n"
+        assert "prompt" in _safe_text_names(ast.parse(src))
+
+    def test_optional_text_parameter_is_safe(self) -> None:
+        src = "def f(prompt: Text | None = None) -> None:\n    Prompt.ask(prompt)\n"
+        assert "prompt" in _safe_text_names(ast.parse(src))
+
+    def test_local_assigned_from_styled_is_safe(self) -> None:
+        src = 'def f():\n    p = styled("[b]x[/b]")\n    Prompt.ask(p)\n'
+        assert "p" in _safe_text_names(ast.parse(src))
+
+    def test_conditional_between_safe_values_is_safe(self) -> None:
+        src = (
+            "def f(prompt: Text | None = None):\n"
+            '    p = styled("[b]x[/b]") if prompt is None else prompt\n'
+            "    Prompt.ask(p)\n"
+        )
+        assert "p" in _safe_text_names(ast.parse(src))
+
+    def test_str_annotated_parameter_is_not_safe(self) -> None:
+        src = "def f(prompt: str) -> None:\n    Prompt.ask(prompt)\n"
+        assert "prompt" not in _safe_text_names(ast.parse(src))
+
+    def test_unannotated_parameter_is_not_safe(self) -> None:
+        src = "def f(prompt):\n    Prompt.ask(prompt)\n"
+        assert "prompt" not in _safe_text_names(ast.parse(src))
+
+    def test_local_assigned_from_an_f_string_is_not_safe(self) -> None:
+        src = 'def f(x):\n    p = f"[b]{x}[/b]"\n    Prompt.ask(p)\n'
+        assert "p" not in _safe_text_names(ast.parse(src))
+
+    def test_conditional_with_one_unsafe_branch_is_not_safe(self) -> None:
+        src = 'def f(x, flag):\n    p = styled("[b]y[/b]") if flag else x\n    Prompt.ask(p)\n'
+        assert "p" not in _safe_text_names(ast.parse(src))
+
+    def test_rule_b_still_flags_an_unresolvable_name(self) -> None:
+        """The end-to-end consequence of the two cases above."""
+        src = "def f(prompt: str) -> None:\n    Panel(body, title=prompt)\n"
+        tree = ast.parse(src)
+        safe = frozenset(_safe_text_names(tree))
+        call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _callee(n) == "Panel")
+        title = next(kw.value for kw in call.keywords if kw.arg == "title")
+        assert _is_dynamic(title, safe)
+
+
+class TestTheGuardsCoverRealSource:
+    """Guard the guards: a path typo would make every rule vacuous."""
+
+    def test_source_tree_is_found(self) -> None:
+        files = _python_files()
+        assert len(files) > 50, f"only found {len(files)} files under {SRC}"
+        assert any(p.name == "run.py" for p in files)
+
+    def test_sinks_are_actually_present_in_the_source(self) -> None:
+        """If nothing matches the sink names, rule D can never fail."""
+        seen = 0
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and _callee(node) in PRINT_SINKS | HELPER_SINKS | CELL_SINKS
+                ):
+                    seen += 1
+        assert seen > 100, f"only {seen} sink calls found; the scan is not reaching the source"
+
+    def test_panel_titles_are_actually_present(self) -> None:
+        """Likewise for rule B, whose match set is much smaller."""
+        seen = 0
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and _callee(node) == "Panel":
+                    seen += sum(1 for kw in node.keywords if kw.arg in {"title", "subtitle"})
+        assert seen > 5, f"only {seen} Panel titles found; the scan is not reaching the source"

--- a/tests/test_cli/test_markup_guards.py
+++ b/tests/test_cli/test_markup_guards.py
@@ -8,11 +8,13 @@ that same week — ``conductor status`` (#389) and ``conductor plugin list``
 (#398) — were written against the unfixed pattern in files the fix never
 touched.
 
-So the convention is enforced by reading the source. Four rules, each closing
+So the convention is enforced by reading the source. Eight rules, each closing
 a hole the previous one leaves open:
 
 A. Every ``Console`` is built by ``make_console`` (or explicitly passes
-   ``markup=False``). This is what makes a plain string literal by default.
+   ``markup=False``), and every ``Console`` subclass derives from
+   ``MarkupFreeConsole`` so it inherits the refusal. This is what makes a
+   plain string literal by default.
 B. ``Panel(title=/subtitle=)`` and ``Prompt``/``Confirm``/``IntPrompt``
    prompts are handed a ``Text``, never an interpolated string. Rich parses
    those with ``Text.from_markup`` unconditionally, so rule A never reaches
@@ -22,16 +24,33 @@ C. ``Text.from_markup`` is never given an f-string, because the interpolated
 D. No bare string literal containing markup reaches a print/cell sink. Under
    rule A such a literal renders its tags as visible text, so this rule is
    what makes the conversion verifiable rather than eyeballed.
+E. No ``Text`` is handed to the *builtin* ``print``, which renders its plain
+   form -- dropping styling, and dropping outright any text rich already
+   parsed as a tag.
+F. No ``Text`` is interpolated into an f-string, for the same reason. This is
+   the general form of rule E and the defect with the worst record here: it
+   shipped four separate times, twice destroying data rather than styling.
+G. ``typer`` ``help=``/``epilog=`` text escapes its brackets. Typer renders
+   help through its *own* rich console, so the console convention does not
+   reach it -- which is how ``[@registry][@version]`` went missing from
+   ``conductor run --help`` entirely.
+H. ``rich.markup.escape`` is never used. It is not byte-exact, so it cannot
+   round-trip a value that already contains a backslash before a bracket.
 
 A failure names file and line, and the fix is always one of: wrap in
 ``styled(...)``, wrap in ``Text.from_markup(...)`` when there is nothing to
-interpolate, or build the console with ``make_console``.
+interpolate, build the console with ``make_console``, or escape the bracket.
+
+Each rule is a ``_violates_*`` predicate called by both the source scan and
+its negative control, so a control cannot pass while the rule it claims to
+control has drifted -- which had already happened once.
 """
 
 from __future__ import annotations
 
 import ast
 import re
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -51,15 +70,35 @@ CELL_SINKS = {"add_row", "add_column"}
 PROMPT_CLASSES = {"Prompt", "Confirm", "IntPrompt", "FloatPrompt"}
 
 # Calls whose result is already a ``Text`` and so never reaches the parser.
-SAFE_WRAPPERS = {"styled", "join", "Text", "from_markup", "assemble", "make_console"}
+# Split by callee shape on purpose: ``_callee`` returns the bare attribute
+# name, so a flat name set would match ``", ".join(names)`` -- a plain ``str``
+# built from runtime data -- and wave it through rules B and C.
+_SAFE_BARE_CALLS = {"styled", "join", "Text"}
+_SAFE_TEXT_METHODS = {"from_markup", "assemble"}
+SAFE_WRAPPERS = _SAFE_BARE_CALLS | _SAFE_TEXT_METHODS
 
-# ``typer`` renders its own help text through its own console, so these are
-# outside this convention entirely.
+# ``typer`` renders help through rich (``rich_markup_mode="rich"``), so these
+# strings *are* markup-parsed -- just not by a conductor console. They are
+# excluded from rule D (which is about conductor's sinks) and covered by rule
+# G instead. Excluding them without rule G is what let ``[@registry]`` go
+# missing from ``conductor run --help``.
 TYPER_TEXT_KWARGS = {"help", "epilog", "rich_help_panel", "short_help"}
+TYPER_CALLEES = {"Option", "Argument", "Typer", "command", "callback"}
 
 
 def _python_files() -> list[Path]:
     return sorted(p for p in SRC.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _is_factory(path: Path) -> bool:
+    """Is this the module that *implements* the safe primitives?
+
+    ``console.py`` builds the very things the rules look for -- it constructs
+    the markup-free console and calls ``Text.from_markup`` on an assembled
+    template -- so scanning it reports the implementation as a violation of
+    itself.
+    """
+    return path.name == "console.py" and path.parent == SRC
 
 
 def _rel(path: Path) -> str:
@@ -76,21 +115,48 @@ def _callee(node: ast.Call) -> str | None:
 
 
 def _is_safe_wrapper(node: ast.AST) -> bool:
-    return isinstance(node, ast.Call) and _callee(node) in SAFE_WRAPPERS
+    """Does this call provably produce a ``Text``?
+
+    Resolved by receiver rather than by bare name: ``Text.from_markup(...)``
+    is safe, ``", ".join(...)`` is not, and both end in an attribute called
+    ``join``/``from_markup``.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    fn = node.func
+    if isinstance(fn, ast.Name):
+        return fn.id in _SAFE_BARE_CALLS
+    return (
+        isinstance(fn, ast.Attribute)
+        and fn.attr in _SAFE_TEXT_METHODS
+        and isinstance(fn.value, ast.Name)
+        and fn.value.id == "Text"
+    )
 
 
 def _annotation_is_text(node: ast.AST | None) -> bool:
-    """Is this annotation ``Text`` or a union containing only ``Text``/``None``?"""
+    """Is this annotation ``Text``, or a union of only ``Text`` and ``None``?
+
+    A union containing ``str`` is deliberately *not* safe. ``verbose_log``
+    takes ``str | Text``, and accepting that would mark the name ``message``
+    safe for the whole module, blinding rule B on every other function that
+    happens to use the same parameter name.
+    """
     if node is None:
         return False
     if isinstance(node, ast.Name):
         return node.id == "Text"
     if isinstance(node, ast.Attribute):
         return node.attr == "Text"
+    if isinstance(node, ast.Constant):
+        if node.value is None:
+            return True
+        if isinstance(node.value, str):
+            parts = [p.strip() for p in node.value.split("|")]
+            return bool(parts) and all(p in {"Text", "None"} for p in parts)
+        return False
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return any(_annotation_is_text(side) for side in (node.left, node.right))
-    if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value.replace(" ", "").split("|")[0] == "Text"
+        return all(_annotation_is_text(side) for side in (node.left, node.right))
     return False
 
 
@@ -105,12 +171,11 @@ def _safe_text_names(scope: ast.AST) -> set[str]:
     """
     safe: set[str] = set()
 
-    for node in ast.walk(scope):
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-            args = node.args
-            for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
-                if _annotation_is_text(arg.annotation):
-                    safe.add(arg.arg)
+    if isinstance(scope, ast.FunctionDef | ast.AsyncFunctionDef):
+        args = scope.args
+        for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
+            if _annotation_is_text(arg.annotation):
+                safe.add(arg.arg)
 
     def _value_is_safe(value: ast.AST) -> bool:
         if _is_safe_wrapper(value):
@@ -123,7 +188,7 @@ def _safe_text_names(scope: ast.AST) -> set[str]:
 
     # Two passes: an assignment may reference a name defined by a later branch.
     for _ in range(2):
-        for node in ast.walk(scope):
+        for node in _scope_nodes(scope):
             if isinstance(node, ast.Assign) and _value_is_safe(node.value):
                 for target in node.targets:
                     if isinstance(target, ast.Name):
@@ -166,6 +231,120 @@ def _literal_markup(node: ast.AST) -> bool:
     return False
 
 
+def _maybe_text_names(scope: ast.AST) -> set[str]:
+    """Names in *scope* that *may* hold a ``Text``.
+
+    Deliberately a different predicate from :func:`_safe_text_names`. That one
+    answers "is this definitely a ``Text``?", which rules B and C need before
+    they can *clear* a name. Rule F needs the opposite: it must *flag* a name
+    that could be a ``Text``, so a conditional with one ``Text`` branch counts
+    even though it is not definitely a ``Text``.
+
+    Concretely, the loop-target marker that shipped this bug was
+    ``Text.from_markup(...) if step.is_loop_target else ""`` -- not "definitely
+    Text", and therefore invisible to the stricter predicate.
+    """
+    names: set[str] = set()
+
+    def _value_may_be_text(value: ast.AST) -> bool:
+        if _is_safe_wrapper(value):
+            return True
+        if isinstance(value, ast.IfExp):
+            return _value_may_be_text(value.body) or _value_may_be_text(value.orelse)
+        if isinstance(value, ast.Name):
+            return value.id in names
+        return False
+
+    if isinstance(scope, ast.FunctionDef | ast.AsyncFunctionDef):
+        args = scope.args
+        for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
+            if arg.annotation is not None and _annotation_mentions_text(arg.annotation):
+                names.add(arg.arg)
+
+    for _ in range(2):
+        for node in _scope_nodes(scope):
+            if isinstance(node, ast.Assign) and _value_may_be_text(node.value):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+            # Mirrors the ``AnnAssign`` arm in ``_safe_text_names``; without it
+            # ``m: Text = styled(...)`` is invisible to rule F.
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and (
+                    _annotation_mentions_text(node.annotation)
+                    or (node.value is not None and _value_may_be_text(node.value))
+                )
+            ):
+                names.add(node.target.id)
+    return names
+
+
+def _annotation_mentions_text(node: ast.AST) -> bool:
+    """Does this annotation mention ``Text`` anywhere (including a union)?"""
+    if isinstance(node, ast.Name):
+        return node.id == "Text"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "Text"
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return any(_annotation_mentions_text(s) for s in (node.left, node.right))
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return "Text" in node.value
+    return False
+
+
+def _scope_nodes(scope: ast.AST) -> Iterator[ast.AST]:
+    """Walk *scope* without descending into a nested function or class.
+
+    ``ast.walk`` would pull a nested function's parameters into its parent's
+    name set, which is the cross-function leak this scoping exists to avoid.
+    """
+    stack = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _scope_names(tree: ast.Module, resolver: Callable[[ast.AST], set[str]]) -> dict[int, set[str]]:
+    """Map every node to the names *resolver* finds in its enclosing function.
+
+    Resolving names per module would let one function's annotation clear a
+    same-named local everywhere else in the file. That is not hypothetical:
+    ``verbose_log(message: str | Text)`` would otherwise mark ``message`` as
+    Text-bearing for the whole of ``cli/run.py``, where several unrelated
+    functions take a ``message: str``.
+    """
+    scopes: dict[int, set[str]] = {}
+
+    def _descend(scope: ast.AST, inherited: set[str]) -> None:
+        # A nested function closes over its enclosing scope, so names
+        # accumulate inward. ``_get_user_input`` binds ``prompt`` and its inner
+        # ``_ask`` is what actually calls ``Prompt.ask(prompt)``.
+        names = inherited | resolver(scope)
+        for node in ast.walk(scope):
+            scopes[id(node)] = names
+        for node in ast.iter_child_nodes(scope):
+            _walk_for_functions(node, names)
+
+    def _walk_for_functions(node: ast.AST, inherited: set[str]) -> None:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            _descend(node, inherited)
+            return
+        for child in ast.iter_child_nodes(node):
+            _walk_for_functions(child, inherited)
+
+    _descend(tree, set())
+    return scopes
+
+
+def _names_for(scopes: dict[int, set[str]], node: ast.AST) -> frozenset[str]:
+    return frozenset(scopes.get(id(node), ()))
+
+
 def _docstring_ids(tree: ast.AST) -> set[int]:
     out: set[int] = set()
     for node in ast.walk(tree):
@@ -180,6 +359,167 @@ def _docstring_ids(tree: ast.AST) -> set[int]:
     return out
 
 
+# --------------------------------------------------------------------------
+# Rule predicates.
+#
+# Each returns the violating labels for one node. Both the source scan and its
+# negative control call these, so a control cannot pass while the rule it
+# claims to control has drifted -- which had already happened once, when rule
+# D grew a ``TYPER_TEXT_KWARGS`` exemption its control never learned about.
+# --------------------------------------------------------------------------
+
+
+def _violates_a(node: ast.AST) -> list[str]:
+    if not isinstance(node, ast.Call) or _callee(node) != "Console":
+        return []
+    explicit = any(
+        kw.arg == "markup" and isinstance(kw.value, ast.Constant) and kw.value.value is False
+        for kw in node.keywords
+    )
+    return [] if explicit else ["Console(...)"]
+
+
+def _violates_b_panel(node: ast.AST, safe: frozenset[str]) -> list[str]:
+    if not isinstance(node, ast.Call) or _callee(node) != "Panel":
+        return []
+    return [
+        f"Panel({kw.arg}=...)"
+        for kw in node.keywords
+        if kw.arg in {"title", "subtitle"} and _is_dynamic(kw.value, safe)
+    ]
+
+
+def _violates_b_prompt(node: ast.AST, safe: frozenset[str]) -> list[str]:
+    if not isinstance(node, ast.Call):
+        return []
+    fn = node.func
+    is_ask = (
+        isinstance(fn, ast.Attribute)
+        and fn.attr == "ask"
+        and isinstance(fn.value, ast.Name)
+        and fn.value.id in PROMPT_CLASSES
+    )
+    if not is_ask or not node.args or not _is_dynamic(node.args[0], safe):
+        return []
+    return [f"{fn.value.id}.ask(...)"]  # type: ignore[union-attr]
+
+
+def _violates_c(node: ast.AST, safe: frozenset[str]) -> list[str]:
+    if not isinstance(node, ast.Call) or _callee(node) != "from_markup":
+        return []
+    if node.args and _is_dynamic(node.args[0], safe):
+        return ["Text.from_markup(...)"]
+    return []
+
+
+def _violates_d(node: ast.AST, docstrings: set[int]) -> list[str]:
+    if not isinstance(node, ast.Call):
+        return []
+    name = _callee(node)
+    if name not in PRINT_SINKS | HELPER_SINKS | CELL_SINKS:
+        return []
+    # The *builtin* ``print`` is rule E's job: a markup literal there is
+    # correct, because nothing parses it. A bare-Name call to anything else
+    # (``_print``, a console fan-out helper) still routes to a console.
+    if isinstance(node.func, ast.Name) and node.func.id == "print":
+        return []
+    args: list[ast.AST] = list(node.args)
+    # No typer exemption here: rule D's sinks and rule G's typer callees are
+    # disjoint sets, so exempting ``help=`` would only create a hole for a
+    # conductor sink that happened to take a kwarg of that name.
+    args += [kw.value for kw in node.keywords if kw.arg != "style"]
+    return [f"{name}(...)" for arg in args if id(arg) not in docstrings and _literal_markup(arg)]
+
+
+def _violates_e(node: ast.AST) -> list[str]:
+    if not isinstance(node, ast.Call):
+        return []
+    if not isinstance(node.func, ast.Name) or node.func.id != "print":
+        return []
+    return [f"print({_callee(arg)}(...))" for arg in node.args if _is_safe_wrapper(arg)]
+
+
+def _violates_f(node: ast.AST, maybe: frozenset[str]) -> list[str]:
+    if not isinstance(node, ast.JoinedStr):
+        return []
+    out: list[str] = []
+    for part in node.values:
+        if not isinstance(part, ast.FormattedValue):
+            continue
+        # ``!r`` is a deliberate repr, not an accidental flatten.
+        if part.conversion == ord("r"):
+            continue
+        value = part.value
+        if _is_safe_wrapper(value) or (isinstance(value, ast.Name) and value.id in maybe):
+            out.append("f-string")
+    return out
+
+
+def _violates_g(node: ast.AST) -> list[str]:
+    if not isinstance(node, ast.Call) or _callee(node) not in TYPER_CALLEES:
+        return []
+    out: list[str] = []
+    for kw in node.keywords:
+        if kw.arg not in TYPER_TEXT_KWARGS:
+            continue
+        for part in _string_parts(kw.value):
+            # An escaped bracket is fine; rich renders ``\\[`` literally.
+            if MARKUP_RE.search(part.replace("\\[", "")):
+                out.append(f"typer {kw.arg}=")
+    return out
+
+
+def _string_parts(node: ast.AST) -> list[str]:
+    """Every literal string chunk in a constant or implicitly-joined value."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, ast.JoinedStr):
+        return [
+            v.value for v in node.values if isinstance(v, ast.Constant) and isinstance(v.value, str)
+        ]
+    return []
+
+
+def _violates_a_subclass(node: ast.AST) -> list[str]:
+    """A ``Console`` subclass bypasses ``make_console``, so it must not exist.
+
+    Matches a dotted base (``rich.console.Console``) as well as a bare name,
+    since an aliased import would otherwise slip past.
+    """
+    if not isinstance(node, ast.ClassDef):
+        return []
+    for base in node.bases:
+        name = base.id if isinstance(base, ast.Name) else getattr(base, "attr", None)
+        if name == "Console":
+            return [f"class {node.name}(Console)"]
+    return []
+
+
+def _violates_h(node: ast.AST) -> list[str]:
+    """``rich.markup.escape`` is banned: it is not byte-exact.
+
+    The parser treats ``\\[`` as an escaped bracket, so ``\\[0-9\\]+`` renders as
+    ``[0-9\\]+`` whether or not it was escaped first. Building a ``Text``
+    avoids the parser entirely.
+    """
+    if (
+        isinstance(node, ast.ImportFrom)
+        and node.module == "rich.markup"
+        and any(alias.name == "escape" for alias in node.names)
+    ):
+        return ["from rich.markup import escape"]
+    if isinstance(node, ast.Call):
+        fn = node.func
+        if (
+            isinstance(fn, ast.Attribute)
+            and fn.attr == "escape"
+            and isinstance(fn.value, ast.Name)
+            and fn.value.id == "markup"
+        ):
+            return ["markup.escape(...)"]
+    return []
+
+
 def _report(violations: list[str], remedy: str) -> str:
     listing = "\n".join(f"  {v}" for v in violations)
     return f"{len(violations)} markup-unsafe call site(s):\n{listing}\n\n{remedy}"
@@ -191,20 +531,11 @@ class TestRuleAConsolesAreMarkupFree:
     def test_no_bare_console_construction(self) -> None:
         violations: list[str] = []
         for path in _python_files():
-            if path.name == "console.py" and path.parent == SRC:
-                continue  # the factory itself
+            if _is_factory(path):
+                continue
             tree = ast.parse(path.read_text(encoding="utf-8"))
             for node in ast.walk(tree):
-                if not isinstance(node, ast.Call) or _callee(node) != "Console":
-                    continue
-                explicit = any(
-                    kw.arg == "markup"
-                    and isinstance(kw.value, ast.Constant)
-                    and kw.value.value is False
-                    for kw in node.keywords
-                )
-                if not explicit:
-                    violations.append(f"{_rel(path)}:{node.lineno}: Console(...)")
+                violations += [f"{_rel(path)}:{node.lineno}: {v}" for v in _violates_a(node)]
         assert not violations, _report(
             violations,
             "Build consoles with conductor.console.make_console() so an "
@@ -212,14 +543,32 @@ class TestRuleAConsolesAreMarkupFree:
         )
 
     def test_console_subclasses_lock_markup_off(self) -> None:
-        """A subclass bypasses ``make_console`` and must lock it itself."""
+        """A subclass bypasses ``make_console``, so the class enforces it.
+
+        Enumerated from the source rather than hardcoding one class name: a
+        hardcoded import covers exactly one subclass forever, and the rule
+        exists for the *next* one.
+        """
+        subclasses: list[str] = []
+        for path in _python_files():
+            if _is_factory(path):
+                continue  # MarkupFreeConsole itself is the one legitimate base
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                subclasses += [
+                    f"{_rel(path)}:{node.lineno}: {v}" for v in _violates_a_subclass(node)
+                ]
+        assert not subclasses, _report(
+            subclasses,
+            "Subclass conductor.console.MarkupFreeConsole rather than rich's "
+            "Console, so the markup refusal is inherited.",
+        )
+
+        # And the one legitimate subclass actually refuses.
         from conductor.cli.run import _SilentAwareConsole
 
-        console = _SilentAwareConsole(markup=True)
-        with console.capture() as captured:
-            console.print("keep [dim] this")
-        # ``markup=True`` must be ignored, not honoured.
-        assert "[dim]" in captured.get()
+        with pytest.raises(TypeError):
+            _SilentAwareConsole(markup=True)
 
 
 class TestRuleBBypassSinksReceiveText:
@@ -229,13 +578,12 @@ class TestRuleBBypassSinksReceiveText:
         violations: list[str] = []
         for path in _python_files():
             tree = ast.parse(path.read_text(encoding="utf-8"))
-            safe = frozenset(_safe_text_names(tree))
+            scopes = _scope_names(tree, _safe_text_names)
             for node in ast.walk(tree):
-                if not isinstance(node, ast.Call) or _callee(node) != "Panel":
-                    continue
-                for kw in node.keywords:
-                    if kw.arg in {"title", "subtitle"} and _is_dynamic(kw.value, safe):
-                        violations.append(f"{_rel(path)}:{node.lineno}: Panel({kw.arg}=...)")
+                violations += [
+                    f"{_rel(path)}:{node.lineno}: {v}"
+                    for v in _violates_b_panel(node, _names_for(scopes, node))
+                ]
         assert not violations, _report(
             violations,
             "rich calls Text.from_markup on a Panel title regardless of the "
@@ -246,21 +594,12 @@ class TestRuleBBypassSinksReceiveText:
         violations: list[str] = []
         for path in _python_files():
             tree = ast.parse(path.read_text(encoding="utf-8"))
-            safe = frozenset(_safe_text_names(tree))
+            scopes = _scope_names(tree, _safe_text_names)
             for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-                fn = node.func
-                is_ask = (
-                    isinstance(fn, ast.Attribute)
-                    and fn.attr == "ask"
-                    and isinstance(fn.value, ast.Name)
-                    and fn.value.id in PROMPT_CLASSES
-                )
-                if not is_ask or not node.args:
-                    continue
-                if _is_dynamic(node.args[0], safe):
-                    violations.append(f"{_rel(path)}:{node.lineno}: {fn.value.id}.ask(...)")
+                violations += [
+                    f"{_rel(path)}:{node.lineno}: {v}"
+                    for v in _violates_b_prompt(node, _names_for(scopes, node))
+                ]
         assert not violations, _report(
             violations,
             "rich calls Text.from_markup on a prompt regardless of the "
@@ -274,13 +613,15 @@ class TestRuleCFromMarkupTakesOnlyLiterals:
     def test_from_markup_is_never_given_an_f_string(self) -> None:
         violations: list[str] = []
         for path in _python_files():
+            if _is_factory(path):
+                continue
             tree = ast.parse(path.read_text(encoding="utf-8"))
-            safe = frozenset(_safe_text_names(tree))
+            scopes = _scope_names(tree, _safe_text_names)
             for node in ast.walk(tree):
-                if not isinstance(node, ast.Call) or _callee(node) != "from_markup":
-                    continue
-                if node.args and _is_dynamic(node.args[0], safe):
-                    violations.append(f"{_rel(path)}:{node.lineno}: Text.from_markup(...)")
+                violations += [
+                    f"{_rel(path)}:{node.lineno}: {v}"
+                    for v in _violates_c(node, _names_for(scopes, node))
+                ]
         assert not violations, _report(
             violations,
             "Use styled('<template>', value) — it parses the template but "
@@ -301,26 +642,9 @@ class TestRuleDNoUnwrappedMarkupAtASink:
             tree = ast.parse(path.read_text(encoding="utf-8"))
             docstrings = _docstring_ids(tree)
             for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-                name = _callee(node)
-                if name not in PRINT_SINKS | HELPER_SINKS | CELL_SINKS:
-                    continue
-                # The *builtin* ``print`` is rule E's job: a markup literal
-                # there is correct, because nothing parses it. A bare-Name
-                # call to anything else (``_print``, a console fan-out
-                # helper) still routes to a console and stays covered here.
-                if isinstance(node.func, ast.Name) and node.func.id == "print":
-                    continue
-                args: list[ast.AST] = list(node.args)
-                args += [
-                    kw.value for kw in node.keywords if kw.arg not in {"style", *TYPER_TEXT_KWARGS}
+                violations += [
+                    f"{_rel(path)}:{node.lineno}: {v}" for v in _violates_d(node, docstrings)
                 ]
-                for arg in args:
-                    if id(arg) in docstrings:
-                        continue
-                    if _literal_markup(arg):
-                        violations.append(f"{_rel(path)}:{node.lineno}: {name}(...)")
         assert not violations, _report(
             violations,
             "Wrap in styled('<template>', ...) — or Text.from_markup('...') "
@@ -350,20 +674,89 @@ class TestRuleENoTextThroughBuiltinPrint:
         for path in _python_files():
             tree = ast.parse(path.read_text(encoding="utf-8"))
             for node in ast.walk(tree):
-                # A bare Name callee is the builtin; ``console.print`` is an
-                # Attribute and is governed by rules A and D instead.
-                if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
-                    continue
-                if node.func.id != "print":
-                    continue
-                for arg in node.args:
-                    if isinstance(arg, ast.Call) and _callee(arg) in SAFE_WRAPPERS:
-                        violations.append(f"{_rel(path)}:{node.lineno}: print({_callee(arg)}(...))")
+                violations += [f"{_rel(path)}:{node.lineno}: {v}" for v in _violates_e(node)]
         assert not violations, _report(
             violations,
             "The builtin print() renders a Text as its plain form, dropping "
             "styling and any text rich parsed as a tag. Pass a plain string, "
             "or print through a console built by make_console().",
+        )
+
+
+class TestRuleFNoTextInsideAnFString:
+    """An f-string renders a ``Text`` as its plain form, discarding styling.
+
+    This is the defect with the worst track record in this change: it shipped
+    four separate times. Twice it destroyed data rather than styling -- a
+    ``[workspace-instructions]`` stderr prefix vanished because rich had
+    already parsed it as a tag, and a plugin listing's ✓/⚠ marker lost the
+    colour that distinguishes the two states.
+
+    Rule E is this same defect narrowed to the builtin ``print``. This is the
+    general form: any ``Text``-bearing name interpolated into an f-string.
+    """
+
+    def test_no_text_value_is_interpolated_into_an_f_string(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            if _is_factory(path):
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            scopes = _scope_names(tree, _maybe_text_names)
+            for node in ast.walk(tree):
+                violations += [
+                    f"{_rel(path)}:{node.lineno}: {v}"
+                    for v in _violates_f(node, _names_for(scopes, node))
+                ]
+        assert not violations, _report(
+            violations,
+            "An f-string renders a Text as its plain form, dropping its "
+            "styling. Use styled('{}{}', ...) or join(...) instead.",
+        )
+
+
+class TestRuleGTyperHelpIsEscaped:
+    """Typer help is markup-parsed too, by typer's own rich console.
+
+    The console convention does not reach it, so it was documented as being
+    "outside" the rules -- and the four ``help=`` strings describing the
+    registry reference syntax silently lost ``[@registry][@version]``, because
+    ``@`` leads a tag rich deletes. That syntax appears nowhere else in
+    ``--help``, so the flag was documented as not existing.
+    """
+
+    def test_typer_help_has_no_unescaped_markup(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                violations += [f"{_rel(path)}:{node.lineno}: {v}" for v in _violates_g(node)]
+        assert not violations, _report(
+            violations,
+            "typer renders help through rich, so escape brackets as \\[ ... ] "
+            "or the token is parsed as a style tag.",
+        )
+
+
+class TestRuleHEscapeIsNotUsed:
+    """``rich.markup.escape`` is a convention the guard now actually enforces.
+
+    It was listed as a rule while nothing checked it — the doc promised more
+    than it delivered. It is banned because it is not byte-exact: the parser
+    treats ``\\[`` as an escaped bracket, so an ordinary regex round-trips
+    wrong whether or not it was escaped first.
+    """
+
+    def test_rich_markup_escape_is_never_used(self) -> None:
+        violations: list[str] = []
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                violations += [f"{_rel(path)}:{node.lineno}: {v}" for v in _violates_h(node)]
+        assert not violations, _report(
+            violations,
+            "escape() is not byte-exact. Build a Text (styled(...) / "
+            "Text.from_markup(...)) so the parser is never involved.",
         )
 
 
@@ -377,38 +770,39 @@ class TestTheGuardsActuallyDetectViolations:
 
     @staticmethod
     def _violations_in(source: str, rule: str) -> list[str]:
+        """Run one enforced rule over a snippet.
+
+        Calls the same predicate the source scan uses, so a control cannot
+        pass while the rule it controls has drifted.
+        """
         tree = ast.parse(source)
         docstrings = _docstring_ids(tree)
+        safe_scopes = _scope_names(tree, _safe_text_names)
+        maybe_scopes = _scope_names(tree, _maybe_text_names)
         found: list[str] = []
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            name = _callee(node)
-            if rule == "A" and name == "Console":
-                if not any(
-                    kw.arg == "markup"
-                    and isinstance(kw.value, ast.Constant)
-                    and kw.value.value is False
-                    for kw in node.keywords
-                ):
-                    found.append(f"line {node.lineno}")
-            elif rule == "B" and name == "Panel":
-                for kw in node.keywords:
-                    if kw.arg in {"title", "subtitle"} and _is_dynamic(kw.value):
-                        found.append(f"line {node.lineno}")
-            elif rule == "C" and name == "from_markup":
-                if node.args and _is_dynamic(node.args[0]):
-                    found.append(f"line {node.lineno}")
-            elif rule == "D" and name in PRINT_SINKS | HELPER_SINKS | CELL_SINKS:
-                if isinstance(node.func, ast.Name) and node.func.id == "print":
-                    continue
-                for arg in list(node.args) + [k.value for k in node.keywords if k.arg != "style"]:
-                    if id(arg) not in docstrings and _literal_markup(arg):
-                        found.append(f"line {node.lineno}")
-            elif rule == "E" and isinstance(node.func, ast.Name) and node.func.id == "print":
-                for arg in node.args:
-                    if isinstance(arg, ast.Call) and _callee(arg) in SAFE_WRAPPERS:
-                        found.append(f"line {node.lineno}")
+            if rule == "A":
+                found += _violates_a(node)
+            elif rule == "B":
+                found += _violates_b_panel(node, _names_for(safe_scopes, node))
+            elif rule == "B-prompt":
+                found += _violates_b_prompt(node, _names_for(safe_scopes, node))
+            elif rule == "C":
+                found += _violates_c(node, _names_for(safe_scopes, node))
+            elif rule == "D":
+                found += _violates_d(node, docstrings)
+            elif rule == "E":
+                found += _violates_e(node)
+            elif rule == "F":
+                found += _violates_f(node, _names_for(maybe_scopes, node))
+            elif rule == "G":
+                found += _violates_g(node)
+            elif rule == "A-subclass":
+                found += _violates_a_subclass(node)
+            elif rule == "H":
+                found += _violates_h(node)
+            else:  # pragma: no cover - guard against a typo in a new control
+                raise AssertionError(f"unknown rule {rule!r}")
         return found
 
     def test_rule_a_flags_a_bare_console(self) -> None:
@@ -429,6 +823,20 @@ class TestTheGuardsActuallyDetectViolations:
     def test_rule_b_accepts_a_constant_title(self) -> None:
         """Conductor's own literal title is parsed as intended."""
         assert not self._violations_in('Panel(body, title="[cyan]Plan[/cyan]")', "B")
+
+    def test_rule_b_prompt_flags_an_interpolated_prompt(self) -> None:
+        assert self._violations_in('Prompt.ask(f"[bold]{name}[/bold]")', "B-prompt")
+
+    def test_rule_b_prompt_accepts_styled(self) -> None:
+        assert not self._violations_in('Prompt.ask(styled("[bold]{}[/bold]", name))', "B-prompt")
+
+    def test_rule_b_prompt_accepts_a_text_annotated_parameter(self) -> None:
+        src = "def f(prompt: Text) -> None:\n    Prompt.ask(prompt)\n"
+        assert not self._violations_in(src, "B-prompt")
+
+    def test_rule_b_prompt_flags_a_str_annotated_parameter(self) -> None:
+        src = "def f(prompt: str) -> None:\n    Prompt.ask(prompt)\n"
+        assert self._violations_in(src, "B-prompt")
 
     def test_rule_c_flags_an_f_string(self) -> None:
         assert self._violations_in('Text.from_markup(f"[b]{x}[/b]")', "C")
@@ -489,6 +897,109 @@ class TestTheGuardsActuallyDetectViolations:
     def test_rule_e_accepts_safe_sites(self, snippet: str) -> None:
         assert not self._violations_in(snippet, "E")
 
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            # The exact shape that shipped four times.
+            'm = Text.from_markup("[y]x[/y]") if flag else ""\ntable.add_row(f"{name}{m}")',
+            'm = styled("[y]{}[/y]", v)\nconsole.print(f"{m} done")',
+            "console.print(f\"{styled('[y]{}[/y]', v)} done\")",
+            'def f(t: Text) -> str:\n    return f"<{t}>"',
+        ],
+    )
+    def test_rule_f_flags_a_text_in_an_f_string(self, snippet: str) -> None:
+        assert self._violations_in(snippet, "F")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            'console.print(f"{name} done")',
+            'console.print(styled("{}{}", name, marker))',
+            'm = ", ".join(names)\nconsole.print(f"{m} done")',
+            # ``!r`` is a deliberate repr, not an accidental flatten.
+            'def f(t: Text) -> str:\n    return f"{t!r}"',
+        ],
+    )
+    def test_rule_f_accepts_safe_sites(self, snippet: str) -> None:
+        assert not self._violations_in(snippet, "F")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            'typer.Argument(help="ref (name[@registry])")',
+            'typer.Option(help="see [docs] for detail")',
+            'typer.Typer(epilog="run [cmd] first")',
+        ],
+    )
+    def test_rule_g_flags_unescaped_typer_help(self, snippet: str) -> None:
+        assert self._violations_in(snippet, "G")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            r'typer.Argument(help=r"ref (name\[@registry])")',
+            'typer.Argument(help="ref (name)")',
+            'typer.Option(help="uppercase [KPI] renders literally")',
+            'console.print("[dim]not a typer call[/dim]")',
+        ],
+    )
+    def test_rule_g_accepts_safe_typer_help(self, snippet: str) -> None:
+        assert not self._violations_in(snippet, "G")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "class Bad(Console):\n    pass\n",
+            "class Bad(rich.console.Console):\n    pass\n",
+        ],
+    )
+    def test_rule_a_subclass_flags_a_console_subclass(self, snippet: str) -> None:
+        assert self._violations_in(snippet, "A-subclass")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "class Fine(MarkupFreeConsole):\n    pass\n",
+            "class Fine:\n    pass\n",
+        ],
+    )
+    def test_rule_a_subclass_accepts_the_safe_base(self, snippet: str) -> None:
+        assert not self._violations_in(snippet, "A-subclass")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "from rich.markup import escape",
+            "from rich.markup import escape, render",
+            "x = markup.escape(value)",
+        ],
+    )
+    def test_rule_h_flags_escape(self, snippet: str) -> None:
+        assert self._violations_in(snippet, "H")
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "import re\nx = re.escape(value)",
+            "from rich.markup import render",
+            'x = styled("[b]{}[/b]", value)',
+        ],
+    )
+    def test_rule_h_accepts_safe_sites(self, snippet: str) -> None:
+        assert not self._violations_in(snippet, "H")
+
+    def test_rule_f_does_not_leak_names_across_functions(self) -> None:
+        """A ``Text`` name in one function must not clear another's local.
+
+        ``verbose_log(message: str | Text)`` would otherwise make ``message``
+        Text-bearing for all of ``cli/run.py``.
+        """
+        src = (
+            "def a(message: str | Text) -> None:\n    pass\n\n"
+            'def b(message: str) -> str:\n    return f"{message}"\n'
+        )
+        assert not self._violations_in(src, "F")
+
 
 class TestSafeNameResolution:
     """``_safe_text_names`` must resolve narrowly, or rule B goes blind.
@@ -496,19 +1007,37 @@ class TestSafeNameResolution:
     It exists so a real ``Text``-typed local is not pushed onto an allowlist.
     If it over-accepts, every bare name becomes invisible to rule B and the
     guard silently stops working.
+
+    Resolved through ``_scope_names``/``_names_for`` — the same path the rules
+    take — so these assert what a rule would actually see at that call site,
+    not what the resolver returns for a whole module.
     """
+
+    @staticmethod
+    def _names_at_the_prompt(source: str) -> frozenset[str]:
+        """The names visible where ``Prompt.ask(...)`` is called."""
+        tree = ast.parse(source)
+        scopes = _scope_names(tree, _safe_text_names)
+        call = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "ask"
+        )
+        return _names_for(scopes, call)
 
     def test_text_annotated_parameter_is_safe(self) -> None:
         src = "def f(prompt: Text) -> None:\n    Prompt.ask(prompt)\n"
-        assert "prompt" in _safe_text_names(ast.parse(src))
+        assert "prompt" in self._names_at_the_prompt(src)
 
     def test_optional_text_parameter_is_safe(self) -> None:
         src = "def f(prompt: Text | None = None) -> None:\n    Prompt.ask(prompt)\n"
-        assert "prompt" in _safe_text_names(ast.parse(src))
+        assert "prompt" in self._names_at_the_prompt(src)
 
     def test_local_assigned_from_styled_is_safe(self) -> None:
         src = 'def f():\n    p = styled("[b]x[/b]")\n    Prompt.ask(p)\n'
-        assert "p" in _safe_text_names(ast.parse(src))
+        assert "p" in self._names_at_the_prompt(src)
 
     def test_conditional_between_safe_values_is_safe(self) -> None:
         src = (
@@ -516,23 +1045,23 @@ class TestSafeNameResolution:
             '    p = styled("[b]x[/b]") if prompt is None else prompt\n'
             "    Prompt.ask(p)\n"
         )
-        assert "p" in _safe_text_names(ast.parse(src))
+        assert "p" in self._names_at_the_prompt(src)
 
     def test_str_annotated_parameter_is_not_safe(self) -> None:
         src = "def f(prompt: str) -> None:\n    Prompt.ask(prompt)\n"
-        assert "prompt" not in _safe_text_names(ast.parse(src))
+        assert "prompt" not in self._names_at_the_prompt(src)
 
     def test_unannotated_parameter_is_not_safe(self) -> None:
         src = "def f(prompt):\n    Prompt.ask(prompt)\n"
-        assert "prompt" not in _safe_text_names(ast.parse(src))
+        assert "prompt" not in self._names_at_the_prompt(src)
 
     def test_local_assigned_from_an_f_string_is_not_safe(self) -> None:
         src = 'def f(x):\n    p = f"[b]{x}[/b]"\n    Prompt.ask(p)\n'
-        assert "p" not in _safe_text_names(ast.parse(src))
+        assert "p" not in self._names_at_the_prompt(src)
 
     def test_conditional_with_one_unsafe_branch_is_not_safe(self) -> None:
         src = 'def f(x, flag):\n    p = styled("[b]y[/b]") if flag else x\n    Prompt.ask(p)\n'
-        assert "p" not in _safe_text_names(ast.parse(src))
+        assert "p" not in self._names_at_the_prompt(src)
 
     def test_rule_b_still_flags_an_unresolvable_name(self) -> None:
         """The end-to-end consequence of the two cases above."""

--- a/tests/test_cli/test_markup_injection.py
+++ b/tests/test_cli/test_markup_injection.py
@@ -17,16 +17,43 @@ the one that ships unnoticed.
 
 from __future__ import annotations
 
+import importlib
+import io
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
 
 from conductor.cli.app import app
+from conductor.console import make_console
+
+# ``conductor.cli.app`` binds a Typer named ``app`` at module scope, so a
+# plain ``import conductor.cli.app as _app_module`` resolves to the Typer
+# rather than the module. Same trap documented in test_doctor.py.
+_app_module = importlib.import_module("conductor.cli.app")
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _fixed_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Render at a fixed width regardless of the developer's terminal.
+
+    These tests assert that a bracketed value survives *rendering*, so a
+    narrow terminal wrapping a table cell reports a markup regression that did
+    not happen. ``tests/test_cli/test_doctor.py`` pins the app consoles for
+    the same reason; pinning ``COLUMNS`` covers the commands that build their
+    own console too.
+    """
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setenv("CONDUCTOR_NO_UPDATE_CHECK", "1")
+    # The CLI's consoles are module-level, so they take their width at import
+    # time and ``COLUMNS`` alone does not reach them.
+    monkeypatch.setattr(_app_module, "output_console", make_console(width=200))
+    monkeypatch.setattr(_app_module, "console", make_console(stderr=True, width=200))
+
 
 # ``/``-leading tokens raise MarkupError; the rest are silently deleted.
 CRASHING = "[/etc/x]"
@@ -217,25 +244,32 @@ class TestForEachIterationIdentitySurvives:
 class TestDialogRendersAgentNames:
     """``gates/dialog.py`` builds a Panel title from the same qualified name."""
 
-    @pytest.mark.parametrize("key", ["task1", "/etc/x"])
-    def test_dialog_opening_title_keeps_the_agent_name(self, key: str) -> None:
-        from rich.panel import Panel
+    @pytest.mark.parametrize("key", ["task1", "kpi-7", "#42", "user@host", "/etc/x", "0"])
+    def test_dialog_opening_renders_the_agent_name_in_body_and_title(self, key: str) -> None:
+        """Render for real rather than inspecting a mocked ``Panel``.
 
+        Reading ``str(panel.title)`` off a ``MagicMock`` cannot see this bug: a
+        regressed f-string title is a ``str`` that still *contains* the name,
+        so the assertion holds while the rendered output has the name deleted.
+        Rendering also covers the ``Panel`` body, which carries the same name.
+
+        The name appears twice — once in the "Dialog Mode" body and once as the
+        question panel's title — so ``count >= 2`` is what isolates the title.
+        A plain ``in`` would be satisfied by the body alone.
+        """
         from conductor.config.schema import AgentDef
+        from conductor.console import make_console
         from conductor.gates.dialog import DialogHandler
 
-        console = MagicMock()
-        handler = DialogHandler(console=console)
+        buf = io.StringIO()
+        handler = DialogHandler(console=make_console(file=buf, width=300, no_color=True))
         agent = AgentDef(name=f"review[{key}]", prompt="p")
 
         handler._display_dialog_start(agent, {"out": 1}, "question?")
 
-        titles = [
-            call.args[0].title
-            for call in console.print.call_args_list
-            if call.args and isinstance(call.args[0], Panel) and call.args[0].title is not None
-        ]
-        assert any(f"review[{key}]" in str(title) for title in titles), titles
+        rendered = "".join(buf.getvalue().split())
+        needle = "".join(f"review[{key}]".split())
+        assert rendered.count(needle) >= 2, rendered
 
 
 class TestErrorPanelsRenderExceptionText:
@@ -324,6 +358,22 @@ class TestFetchedPluginMetadataRenders:
         with console.capture() as captured:
             print_error(PluginManifestError(message))
         assert "".join(message.split()) in "".join(captured.get().split())
+
+
+class TestTyperHelpDocumentsRegistrySyntax:
+    """Typer renders help through its own rich console, which parses markup.
+
+    ``[@registry]`` starts with ``@``, so rich read it as a tag and deleted
+    it: every command that accepts a registry reference documented the syntax
+    as plain ``name``, and it appears nowhere else in ``--help``.
+    """
+
+    @pytest.mark.parametrize("command", ["run", "resume", "validate", "show"])
+    def test_registry_reference_syntax_is_visible(self, command: str) -> None:
+        result = runner.invoke(app, [command, "--help"])
+        assert result.exit_code == 0, result.output
+        rendered = "".join(result.output.split())
+        assert "name[@registry][@version]" in rendered
 
 
 class TestGateResponseRendersServerPayloads:

--- a/tests/test_cli/test_markup_injection.py
+++ b/tests/test_cli/test_markup_injection.py
@@ -1,0 +1,344 @@
+"""End-to-end markup safety across the CLI and gates (issue #406).
+
+``tests/test_console.py`` covers the primitives. This file drives the real
+commands and handlers, because the primitives being correct says nothing about
+whether a given call site actually uses them — which is precisely how #387
+fixed ``cli/run.py`` and still left ``title=`` broken in the function it
+changed, and how two commands written the same week reintroduced the pattern.
+
+Every value here is one a user or a fetched third-party repository can supply:
+a workflow ``name:``, a for-each key derived from agent output, a PID file
+stem, a plugin or marketplace name from a cloned checkout.
+
+Both failure modes are asserted throughout. A crash-only suite cannot tell a
+correct fix from one that silently deletes the value, and the silent half is
+the one that ships unnoticed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from conductor.cli.app import app
+
+runner = CliRunner()
+
+# ``/``-leading tokens raise MarkupError; the rest are silently deleted.
+CRASHING = "[/etc/x]"
+DELETED = "[dim]"
+
+
+def _write_workflow(path: Path, name: str) -> Path:
+    path.write_text(
+        "workflow:\n"
+        f'  name: "{name}"\n'
+        '  entry_point: "start"\n'
+        "agents:\n"
+        '  - name: "start"\n'
+        "    type: script\n"
+        '    command: "echo"\n'
+        '    args: ["hi"]\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestValidateRendersWorkflowNames:
+    """The lead repro: ``conductor validate`` died on a bracketed name."""
+
+    @pytest.mark.parametrize("name", [f"probe {CRASHING} name", f"probe {DELETED} name"])
+    def test_bracketed_workflow_name_survives(self, tmp_path: Path, name: str) -> None:
+        wf = _write_workflow(tmp_path / "wf.yaml", name)
+        result = runner.invoke(app, ["validate", str(wf)])
+        assert result.exit_code == 0, result.output
+        assert name in result.output
+
+    def test_bracketed_description_survives(self, tmp_path: Path) -> None:
+        wf = tmp_path / "wf.yaml"
+        wf.write_text(
+            "workflow:\n"
+            '  name: "wf"\n'
+            f'  description: "handles {CRASHING} paths"\n'
+            '  entry_point: "start"\n'
+            "agents:\n"
+            '  - name: "start"\n'
+            "    type: script\n"
+            '    command: "echo"\n'
+            '    args: ["hi"]\n',
+            encoding="utf-8",
+        )
+        result = runner.invoke(app, ["validate", str(wf)])
+        assert result.exit_code == 0, result.output
+        assert f"handles {CRASHING} paths" in result.output
+
+    @pytest.mark.parametrize("agent_name", [f"step{CRASHING}", f"step{DELETED}"])
+    def test_bracketed_agent_name_survives_the_agents_table(
+        self, tmp_path: Path, agent_name: str
+    ) -> None:
+        wf = tmp_path / "wf.yaml"
+        wf.write_text(
+            "workflow:\n"
+            '  name: "wf"\n'
+            f'  entry_point: "{agent_name}"\n'
+            "agents:\n"
+            f'  - name: "{agent_name}"\n'
+            "    type: script\n"
+            '    command: "echo"\n'
+            '    args: ["hi"]\n',
+            encoding="utf-8",
+        )
+        result = runner.invoke(app, ["validate", str(wf)])
+        assert result.exit_code == 0, result.output
+        assert agent_name in result.output
+
+
+class TestShowRendersWorkflowNames:
+    """``conductor show`` prints the same fields through ``output_console``."""
+
+    @pytest.mark.parametrize("name", [f"probe {CRASHING} name", f"probe {DELETED} name"])
+    def test_bracketed_workflow_name_survives(self, tmp_path: Path, name: str) -> None:
+        wf = _write_workflow(tmp_path / "wf.yaml", name)
+        result = runner.invoke(app, ["show", str(wf)])
+        assert result.exit_code == 0, result.output
+        assert name in result.output
+
+
+class TestStatusAndStopRenderWorkflowNames:
+    """``conductor status`` (#389) was written against the unfixed pattern.
+
+    The crash mode is unreachable here — the value is a path *stem*, which
+    cannot contain ``/`` — but corruption still damages the name a user reads
+    to pick a port for ``conductor stop``.
+    """
+
+    @pytest.fixture()
+    def pid_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        monkeypatch.setattr("conductor.cli.pid.pid_dir", lambda: runs)
+        return runs
+
+    def _write_pid(self, pid_dir: Path, stem: str) -> None:
+        (pid_dir / f"{stem}-8124.pid").write_text(
+            json.dumps(
+                {
+                    "pid": 610745,
+                    "port": 8124,
+                    "workflow": f"/tmp/{stem}.yaml",
+                    "url": "http://127.0.0.1:8124",
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "run_id": "a1b2c3d4",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_status_shows_the_whole_workflow_name(self, pid_dir: Path) -> None:
+        self._write_pid(pid_dir, f"report {DELETED} run")
+        with patch("conductor.cli.pid._is_process_alive", return_value=True):
+            result = runner.invoke(app, ["status"])
+        assert result.exit_code == 0, result.output
+        assert f"report {DELETED} run" in result.output
+
+    def test_stop_listing_shows_the_whole_workflow_name(self, pid_dir: Path) -> None:
+        self._write_pid(pid_dir, f"report {DELETED} run")
+        self._write_pid(pid_dir, "other")
+        with patch("conductor.cli.pid._is_process_alive", return_value=True):
+            result = runner.invoke(app, ["stop"])
+        assert f"report {DELETED} run" in result.output
+
+
+class TestForEachIterationIdentitySurvives:
+    """``verbose_log_section``'s panel title — corrupted on every run today.
+
+    The engine rewrites a for-each member's name to ``<agent>[<key>]`` so
+    interleaved verbose output can be attributed to one iteration. A key from
+    ``key_by:`` is agent-derived, so a lowercase key erased exactly the
+    identity the qualified name exists to carry, and a ``/`` key killed the run
+    from a logging call. ``is_verbose()``/``is_full()`` both default true, so
+    this is a plain ``conductor run``.
+    """
+
+    KEYS = ["0", "task1", "kpi-7", "docs/a.md", "/etc/x", "#42", "user@host"]
+
+    @pytest.mark.parametrize("key", KEYS)
+    def test_console_panel_title_keeps_the_key(self, key: str) -> None:
+        from conductor.cli import run as run_module
+
+        title = f"Prompt for 'review[{key}]'"
+        with (
+            patch("conductor.cli.app.is_verbose", return_value=True),
+            patch("conductor.cli.app.is_full", return_value=True),
+            run_module._verbose_console.capture() as captured,
+        ):
+            run_module.verbose_log_section(title, "body")
+        assert "".join(title.split()) in "".join(captured.get().split())
+
+    @pytest.mark.parametrize("key", KEYS)
+    def test_file_panel_title_keeps_the_key(self, tmp_path: Path, key: str) -> None:
+        """The file sink has no verbosity gate, so it is live on ``--log-file``."""
+        from conductor.cli import run as run_module
+
+        log = tmp_path / "run.log"
+        title = f"Prompt for 'review[{key}]'"
+        try:
+            run_module.init_file_logging(log)
+            with (
+                patch("conductor.cli.app.is_verbose", return_value=False),
+                patch("conductor.cli.app.is_full", return_value=False),
+            ):
+                run_module.verbose_log_section(title, "body")
+        finally:
+            run_module.close_file_logging()
+        written = "".join(log.read_text(encoding="utf-8").split())
+        assert "".join(title.split()) in written
+
+    def test_every_iteration_renders_a_distinct_title(self) -> None:
+        """The regression in one assertion: all titles used to read the same."""
+        from conductor.cli import run as run_module
+
+        rendered = []
+        for key in ["task1", "task2", "task3"]:
+            with (
+                patch("conductor.cli.app.is_verbose", return_value=True),
+                patch("conductor.cli.app.is_full", return_value=True),
+                run_module._verbose_console.capture() as captured,
+            ):
+                run_module.verbose_log_section(f"Prompt for 'review[{key}]'", "body")
+            rendered.append("".join(captured.get().split()))
+        assert len(set(rendered)) == 3
+
+
+class TestDialogRendersAgentNames:
+    """``gates/dialog.py`` builds a Panel title from the same qualified name."""
+
+    @pytest.mark.parametrize("key", ["task1", "/etc/x"])
+    def test_dialog_opening_title_keeps_the_agent_name(self, key: str) -> None:
+        from rich.panel import Panel
+
+        from conductor.config.schema import AgentDef
+        from conductor.gates.dialog import DialogHandler
+
+        console = MagicMock()
+        handler = DialogHandler(console=console)
+        agent = AgentDef(name=f"review[{key}]", prompt="p")
+
+        handler._display_dialog_start(agent, {"out": 1}, "question?")
+
+        titles = [
+            call.args[0].title
+            for call in console.print.call_args_list
+            if call.args and isinstance(call.args[0], Panel) and call.args[0].title is not None
+        ]
+        assert any(f"review[{key}]" in str(title) for title in titles), titles
+
+
+class TestErrorPanelsRenderExceptionText:
+    """``print_error`` titles and bodies carry arbitrary exception text."""
+
+    @pytest.mark.parametrize("message", [f"cannot read {CRASHING}", f"cannot read {DELETED}"])
+    def test_exception_message_survives(self, message: str) -> None:
+        from conductor.cli.app import console, print_error
+
+        with console.capture() as captured:
+            print_error(RuntimeError(message))
+        assert "".join(message.split()) in "".join(captured.get().split())
+
+    def test_error_type_survives_in_the_title(self) -> None:
+        """``error_type`` defaults to the class name, which is the title."""
+        from conductor.cli.app import console, print_error
+        from conductor.exceptions import ConductorError
+
+        class Weird(ConductorError):
+            @property
+            def error_type(self) -> str:
+                return f"Weird{CRASHING}Type"
+
+        with console.capture() as captured:
+            print_error(Weird("boom"))
+        assert f"Weird{CRASHING}Type" in "".join(captured.get().split())
+
+
+class TestFetchedPluginMetadataRenders:
+    """#398 made these strings third-party rather than the author's own YAML.
+
+    ``conductor plugin list`` and ``conductor validate`` render plugin,
+    marketplace, skill and subagent names read out of a cloned repository.
+    """
+
+    @pytest.mark.parametrize("marker", [CRASHING, DELETED])
+    def test_plugin_path_survives_the_report(self, tmp_path: Path, marker: str) -> None:
+        """The plugin *root* is rendered, and a path can contain brackets.
+
+        The plugin *name* cannot — it is charset-validated against
+        ``[A-Za-z0-9_.-]+`` because it is joined into the CLI's
+        delimiter-separated tool list — so the path and the MCP server name
+        are the reachable surfaces here.
+        """
+        root = tmp_path / f"plug{marker}"
+        (root / ".claude-plugin").mkdir(parents=True)
+        (root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "acme", "description": "d", "version": "1.0.0"}),
+            encoding="utf-8",
+        )
+        (root / "agents").mkdir()
+        (root / "agents" / "review.agent.md").write_text(
+            "---\nname: review\ndescription: reviews things\n---\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+        wf = tmp_path / "wf.yaml"
+        wf.write_text(
+            "workflow:\n"
+            '  name: "wf"\n'
+            '  entry_point: "start"\n'
+            "  runtime:\n"
+            "    provider: copilot\n"
+            f'    plugins: ["{root}"]\n'
+            "agents:\n"
+            '  - name: "start"\n'
+            '    prompt: "hi"\n'
+            "    output:\n"
+            "      answer:\n"
+            "        type: string\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["validate", str(wf)])
+        assert result.exit_code == 0, result.output
+        rendered = "".join(result.output.split())
+        assert f"plug{marker}" in rendered
+        assert "acme:review" in rendered
+
+    @pytest.mark.parametrize("message", [f"bad manifest {CRASHING}", f"bad manifest {DELETED}"])
+    def test_plugin_error_text_survives_the_report(self, message: str) -> None:
+        """``str(exc)`` from the plugin layer reaches a markup-parsing sink."""
+        from conductor.cli.app import console, print_error
+        from conductor.plugins.errors import PluginManifestError
+
+        with console.capture() as captured:
+            print_error(PluginManifestError(message))
+        assert "".join(message.split()) in "".join(captured.get().split())
+
+
+class TestGateResponseRendersServerPayloads:
+    """``conductor gate respond`` prints a ``detail`` string from the API."""
+
+    @pytest.mark.parametrize("detail", [f"bad {CRASHING}", f"bad {DELETED}"])
+    def test_server_detail_survives(self, detail: str) -> None:
+        import httpx
+
+        from conductor.cli.gate import console
+
+        response = httpx.Response(409, json={"error": detail})
+        with patch("httpx.post", return_value=response), console.capture() as captured:
+            result = runner.invoke(
+                app, ["gate", "respond", "--port", "8080", "--choice", "ok", "--agent", "a"]
+            )
+        assert result.exit_code == 1
+        assert detail in captured.get()

--- a/tests/test_cli/test_markup_safety.py
+++ b/tests/test_cli/test_markup_safety.py
@@ -30,6 +30,7 @@ from unittest.mock import patch
 import pytest
 from rich.console import Console
 from rich.panel import Panel
+from rich.text import Text
 
 from conductor.cli import run as run_module
 
@@ -136,24 +137,31 @@ class TestFileConsoleRendersAgentTextSafely:
         assert "".join(MARKUP_TRIGGERS[0].split()) in written
 
 
-class TestConsoleSinkEscapesAgentText:
-    """The verbose console sink keeps markup for conductor's own styling, so
-    agent text must be escaped rather than the console de-featured."""
+class TestConsoleSinkRendersAgentTextSafely:
+    """The verbose console sink.
 
-    def test_escaped_content_does_not_raise_with_markup_enabled(self) -> None:
-        from rich.markup import escape
+    When #382 was fixed this console still parsed markup for conductor's own
+    ``[cyan]`` title, so the content had to be wrapped at the call site. Issue
+    #406 inverted that default — ``_verbose_console`` is now markup-free like
+    the file console — but the call-site wrapper is still what the tests here
+    pin, because it is what keeps the panel *body* exact.
+    """
 
+    def test_wrapped_content_does_not_raise_with_markup_enabled(self) -> None:
+        """The old mechanism, kept as the isolating case.
+
+        A ``Text`` is safe even on a console that still parses markup, so this
+        fails if the call-site wrapper is dropped on the assumption that
+        ``markup=False`` alone now covers it — which is true for the body but
+        not for a ``Panel`` title.
+        """
         buf = io.StringIO()
         console = _plain_console(buf, markup=True)
         for content in MARKUP_TRIGGERS:
-            console.print(Panel(escape(content), title="[cyan]Prompt[/cyan]", border_style="dim"))
+            console.print(Panel(Text(content), title=Text("Prompt"), border_style="dim"))
 
-    def test_verbose_section_escapes_before_rendering(self) -> None:
+    def test_verbose_section_renders_agent_text_intact(self) -> None:
         """Drive the real console path and assert it does not raise.
-
-        Without the ``Text`` wrapper at the call site this raises
-        ``MarkupError``, because ``_verbose_console`` deliberately keeps
-        ``markup=True`` for the ``[cyan]`` title.
 
         Deliberately no ``init_file_logging`` here. Pulling the file sink in
         costs the isolating signal: reverting ``markup=False`` alone would kill
@@ -232,9 +240,10 @@ class TestEveryVerboseSinkIsSafe:
 class TestExperimentalBannerIsNotMarkupInTheLog:
     """The banner prints one Panel to both consoles.
 
-    ``_file_console`` has ``markup=False``, so a markup-bearing string writes
-    its tags out literally -- a readability regression in the log file that no
-    existing test could observe, because they swap the console for a MagicMock.
+    Both are markup-free (the file console since #382, the verbose console
+    since #406), so a markup-bearing string writes its tags out literally --
+    a readability regression in the log file that no existing test could
+    observe, because they swap the console for a MagicMock.
     """
 
     def test_banner_is_styled_not_tagged_in_the_file_log(self, tmp_path: Path) -> None:

--- a/tests/test_cli/test_run.py
+++ b/tests/test_cli/test_run.py
@@ -817,7 +817,7 @@ class TestDryRunDisplayFunctions:
         from conductor.cli.run import format_routes
 
         routes = [{"to": "next_agent", "when": None, "is_conditional": False}]
-        result = format_routes(routes)
+        result = format_routes(routes).plain
         assert "next_agent" in result
         assert "if" not in result.lower()
 
@@ -826,7 +826,7 @@ class TestDryRunDisplayFunctions:
         from conductor.cli.run import format_routes
 
         routes = [{"to": "next_agent", "when": "output.success", "is_conditional": True}]
-        result = format_routes(routes)
+        result = format_routes(routes).plain
         assert "next_agent" in result
         assert "if" in result.lower()
 

--- a/tests/test_config/test_instructions.py
+++ b/tests/test_config/test_instructions.py
@@ -1403,7 +1403,10 @@ class TestEmitLoadedInstructionsDebug:
 
         _emit_loaded_instructions_debug(tmp_path, enabled=True)
         captured = capsys.readouterr()
-        assert "1 file(s) discovered from CWD" in captured.err
+        # Includes the prefix: it is a grep label users search for in a
+        # merged stderr stream, and asserting only the tail let it be
+        # silently deleted by a markup parser (#406).
+        assert "[workspace-instructions] 1 file(s) discovered from CWD" in captured.err
         assert "AGENTS.md" in captured.err
         # stdout invariant preserved
         assert captured.out == ""
@@ -1425,7 +1428,7 @@ class TestPrintLoadedInstructionsHelper:
         captured = capsys.readouterr()
         # stdout MUST stay clean (don't pollute JSON output)
         assert captured.out == ""
-        assert "0 files discovered" in captured.err
+        assert "[workspace-instructions] 0 files discovered" in captured.err
 
     def test_emits_populated_state_with_scope(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1459,7 +1462,7 @@ class TestPrintLoadedInstructionsHelper:
         captured = capsys.readouterr()
 
         # Header tracks count
-        assert "3 file(s) discovered from CWD" in captured.err
+        assert "[workspace-instructions] 3 file(s) discovered from CWD" in captured.err
         # All three paths emitted
         assert "AGENTS.md" in captured.err
         assert "cs.md" in captured.err

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -24,7 +24,7 @@ from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 from rich.text import Text
 
-from conductor.console import make_console, styled
+from conductor.console import join, make_console, styled
 
 # Values that a workflow, an agent name, a plugin manifest or an exception
 # string can genuinely contain. Split by failure mode, because they fail
@@ -195,6 +195,38 @@ class TestFormatSyntax:
             styled("a\x00b{}c", "X")
 
 
+class TestStyledRefusesRatherThanLosingData:
+    """The paths where silently doing something reasonable would lose styling."""
+
+    def test_format_spec_on_a_text_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="format spec or conversion"):
+            styled("[dim]{:>10}[/dim]", styled("[green]x[/green]"))
+
+    def test_conversion_on_a_text_is_refused(self) -> None:
+        """``!s`` would call ``str()`` on it, flattening the styling away."""
+        with pytest.raises(ValueError, match="format spec or conversion"):
+            styled("{!s}", styled("[green]x[/green]"))
+
+    def test_a_field_inside_a_tag_is_a_clear_error(self) -> None:
+        """The parser eats the placeholder, so the value has nowhere to land.
+
+        The bare ``'\x00' is not in list`` named an internal detail and told
+        the reader nothing about which template caused it.
+        """
+        with pytest.raises(ValueError, match="field inside a markup tag"):
+            styled("[link={}]docs[/link]", "https://example.com")
+
+    def test_dotted_and_indexed_fields_resolve(self) -> None:
+        """``get_field`` rather than hand-rolled resolution."""
+
+        class Agent:
+            name = "review[/x]"
+
+        assert render(styled("{a.name} {d[0]}", a=Agent(), d=["first[/y]"])) == (
+            "review[/x] first[/y]"
+        )
+
+
 class TestTextIsNotFlattenedByCallers:
     """``str(Text)`` is its plain form, so an f-string discards the styling.
 
@@ -287,9 +319,57 @@ class TestTextValuesAreSpliced:
         b = styled("[red]B[/red]")
         assert render_ansi(styled("{} {}", a, b)) == "\x1b[32mA\x1b[0m \x1b[31mB\x1b[0m"
 
+    def test_a_text_with_a_base_style_keeps_it(self) -> None:
+        """The ``value.style`` branch — a ``Text`` styled at construction.
+
+        Every ``Text`` conductor passes today carries its styling in spans
+        rather than a base style, so without this the branch that re-anchors
+        the base style is never exercised.
+        """
+        assert render_ansi(styled("<{}>", Text("x", style="green"))) == "<\x1b[32mx\x1b[0m>"
+
+    def test_a_base_style_does_not_override_an_inner_span(self) -> None:
+        fragment = Text("ab", style="green")
+        fragment.stylize("bold", 0, 1)
+        assert render_ansi(styled("{}", fragment)) == "\x1b[1;32ma\x1b[0m\x1b[32mb\x1b[0m"
+
     def test_mixed_text_and_plain_values(self) -> None:
         check = styled("[green]✓[/green]")
         assert render(styled("{} {} {}", check, "x[/y]", 3)) == "✓ x[/y] 3"
+
+
+class TestJoin:
+    """``join`` is what carries the mixed ``content_lines`` lists.
+
+    ``Text.join`` requires every part to already be a ``Text``, but the shape
+    in ``gates/`` is a list holding some conductor-styled fragments and some
+    plain runtime values. Untested, a regression to ``"\n".join(str(x))``
+    passes the whole suite while flattening every styled fragment.
+    """
+
+    def test_plain_parts_stay_literal(self) -> None:
+        assert render(join("\n", ["[dim]", "[/etc/x]"])) == "[dim]\n[/etc/x]"
+
+    def test_text_parts_keep_their_styling(self) -> None:
+        out = render_ansi(join(" ", [styled("[green]a[/green]"), "b[/c]"]))
+        assert out == "\x1b[32ma\x1b[0m b[/c]"
+
+    def test_a_plain_separator_stays_literal(self) -> None:
+        assert render(join("[dim]", ["a", "b"])) == "a[dim]b"
+
+    def test_a_text_separator_keeps_its_styling(self) -> None:
+        out = render_ansi(join(styled("[red]|[/red]"), ["a", "b"]))
+        assert out == "a\x1b[31m|\x1b[0mb"
+
+    def test_empty_iterable_is_empty(self) -> None:
+        assert render(join("\n", [])) == ""
+
+    def test_single_part_has_no_separator(self) -> None:
+        assert render(join(", ", ["only[/x]"])) == "only[/x]"
+
+    @pytest.mark.parametrize("value", CRASHING_VALUES + DELETED_VALUES)
+    def test_dangerous_values_survive(self, value: str) -> None:
+        assert value in render(join(" ", ["before", value, "after"]))
 
 
 class TestMakeConsole:
@@ -344,8 +424,65 @@ class TestMakeConsole:
         assert "[/etc/p]" in buf.getvalue()
 
     def test_markup_cannot_be_re_enabled(self) -> None:
-        with pytest.raises(TypeError, match="does not accept 'markup'"):
+        with pytest.raises(TypeError, match="markup is not overridable"):
             make_console(markup=True)
+
+    def test_markup_cannot_be_re_enabled_per_call(self) -> None:
+        """The per-call kwarg reopens both original failure modes.
+
+        Rich lets ``print(..., markup=True)`` override the instance setting, so
+        without this refusal one call site restores the silent deletion and the
+        MarkupError. It is also the obvious-looking fix for the visible
+        ``[green]`` that forgetting ``styled`` now produces, which is exactly
+        why it has to be refused rather than documented against.
+        """
+        console = make_console(file=io.StringIO())
+        with pytest.raises(TypeError, match="markup is not overridable"):
+            console.print("plugin [task1] name", markup=True)
+        with pytest.raises(TypeError, match="markup is not overridable"):
+            console.log("plugin [task1] name", markup=True)
+
+    def test_a_redundant_markup_false_is_tolerated(self) -> None:
+        """Only a *truthy* markup is refused.
+
+        ``Console.input`` forwards ``markup=`` to ``print`` unconditionally,
+        so refusing the kwarg's mere presence breaks every prompt that passes
+        ``console=``. A redundant ``markup=False`` restates the guarantee.
+        """
+        buf = io.StringIO()
+        make_console(file=buf, width=200, no_color=True).print("x [/etc/p] y", markup=False)
+        assert "[/etc/p]" in buf.getvalue()
+
+    def test_prompt_works_when_given_this_console(self) -> None:
+        """``Prompt.ask(console=...)`` goes through ``Console.input``."""
+        from rich.prompt import Prompt
+
+        console = make_console(file=io.StringIO(), width=200, no_color=True)
+        answer = Prompt.ask(
+            styled("[bold]Enter {}[/bold]", "a[/etc/x]"),
+            console=console,
+            stream=io.StringIO("value\n"),
+        )
+        assert answer == "value"
+
+    def test_prompt_text_is_not_parsed_when_given_this_console(self) -> None:
+        buf = io.StringIO()
+        console = make_console(file=buf, width=200, no_color=True)
+        Prompt.ask(Text("name [/etc/x]"), console=console, stream=io.StringIO("v\n"))
+        assert "[/etc/x]" in buf.getvalue()
+
+    def test_log_still_forwards_when_markup_is_not_passed(self) -> None:
+        """The override must guard the kwarg without breaking the method."""
+        buf = io.StringIO()
+        make_console(file=buf, width=200, no_color=True).log("keep [dim] this")
+        assert "keep [dim] this" in buf.getvalue()
+
+    def test_subclasses_inherit_the_refusal(self) -> None:
+        """The rule lives on the class, so a subclass cannot bypass it."""
+        from conductor.cli.run import _SilentAwareConsole
+
+        with pytest.raises(TypeError, match="markup is not overridable"):
+            _SilentAwareConsole(markup=True)
 
     def test_other_console_options_are_forwarded(self) -> None:
         console = make_console(stderr=True, width=123, no_color=True)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,416 @@
+"""Tests for the markup-safe console primitives (issue #406).
+
+``styled`` exists so that conductor's own styling and interpolated runtime
+data cannot be confused for one another. The properties that matter are:
+
+* a value is reproduced **byte for byte**, whatever brackets it contains
+* the template's styling still applies, including where a style spans a
+  placeholder or where tags nest around one
+
+Both halves need assertions. A suite that only checks "does not raise" cannot
+tell a correct fix from one that silently deletes the value, which is exactly
+the quiet failure mode of an opening tag like ``[dim]``.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+from rich.errors import MarkupError
+from rich.panel import Panel
+from rich.prompt import Confirm, IntPrompt, Prompt
+from rich.table import Table
+from rich.text import Text
+
+from conductor.console import make_console, styled
+
+# Values that a workflow, an agent name, a plugin manifest or an exception
+# string can genuinely contain. Split by failure mode, because they fail
+# differently and a fix can address one without the other.
+CRASHING_VALUES = [
+    "[/bold]",
+    "[/]",
+    "[/etc/x]",
+    "docs/[/a].md",
+    "probe [/bold] name",
+    "Permission format: {provider}/{type}[/{nestedType}...]/read",
+]
+
+DELETED_VALUES = [
+    "[dim]",
+    "[task1]",
+    "[#42]",
+    "[user@example.com]",
+    "config [section] then [other]",
+]
+
+# Rendered literally by rich even without the fix. Kept so a regression that
+# only handles the dangerous shapes is still visibly wrong for the safe ones.
+SAFE_VALUES = ["[0]", "[KPI_3]", "plain", ""]
+
+ALL_VALUES = CRASHING_VALUES + DELETED_VALUES + SAFE_VALUES
+
+
+def render(renderable: object, *, width: int = 400) -> str:
+    """Render on a markup-free console and return the plain text."""
+    buf = io.StringIO()
+    make_console(file=buf, width=width, no_color=True, highlight=False).print(renderable)
+    return buf.getvalue().rstrip("\n")
+
+
+def render_ansi(renderable: object) -> str:
+    """Render with colour so styling can be asserted."""
+    buf = io.StringIO()
+    make_console(
+        file=buf, width=400, force_terminal=True, color_system="truecolor", highlight=False
+    ).print(renderable)
+    return buf.getvalue().rstrip("\n")
+
+
+class TestTheseValuesAreRealTriggers:
+    """Negative controls: without the fix these genuinely misbehave.
+
+    Without them the parametrised cases below could pass vacuously against a
+    corpus of harmless strings.
+    """
+
+    @pytest.mark.parametrize("value", CRASHING_VALUES)
+    def test_crashing_values_raise_when_parsed_as_markup(self, value: str) -> None:
+        buf = io.StringIO()
+        with pytest.raises(MarkupError):
+            Console(file=buf, markup=True).print(f"Name: {value}")
+
+    @pytest.mark.parametrize("value", DELETED_VALUES)
+    def test_deleted_values_lose_text_when_parsed_as_markup(self, value: str) -> None:
+        buf = io.StringIO()
+        Console(file=buf, width=400, markup=True, highlight=False).print(f"Name: {value}")
+        assert value not in buf.getvalue(), "sample does not exercise tag-eating"
+
+
+class TestValuesAreByteExact:
+    """The core contract."""
+
+    @pytest.mark.parametrize("value", ALL_VALUES)
+    def test_value_survives_interpolation(self, value: str) -> None:
+        assert render(styled("Name: [green]{}[/green] done", value)) == f"Name: {value} done"
+
+    @pytest.mark.parametrize("value", ALL_VALUES)
+    def test_value_survives_without_surrounding_markup(self, value: str) -> None:
+        assert render(styled("Name: {}", value)) == f"Name: {value}"
+
+    def test_backslash_before_bracket_is_preserved(self) -> None:
+        """``escape()`` cannot do this, which is why it is not used.
+
+        The parser treats ``\\[`` as an escaped bracket, so a regex round
+        trips through ``escape`` + markup parsing as ``[0-9\\]+``.
+        """
+        from rich.markup import escape
+
+        value = r"\[0-9\]+"
+        assert render(styled("{}", value)) == value
+
+        buf = io.StringIO()
+        Console(file=buf, width=400, markup=True, highlight=False).print(escape(value))
+        assert buf.getvalue().rstrip("\n") != value, "escape() is unexpectedly byte-exact now"
+
+    def test_value_containing_the_filler_character_is_preserved(self) -> None:
+        assert render(styled("a{}b", "\x00mid\x00")) == "a\x00mid\x00b"
+
+    def test_non_string_values_are_formatted_then_inserted(self) -> None:
+        assert render(styled("{} and {}", 42, None)) == "42 and None"
+
+
+class TestTemplateStylingStillApplies:
+    """The other half: disabling markup must not disable conductor's styling."""
+
+    def test_literal_only_template_is_styled(self) -> None:
+        assert render_ansi(styled("[green]ok[/green]")) == "\x1b[32mok\x1b[0m"
+
+    def test_style_spans_the_placeholder(self) -> None:
+        assert render_ansi(styled("[green]{}[/green]", "payload")) == "\x1b[32mpayload\x1b[0m"
+
+    def test_nested_tags_around_the_placeholder(self) -> None:
+        """Inheriting only ``spans[0]`` would collapse this to one style."""
+        assert render_ansi(styled("[bold][red]{}[/red][/bold]", "v")) == "\x1b[1;31mv\x1b[0m"
+
+    def test_style_boundaries_are_not_shifted_by_a_longer_value(self) -> None:
+        out = render_ansi(styled("[bold]a [red]{}[/red] b[/bold]", "wide-value"))
+        assert out == "\x1b[1ma \x1b[0m\x1b[1;31mwide-value\x1b[0m\x1b[1m b\x1b[0m"
+
+    def test_empty_value_does_not_shift_later_styles(self) -> None:
+        assert render_ansi(styled("[green]{}[/green]|[red]{}[/red]", "", "b")) == (
+            "|\x1b[31mb\x1b[0m"
+        )
+
+    def test_dangerous_value_does_not_disturb_surrounding_styles(self) -> None:
+        out = render_ansi(styled("[bold]a[/bold] {} [green]b[/green]", "[/etc/x]"))
+        assert out == "\x1b[1ma\x1b[0m [/etc/x] \x1b[32mb\x1b[0m"
+
+
+class TestFormatSyntax:
+    """``styled`` uses ``str.format`` field syntax, so the usual forms work."""
+
+    def test_auto_numbered_fields(self) -> None:
+        assert render(styled("{} / {}", "a[/b]", "c[d]")) == "a[/b] / c[d]"
+
+    def test_explicit_positional_fields(self) -> None:
+        assert render(styled("{1} {0}", "a", "b")) == "b a"
+
+    def test_named_fields(self) -> None:
+        assert render(styled("{n}", n="[/x]")) == "[/x]"
+
+    def test_format_spec(self) -> None:
+        assert render(styled("{:.2f}s", 1.239)) == "1.24s"
+
+    def test_conversion(self) -> None:
+        assert render(styled("{!r}", "q[/z]")) == "'q[/z]'"
+
+    def test_literal_braces(self) -> None:
+        assert render(styled("set {{a}} to {v}", v="[/x]")) == "set {a} to [/x]"
+
+    def test_missing_positional_field_raises(self) -> None:
+        with pytest.raises(IndexError):
+            styled("{} {}", "only-one")
+
+    def test_missing_named_field_raises(self) -> None:
+        with pytest.raises(KeyError):
+            styled("{missing}")
+
+    def test_malformed_template_raises(self) -> None:
+        """A malformed *template* is a conductor bug and should be loud."""
+        with pytest.raises(MarkupError):
+            styled("[/bold] {}", "value")
+
+    def test_filler_character_in_the_template_is_rejected(self) -> None:
+        """The placeholder machinery reserves NUL.
+
+        A NUL in the template's own literal text would capture the search that
+        locates each value and shift every later one, so it is refused rather
+        than silently mis-rendered. Values stay unrestricted — see
+        ``test_value_containing_the_filler_character_is_preserved``.
+        """
+        with pytest.raises(ValueError, match="NUL"):
+            styled("a\x00b{}c", "X")
+
+
+class TestTextIsNotFlattenedByCallers:
+    """``str(Text)`` is its plain form, so an f-string discards the styling.
+
+    This is not hypothetical: converting call sites to ``styled`` introduced
+    exactly this in three places, where a ``styled(...)`` result was then
+    interpolated into an f-string and lost its colour. Worse, feeding a
+    ``Text`` built from markup to the *builtin* ``print`` drops any text rich
+    parsed as a tag, which silently deleted a ``[workspace-instructions]``
+    log prefix that users grep for.
+    """
+
+    def test_f_string_flattens_a_styled_text(self) -> None:
+        """The trap itself, pinned so the reason the guards exist stays clear."""
+        assert f"{styled('[green]{}[/green]', 'ok')}" == "ok"
+
+    def test_from_markup_deletes_a_lowercase_bracketed_prefix(self) -> None:
+        """Why a plain-text log label must not be routed through markup."""
+        assert Text.from_markup("[workspace-instructions] 0 files").plain == " 0 files"
+
+
+class TestStyledReachesTheSinksThatBypassTheConsole:
+    """``Panel`` titles and prompts parse markup regardless of the console.
+
+    ``rich/panel.py`` and ``rich/prompt.py`` call ``Text.from_markup``
+    unconditionally, so ``markup=False`` never reaches them. These are the
+    sites where an f-string still crashes, so they need their own coverage.
+    """
+
+    @pytest.mark.parametrize("value", CRASHING_VALUES + DELETED_VALUES)
+    def test_panel_title(self, value: str) -> None:
+        title = styled("[cyan]Prompt for '{}'[/cyan]", value)
+        assert f"Prompt for '{value}'" in render(Panel(Text("body"), title=title))
+
+    @pytest.mark.parametrize("value", CRASHING_VALUES + DELETED_VALUES)
+    def test_panel_subtitle(self, value: str) -> None:
+        subtitle = styled("[dim]{}[/dim]", value)
+        assert value in render(Panel(Text("body"), subtitle=subtitle))
+
+    @pytest.mark.parametrize("cls", [Prompt, Confirm, IntPrompt])
+    @pytest.mark.parametrize("value", CRASHING_VALUES + DELETED_VALUES)
+    def test_prompt_text(self, cls: type, value: str) -> None:
+        prompt = cls(styled("[bold]{}[/bold]", value), console=make_console(file=io.StringIO()))
+        assert value in str(prompt.make_prompt(default=...))
+
+    @pytest.mark.parametrize("value", CRASHING_VALUES)
+    def test_f_string_in_a_panel_title_still_crashes(self, value: str) -> None:
+        """The reason these sites need ``styled`` rather than the console flip.
+
+        If a future rich release starts honouring ``markup=False`` here, this
+        test fails and the corresponding guard rule can be relaxed.
+        """
+        with pytest.raises(MarkupError):
+            render(Panel(Text("body"), title=f"[cyan]{value}[/cyan]"))
+
+    @pytest.mark.parametrize("value", DELETED_VALUES)
+    def test_f_string_in_a_panel_title_still_deletes_text(self, value: str) -> None:
+        """The quiet half of the same bypass, which raises nothing at all."""
+        assert value not in render(Panel(Text("body"), title=f"[cyan]{value}[/cyan]"))
+
+
+class TestTextValuesAreSpliced:
+    """A pre-styled fragment keeps its styling when interpolated.
+
+    Without this, composing ``styled("{} {}", CHECK, name)`` would call
+    ``format()`` on the ``Text`` and flatten it to plain characters, silently
+    dropping the colour from every doctor table cell.
+    """
+
+    def test_text_value_keeps_its_style(self) -> None:
+        check = styled("[green]✓[/green]")
+        assert render_ansi(styled("{} ok", check)) == "\x1b[32m✓\x1b[0m ok"
+
+    def test_text_value_and_template_styles_coexist(self) -> None:
+        check = styled("[green]✓[/green]")
+        out = render_ansi(styled("{} [dim]{}[/dim]", check, "note"))
+        assert out == "\x1b[32m✓\x1b[0m \x1b[2mnote\x1b[0m"
+
+    def test_text_value_contents_are_byte_exact(self) -> None:
+        assert render(styled("{}", Text("[/etc/x]"))) == "[/etc/x]"
+
+    def test_text_value_with_internal_spans(self) -> None:
+        fragment = styled("[red]a[/red]b")
+        assert render_ansi(styled("<{}>", fragment)) == "<\x1b[31ma\x1b[0mb>"
+
+    def test_empty_text_value_does_not_shift_later_styles(self) -> None:
+        assert render_ansi(styled("{}[red]{}[/red]", Text(""), "b")) == "\x1b[31mb\x1b[0m"
+
+    def test_multiple_text_values(self) -> None:
+        a = styled("[green]A[/green]")
+        b = styled("[red]B[/red]")
+        assert render_ansi(styled("{} {}", a, b)) == "\x1b[32mA\x1b[0m \x1b[31mB\x1b[0m"
+
+    def test_mixed_text_and_plain_values(self) -> None:
+        check = styled("[green]✓[/green]")
+        assert render(styled("{} {} {}", check, "x[/y]", 3)) == "✓ x[/y] 3"
+
+
+class TestMakeConsole:
+    """The inverted default."""
+
+    def test_plain_strings_are_not_parsed(self) -> None:
+        assert render("literal [/etc/x] text") == "literal [/etc/x] text"
+
+    def test_opening_tags_are_not_deleted(self) -> None:
+        assert render("keep [dim] this") == "keep [dim] this"
+
+    def test_table_cells_are_not_parsed(self) -> None:
+        table = Table(show_header=False, box=None)
+        table.add_column("v")
+        for value in CRASHING_VALUES + DELETED_VALUES:
+            table.add_row(value)
+        rendered = render(table)
+        for value in CRASHING_VALUES + DELETED_VALUES:
+            assert value in rendered
+
+    def test_table_headers_and_titles_are_not_parsed(self) -> None:
+        table = Table(title="t [/etc/x]", caption="c [dim] c")
+        table.add_column("h [/etc/x]")
+        table.add_row("v")
+        rendered = render(table)
+        assert "t [/etc/x]" in rendered
+        assert "h [/etc/x]" in rendered
+        assert "c [dim] c" in rendered
+
+    def test_panel_body_is_not_parsed(self) -> None:
+        assert "[/etc/x]" in render(Panel("body [/etc/x] end"))
+
+    def test_style_kwarg_still_styles(self) -> None:
+        """``style=`` is orthogonal to markup and must keep working."""
+        buf = io.StringIO()
+        make_console(
+            file=buf, width=400, force_terminal=True, color_system="truecolor", highlight=False
+        ).print("x [/etc/x] y", style="bold")
+        out = buf.getvalue()
+        assert "\x1b[1m" in out
+        assert "[/etc/x]" in out
+
+    def test_text_renderables_are_still_styled(self) -> None:
+        text = Text()
+        text.append("green", style="green")
+        assert render_ansi(text) == "\x1b[32mgreen\x1b[0m"
+
+    def test_print_json_is_unaffected(self) -> None:
+        """The ``--silent`` stdout result contract runs through here."""
+        buf = io.StringIO()
+        make_console(file=buf, width=400, no_color=True).print_json('{"a": "x [/etc/p] y"}')
+        assert "[/etc/p]" in buf.getvalue()
+
+    def test_markup_cannot_be_re_enabled(self) -> None:
+        with pytest.raises(TypeError, match="does not accept 'markup'"):
+            make_console(markup=True)
+
+    def test_other_console_options_are_forwarded(self) -> None:
+        console = make_console(stderr=True, width=123, no_color=True)
+        assert console.stderr is True
+        assert console.width == 123
+
+
+class TestHighlightingIsPreserved:
+    """Replacing a markup string with a ``Text`` must not drop rich's colour.
+
+    rich applies its ``ReprHighlighter`` to a plain ``str`` passed to
+    ``print`` but not to a ``Text``. Without compensating, converting call
+    sites to ``styled`` would silently de-colour every number, path and
+    quoted value across the whole CLI — a cosmetic regression bundled into a
+    safety fix, which is exactly what makes a change hard to review.
+    """
+
+    @staticmethod
+    def _ansi(renderable: object, **kwargs: object) -> str:
+        buf = io.StringIO()
+        console = make_console(
+            file=buf, width=400, force_terminal=True, color_system="truecolor", **kwargs
+        )
+        console.print(renderable)
+        return buf.getvalue()
+
+    def test_numbers_in_a_styled_text_are_highlighted(self) -> None:
+        """The concrete regression: ``Total steps: 1`` lost its cyan number."""
+        out = self._ansi(styled("[dim]Total steps:[/dim] {}", 42))
+        assert "\x1b[1;36m42\x1b[0m" in out, out
+
+    def test_conductor_styling_wins_over_the_highlighter(self) -> None:
+        """rich highlights first and copies markup styles on top.
+
+        The number highlighter would colour ``42`` bold cyan; the template's
+        green wins the colour while the highlighter's bold survives — which
+        is exactly what the equivalent markup string produced.
+        """
+        buf = io.StringIO()
+        Console(
+            file=buf, width=400, force_terminal=True, color_system="truecolor", markup=True
+        ).print("[green]42[/green]")
+        assert self._ansi(styled("[green]{}[/green]", "42")) == buf.getvalue()
+
+    def test_highlight_false_console_is_not_highlighted(self) -> None:
+        out = self._ansi(styled("count {}", 42), highlight=False)
+        assert "\x1b[1;36m" not in out
+
+    def test_highlight_false_kwarg_is_honoured(self) -> None:
+        buf = io.StringIO()
+        console = make_console(file=buf, width=400, force_terminal=True, color_system="truecolor")
+        console.print(styled("count {}", 42), highlight=False)
+        assert "\x1b[1;36m" not in buf.getvalue()
+
+    def test_highlighting_does_not_reintroduce_markup_parsing(self) -> None:
+        """The highlighter only adds styles; it must not eat or reject text."""
+        for value in CRASHING_VALUES + DELETED_VALUES:
+            assert value in render(styled("{}", value))
+
+    def test_matches_the_markup_string_it_replaces(self) -> None:
+        """Byte-for-byte parity with the pre-fix rendering path."""
+        buf = io.StringIO()
+        Console(
+            file=buf, width=400, force_terminal=True, color_system="truecolor", markup=True
+        ).print("[dim]Total:[/dim] 1353 checkpoint(s)")
+        before = buf.getvalue()
+        after = self._ansi(styled("[dim]Total:[/dim] {} checkpoint(s)", 1353))
+        assert after == before

--- a/tests/test_gates/test_human.py
+++ b/tests/test_gates/test_human.py
@@ -466,7 +466,7 @@ class TestMaxIterationsHandlerInteractive:
             # Verify Panel was called with iteration info
             mock_panel.assert_called()
             panel_args = mock_panel.call_args
-            panel_content = panel_args[0][0]
+            panel_content = str(panel_args[0][0])
             assert "10/10" in panel_content or "10" in panel_content
 
     @pytest.mark.asyncio
@@ -489,7 +489,7 @@ class TestMaxIterationsHandlerInteractive:
             # Verify Panel was called with agent history
             mock_panel.assert_called()
             panel_args = mock_panel.call_args
-            panel_content = panel_args[0][0]
+            panel_content = str(panel_args[0][0])
             assert "agent" in panel_content.lower()
 
     @pytest.mark.asyncio
@@ -513,7 +513,7 @@ class TestMaxIterationsHandlerInteractive:
             # Verify Panel was called with loop warning
             mock_panel.assert_called()
             panel_args = mock_panel.call_args
-            panel_content = panel_args[0][0]
+            panel_content = str(panel_args[0][0])
             assert "loop" in panel_content.lower()
 
 

--- a/tests/test_interrupt/test_handler.py
+++ b/tests/test_interrupt/test_handler.py
@@ -426,8 +426,14 @@ class TestInterruptHandlerPanel:
         assert "Last Output Preview" not in panel_call.renderable
 
     @pytest.mark.asyncio
-    async def test_panel_escapes_rich_markup_in_output_preview(self) -> None:
-        """Verify Rich markup in output preview is escaped, not rendered."""
+    async def test_panel_shows_rich_markup_in_output_preview_literally(self) -> None:
+        """Verify Rich markup in output preview is shown, not rendered.
+
+        The panel content is a ``Text``, so the preview is carried as literal
+        characters rather than escaped with backslashes (#406). That is
+        byte-exact, where ``escape`` was not: it cannot round-trip a value
+        that already contains a backslash before a bracket.
+        """
         console = MagicMock()
         handler = InterruptHandler(console=console)
 
@@ -447,15 +453,13 @@ class TestInterruptHandlerPanel:
                 break
 
         assert panel_call is not None
-        content = panel_call.renderable
-        # The raw markup tags should be escaped (rendered as literal text)
-        from rich.markup import escape
-
-        assert escape("[red]error[/red]") in content
+        content = panel_call.renderable.plain
+        assert "[red]error[/red] and [bold]text[/bold]" in content
+        assert "\\[red]" not in content, "value should be literal, not backslash-escaped"
 
     @pytest.mark.asyncio
-    async def test_panel_escapes_rich_markup_in_guidance(self) -> None:
-        """Verify Rich markup in accumulated guidance is escaped."""
+    async def test_panel_shows_rich_markup_in_guidance_literally(self) -> None:
+        """Verify Rich markup in accumulated guidance is shown, not rendered."""
         console = MagicMock()
         handler = InterruptHandler(console=console)
 
@@ -475,10 +479,9 @@ class TestInterruptHandlerPanel:
                 break
 
         assert panel_call is not None
-        content = panel_call.renderable
-        from rich.markup import escape
-
-        assert escape("[bold]inject markup[/bold]") in content
+        content = panel_call.renderable.plain
+        assert "[bold]inject markup[/bold]" in content
+        assert "\\[bold]" not in content, "value should be literal, not backslash-escaped"
 
 
 class TestInterruptHandlerActions:


### PR DESCRIPTION
Closes #406.

## The bug

Rich parses `[...]` in a plain `str` as console markup, and Conductor interpolated runtime data — workflow names, agent names, plugin metadata read out of git-cloned repos, `str(e)`, gate payloads — straight into those strings. A bracketed token is a tag when its **first character** is lowercase, `#`, `/` or `@`, so the behaviour splits three ways and only one is loud:

| first char | example | result |
|---|---|---|
| digit / uppercase | `[0]`, `[KPI_3]` | renders literally |
| lowercase, `#`, `@` | `[task1]`, `[#42]` | **silently deleted** |
| `/` | `[/bold]`, `[/etc/x]` | **`MarkupError`, out of the print call** |

The quiet half matters more: a listing that drops part of a name looks like it worked. `style=` does **not** disable parsing.

## What was actually broken

Four sites, all reproduced against `main` before the fix:

1. **`conductor validate` crashed** on `workflow.name: "probe [/bold] name"`, and printed `probe  name` for `[dim]`.
2. **Every for-each iteration's verbose panel read the same.** The engine qualifies a member's name as `<agent>[<key>]` so interleaved output can be attributed to one iteration; `key_by:` keys are agent-derived, so:

   ```
   key='0'         -> Prompt for 'review[0]'   ok
   key='task1'     -> Prompt for 'review'      IDENTITY ERASED
   key='docs/a.md' -> Prompt for 'review'      IDENTITY ERASED
   key='/etc/x'    -> MarkupError              RUN DIES
   ```

   This needed no flags — verbose and full mode both default on. The comment directly above it claimed *"`title` is conductor-controlled, so it keeps its styling"*, which was false.
3. **`conductor status`** (#389) corrupted its listing — the name a user reads to pick a port for `conductor stop`.
4. **`gates/dialog.py`** built a Panel title from the same for-each qualified name. Not in the issue; found while working.

This is the third occurrence. #382 was the original; #387 fixed `cli/run.py` thoroughly and still left `title=` in the very function it changed; #389 and #398 then reintroduced the pattern next door, in files #387 never touched. #398 also made these strings *third-party* rather than the author's own YAML.

## Approach

A per-site escape pass across ~450 literals demonstrably does not hold, so the default is inverted instead.

New leaf module `src/conductor/console.py` — top-level rather than under `cli/`, because `gates/` and `providers/` need it and must not import from `cli/`:

- **`make_console()`** locks `markup=False`. A plain string is now literal unless it asks to be styled, which fixes **119 sites with zero code churn** and covers plain prints, `Panel` bodies, `Table` cells/headers/titles/captions and `Rule` titles. It *rejects* a `markup=` kwarg rather than allowing an override.
- **`styled("<template>", value)`** parses conductor's own template but inserts values verbatim and byte-exact. It replaces each field with a **length-matched filler run**, parses once, then substitutes by offset — matching the width is what keeps the parsed template's spans valid, so nested styling around a placeholder (`[bold][red]{}[/red][/bold]`) is correct. Reading `spans[0].style` instead would collapse it. A value that is already a `Text` splices in with its own spans re-anchored.
- **`join(sep, parts)`** — `Text.join` requires every part to already be a `Text`, but the common shape here is a `content_lines` list mixing styled fragments with plain runtime values.

**`Panel(title=)`/`(subtitle=)` and `Prompt`/`Confirm`/`IntPrompt` are handled separately.** Rich calls `Text.from_markup` on those *unconditionally* (`rich/panel.py:113,129`, `rich/prompt.py:67`), so `markup=False` never reaches them. Measured, not assumed — and it is exactly the trap that left #387 incomplete one line from the code it changed.

**`rich.markup.escape` is dropped everywhere.** It is not byte-exact: the parser treats `\[` as an escaped bracket, so an ordinary regex `\[0-9\]+` renders as `[0-9\]+` whether escaped first or not.

Typer's `help=`/`epilog=` are deliberately left alone — Typer renders those through its own console.

## Rendering is byte-identical to `main`

Verified across ten commands, ANSI codes included. That took one extra step worth calling out: rich applies its `ReprHighlighter` to a plain `str` but **not** to a `Text`, so the conversion would otherwise have silently de-coloured every number, path and quoted value across the whole CLI — a cosmetic regression bundled into a safety fix. `_MarkupFreeConsole.print` re-applies the highlighter in rich's own order (highlight first, conductor's spans copied on top).

## Keeping it fixed

`tests/test_cli/test_markup_guards.py` reads `src/conductor` with `ast` and fails with file:line:

- **A** — every `Console` goes through `make_console` (or explicitly passes `markup=False`)
- **B** — no interpolated string to a `Panel` title/subtitle or a `Prompt`
- **C** — no f-string to `Text.from_markup`
- **D** — no bare markup literal at a print/cell sink (this is what makes the conversion verifiable rather than eyeballed)
- **E** — no Rich `Text` through the *builtin* `print`, which renders its plain form and drops anything rich parsed as a tag

Each rule has negative controls, because a source scan that quietly matches nothing reports "all clear" forever. `_safe_text_names` does small intra-function dataflow so a genuinely `Text`-typed local is not pushed onto an allowlist. I verified the guards **fail** when the original bug is reintroduced.

The convention is written up in **AGENTS.md** (new *Console Output* section under Code Style, plus an architecture entry), not only in code comments.

## Review notes

A code review of this branch caught two regressions I had introduced, both now fixed and both covered by new tests:

- the codemod wrapped a stderr log label in `Text.from_markup`, and because `[workspace-instructions]` starts with a lowercase letter rich **deleted the prefix**. The existing test passed, because it asserted on a substring after it. Rule E exists because of this.
- `f"{mark} ..."` flattened a `Text` and dropped the ✓/⚠ colour from `conductor plugin fetch` — the marker column on a command CI gates on.

One `styled()` hardening also came out of it: a NUL in the *template* is now rejected up front, since it would capture the search that locates each value.

## Validation

- `make check` (ruff lint + format + ty) clean
- **5766 tests pass**, 47 skipped (+88 new)
- 44 example workflows validate
- All four repros verified fixed; conversion audit at zero
- Rendered output byte-identical to `main` across ten commands