### PR TITLE
fix(cli): fold dashboard URL instead of cropping in `conductor status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,15 +245,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`conductor status`'s dashboard URL no longer gets cropped at a default
   80-column terminal** (#405). At that width, the `Dashboard` column — the
   one field the command exists to surface — was the one rich elided,
-  leaving a bare `…` reconstructable only by hand from the `Port` column.
-  `Started` now renders to minute precision in UTC (`2026-08-11 12:48Z`,
-  down from a 32-character microsecond-precision timestamp) rather than
-  being dropped outright, and the `Dashboard` column folds onto a second
-  line instead of cropping — a folded URL is complete and readable, a
-  cropped one is unrecoverable from the output. `conductor status` is
-  unreleased, so the `--json` payload keeps the exact recorded timestamp
-  untouched; only the table's human-readable rendering changed. `_print_running_list`
-  is shared with `conductor stop`, so its listing gets the shorter timestamp
+  leaving `http://127.0.0.1:…` reconstructable only by hand from the `Port`
+  column. Both the `Started` and `Dashboard` columns now fold onto a second
+  line instead of cropping — a folded value is complete and readable, a
+  cropped one is unrecoverable from the output. `Started` also renders to
+  minute precision in UTC (`2026-08-11 12:48Z`, down from a 32-character
+  microsecond-precision timestamp), leaving more room for `Workflow` before
+  folding is ever needed. The table is a glance-at listing, not an audit
+  log, so `--json` keeps reporting the exact recorded timestamp untouched —
+  only the human-readable rendering changed. `_print_running_list` is
+  shared with `conductor stop`, so its listing gets the shorter timestamp
   too. The test fixture that let this through built its own PID-file JSON by
   hand with a 19-character naive `started_at`, well short of production's
   32-character value — it now goes through the real `write_pid_file`, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   file predating this fix is distinguishable from one that legitimately has
   no run id. `conductor status` is unreleased, so the `log_file` →
   `stderr_log`/`stdout_log` rename costs no released contract.
+- **`conductor status`'s dashboard URL no longer gets cropped at a default
+  80-column terminal** (#405). At that width, the `Dashboard` column — the
+  one field the command exists to surface — was the one rich elided,
+  leaving a bare `…` reconstructable only by hand from the `Port` column.
+  `Started` now renders to minute precision in UTC (`2026-08-11 12:48Z`,
+  down from a 32-character microsecond-precision timestamp) rather than
+  being dropped outright, and the `Dashboard` column folds onto a second
+  line instead of cropping — a folded URL is complete and readable, a
+  cropped one is unrecoverable from the output. `conductor status` is
+  unreleased, so the `--json` payload keeps the exact recorded timestamp
+  untouched; only the table's human-readable rendering changed. `_print_running_list`
+  is shared with `conductor stop`, so its listing gets the shorter timestamp
+  too. The test fixture that let this through built its own PID-file JSON by
+  hand with a 19-character naive `started_at`, well short of production's
+  32-character value — it now goes through the real `write_pid_file`, so the
+  widths under test match the widths production writes.
 - **Agent text containing bracketed tokens no longer kills a run** (#382). A
   step whose output contained ordinary technical prose such as
   `{provider}/{type}[/{nestedType}...]/read` was parsed by rich as a closing

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -247,7 +247,7 @@ conductor status [OPTIONS]
 
 It is also read-only on disk: unlike `stop`, it never removes a PID file, so a run stays discoverable even if its liveness cannot be confirmed at that moment.
 
-The dashboard URL is included because there is otherwise no supported way to recover it once the launching terminal is gone.
+The dashboard URL is included because there is otherwise no supported way to recover it once the launching terminal is gone. The table renders `Started` to minute precision in UTC, and the dashboard URL wraps onto a second line rather than being cropped on a narrow terminal. `--json` reports the exact recorded `started_at` value regardless.
 
 ### `--json` Payload
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -309,7 +309,7 @@ conductor stop [OPTIONS]
 | `--force` | Proceed when the run's identity cannot be confirmed (see [Identity and `--force`](#identity-and---force)) |
 | `--json` | Emit a machine-readable result per workflow on stdout instead of prose |
 
-With no options, `conductor stop` lists running background workflows. If exactly one is found, it stops automatically. If multiple are running, it prints the list and asks you to specify `--port`.
+With no options, `conductor stop` lists running background workflows. If exactly one is found, it stops automatically. If multiple are running, it prints the list and asks you to specify `--port`. That listing shares its rendering with `conductor status`, so `Started` is shown at the same minute precision in UTC.
 
 ### Exit Codes
 

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextvars
 import logging
 import os
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any
@@ -1734,6 +1735,33 @@ def _stop_process(entry: dict, con: Console, force: bool = False) -> dict:
     return _result("unconfirmed", "terminate")
 
 
+def _format_started_at(value: object) -> str:
+    """Render a PID file's ``started_at`` for the running-list table.
+
+    ``write_pid_file`` records a full microsecond-precision ISO timestamp
+    (32 characters), which crowds out the ``Dashboard`` column at a default
+    80-column terminal width. This trims it to minute precision in UTC —
+    the table is a glance-at listing, not an audit log; ``--json`` continues
+    to report the exact recorded value untouched.
+
+    Args:
+        value: The raw ``started_at`` value read from the PID file JSON.
+
+    Returns:
+        ``"%Y-%m-%d %H:%MZ"`` in UTC, the raw string unchanged if it cannot
+        be parsed as an ISO timestamp, or ``"?"`` if missing/empty/non-string.
+    """
+    if not isinstance(value, str) or not value:
+        return "?"
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return value
+    # Legacy/naive values were always written via ``datetime.now(UTC)``.
+    parsed = parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+    return parsed.strftime("%Y-%m-%d %H:%MZ")
+
+
 def _print_running_list(entries: list[dict], con: Console, show_url: bool = False) -> None:
     """Print a table of running background workflows.
 
@@ -1743,7 +1771,12 @@ def _print_running_list(entries: list[dict], con: Console, show_url: bool = Fals
         show_url: Append a Dashboard URL column. Defaults to False;
             ``conductor status`` passes True, since discovery is its whole
             purpose and the URL is otherwise unrecoverable once the launching
-            terminal is gone.
+            terminal is gone. That column folds rather than crops (see
+            below), so a long workflow stem plus this column can wrap the
+            row onto two lines rather than lose part of the URL.
+            ``Started`` is rendered to minute precision (``_format_started_at``)
+            regardless of ``show_url`` — ``conductor stop`` shares this
+            function and gets the shorter timestamp too.
     """
     from rich.table import Table
 
@@ -1753,14 +1786,17 @@ def _print_running_list(entries: list[dict], con: Console, show_url: bool = Fals
     table.add_column("Workflow", style="white")
     table.add_column("Started", style="dim")
     if show_url:
-        table.add_column("Dashboard", style="blue")
+        # Folds onto a second line instead of cropping. A cropped URL is
+        # unrecoverable from the output — the one thing this column exists
+        # to surface — whereas a folded one is complete, just wrapped.
+        table.add_column("Dashboard", style="blue", overflow="fold")
 
     for e in entries:
         row = [
             str(e["port"]),
             str(e["pid"]),
             Path(e.get("workflow", "unknown")).stem,
-            e.get("started_at", "?"),
+            _format_started_at(e.get("started_at")),
         ]
         if show_url:
             row.append(f"http://127.0.0.1:{e['port']}")

--- a/src/conductor/cli/app.py
+++ b/src/conductor/cli/app.py
@@ -1749,21 +1749,34 @@ def _format_started_at(value: object) -> str:
 
     Returns:
         ``"%Y-%m-%d %H:%MZ"`` in UTC, the raw string unchanged if it cannot
-        be parsed as an ISO timestamp, or ``"?"`` if missing/empty/non-string.
+        be parsed as an ISO timestamp or normalized to UTC, or ``"?"`` if
+        missing/empty/non-string.
     """
     if not isinstance(value, str) or not value:
         return "?"
     try:
         parsed = datetime.fromisoformat(value)
-    except ValueError:
+        # write_pid_file always writes a tz-aware UTC value; a naive one
+        # implies an externally-written or hand-edited file. Treat it as
+        # UTC rather than guessing the local timezone.
+        parsed = parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+        return parsed.strftime("%Y-%m-%d %H:%MZ")
+    except (ValueError, OverflowError):
+        # ValueError: not a parseable ISO timestamp. OverflowError: parsed
+        # fine but astimezone() pushed a near-datetime.min/max value out of
+        # range. Either way, one malformed entry must not crash the whole
+        # listing (see pid.py's scan_pid_files for the same principle) —
+        # fall back to the raw value rather than raise.
+        logger.warning("Could not render started_at value %r as UTC; showing it as-is", value)
         return value
-    # Legacy/naive values were always written via ``datetime.now(UTC)``.
-    parsed = parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
-    return parsed.strftime("%Y-%m-%d %H:%MZ")
 
 
 def _print_running_list(entries: list[dict], con: Console, show_url: bool = False) -> None:
     """Print a table of running background workflows.
+
+    ``Started`` is rendered to minute precision (``_format_started_at``)
+    regardless of ``show_url`` — ``conductor stop`` shares this function and
+    gets the shorter timestamp too.
 
     Args:
         entries: List of PID-file dicts.
@@ -1774,9 +1787,6 @@ def _print_running_list(entries: list[dict], con: Console, show_url: bool = Fals
             terminal is gone. That column folds rather than crops (see
             below), so a long workflow stem plus this column can wrap the
             row onto two lines rather than lose part of the URL.
-            ``Started`` is rendered to minute precision (``_format_started_at``)
-            regardless of ``show_url`` — ``conductor stop`` shares this
-            function and gets the shorter timestamp too.
     """
     from rich.table import Table
 
@@ -1784,7 +1794,11 @@ def _print_running_list(entries: list[dict], con: Console, show_url: bool = Fals
     table.add_column("Port", style="cyan")
     table.add_column("PID", style="yellow")
     table.add_column("Workflow", style="white")
-    table.add_column("Started", style="dim")
+    # Folds rather than crops: _format_started_at's happy path is a fixed
+    # 17 characters, but its fallback for an unparseable/out-of-range value
+    # returns the raw string unbounded, which could otherwise reproduce the
+    # exact cropping bug this PR fixes for Dashboard, one column over.
+    table.add_column("Started", style="dim", overflow="fold")
     if show_url:
         # Folds onto a second line instead of cropping. A cropped URL is
         # unrecoverable from the output — the one thing this column exists

--- a/tests/test_cli/test_status.py
+++ b/tests/test_cli/test_status.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 import pytest
 from typer.testing import CliRunner
 
-from conductor.cli.app import _format_started_at, app
+from conductor.cli.app import _format_started_at, _print_running_list, app
 
 runner = CliRunner()
 
@@ -369,8 +369,8 @@ class TestStatusFitsAnEightyColumnTerminal:
 
         ``Dashboard`` is the last column, so a folded continuation line has
         only empty cells before it and squashing rejoins the URL
-        contiguously. An ellipsis breaks contiguity, so this assertion fails
-        against today's cropping behaviour.
+        contiguously. An ellipsis breaks contiguity, so this assertion would
+        have failed against the pre-fix cropping behaviour.
         """
         _write_pid(pid_tmpdir, 4242, 53941, "/home/u/workflows/code-review-pipeline.yaml")
 
@@ -405,6 +405,74 @@ class TestStatusFitsAnEightyColumnTerminal:
         assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}Z", result.output)
         assert on_disk not in result.output
 
+    def test_one_malformed_started_at_does_not_hide_a_healthy_run(self, pid_tmpdir: Path) -> None:
+        """A near-``datetime.max`` value raises ``OverflowError`` in
+        ``.astimezone(UTC)``, not ``ValueError`` — a distinct failure mode
+        from an unparseable string. One poisoned entry must not crash the
+        whole listing and hide every other running workflow, matching the
+        "one bad PID file can't cost you the rest" guarantee ``pid.py``'s
+        own malformed-file handling already provides.
+        """
+        _write_pid(pid_tmpdir, 4242, 53941, "/home/u/workflows/code-review-pipeline.yaml")
+        poisoned = pid_tmpdir / "poisoned-9999.pid"
+        poisoned.write_text(
+            json.dumps(
+                {
+                    "pid": 4243,
+                    "port": 9999,
+                    "workflow": "/tmp/poisoned.yaml",
+                    "started_at": "9999-12-31T23:59:59-14:00",
+                    "run_id": "deadbeef",
+                    "stderr_log": "",
+                    "stdout_log": "",
+                }
+            )
+        )
+
+        with patch("conductor.cli.pid._is_process_alive", return_value=True):
+            result = runner.invoke(app, ["status"], env=_NARROW)
+
+        assert result.exit_code == 0
+        assert "http://127.0.0.1:53941" in _squash(result.output)
+
+    def test_an_unfoldable_started_fallback_still_wraps_instead_of_cropping(self) -> None:
+        """``_format_started_at``'s failure fallback returns the raw value
+        unbounded (unlike its fixed-width happy path), which could
+        reintroduce issue #405's cropping in the ``Started`` column instead
+        of ``Dashboard``. ``Started`` must fold too, so a long fallback
+        value wraps rather than gets cropped to an ellipsis.
+
+        Checked directly against the constructed ``Table``, not via
+        end-to-end squashing: with two folding columns on the same row,
+        their wrapped continuation text interleaves and is no longer
+        contiguous once whitespace is stripped, so squashing (which relies
+        on ``Dashboard`` being the only folding, trailing column) cannot
+        distinguish "folded" from "cropped" here. ``_print_running_list``
+        only calls ``con.print(table)``, so a bare recorder standing in for
+        ``con`` is enough to capture it without touching real ``Console``
+        internals.
+        """
+        from rich.table import Table as RichTable
+
+        class _Recorder:
+            def __init__(self) -> None:
+                self.printed: list[object] = []
+
+            def print(self, *args: object, **kwargs: object) -> None:
+                self.printed.extend(args)
+
+        recorder = _Recorder()
+        _print_running_list(
+            [{"port": 53941, "pid": 4242, "workflow": "wf.yaml", "started_at": "bad"}],
+            recorder,  # type: ignore[arg-type]
+            show_url=True,
+        )
+
+        tables = [p for p in recorder.printed if isinstance(p, RichTable)]
+        assert tables, "expected _print_running_list to print a Table"
+        started_column = next(c for c in tables[0].columns if c.header == "Started")
+        assert started_column.overflow == "fold"
+
 
 class TestStartedColumnFormatting:
     """Direct unit tests for ``_format_started_at``'s five input shapes.
@@ -427,6 +495,15 @@ class TestStartedColumnFormatting:
 
     def test_unparseable_value_is_returned_verbatim(self) -> None:
         assert _format_started_at("not-a-timestamp") == "not-a-timestamp"
+
+    def test_out_of_range_after_utc_conversion_is_returned_verbatim(self) -> None:
+        """``fromisoformat`` parses this fine, but converting to UTC pushes
+        it past ``datetime.max`` and ``.astimezone`` raises ``OverflowError``
+        — a distinct failure mode from an unparseable string, and one the
+        ``except ValueError`` alone would not catch.
+        """
+        value = "9999-12-31T23:59:59-14:00"
+        assert _format_started_at(value) == value
 
     def test_none_becomes_a_question_mark(self) -> None:
         assert _format_started_at(None) == "?"

--- a/tests/test_cli/test_status.py
+++ b/tests/test_cli/test_status.py
@@ -15,17 +15,31 @@ launching terminal is gone.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
 
-from conductor.cli.app import app
+from conductor.cli.app import _format_started_at, app
 
 runner = CliRunner()
 
 _RUN_ID = "a1b2c3d4"
+
+_NARROW = {"COLUMNS": "80"}
+"""The default terminal width — the inverse of ``test_help_panels.py``'s ``_WIDE``."""
+
+
+def _squash(text: str) -> str:
+    """Strip whitespace and box-drawing characters so a folded cell rejoins.
+
+    ``Dashboard`` is the last table column, so a folded continuation line has
+    only empty cells before it; squashing makes a wrapped URL contiguous
+    again so it can be searched for as one string.
+    """
+    return re.sub(r"[\s\u2500-\u257f]", "", text)
 
 
 @pytest.fixture()
@@ -46,21 +60,29 @@ def _write_pid(
     stderr_log: str = "/tmp/conductor/conductor-wf-20260303-000000-a1b2c3d4.bg.stderr.log",
     stdout_log: str = "/tmp/conductor/conductor-wf-20260303-000000-a1b2c3d4.bg.stdout.log",
 ) -> Path:
-    name = Path(workflow).stem
-    filepath = pid_dir / f"{name}-{port}.pid"
-    filepath.write_text(
-        json.dumps(
-            {
-                "pid": pid,
-                "port": port,
-                "workflow": workflow,
-                "started_at": "2026-03-03T00:00:00",
-                "run_id": _RUN_ID,
-                "stderr_log": stderr_log,
-                "stdout_log": stdout_log,
-            }
-        )
+    """Write a PID file via the real ``write_pid_file``, not hand-built JSON.
+
+    A hand-built fixture with a 19-character naive ``started_at`` (rather than
+    production's 32-character microsecond-precision value) is what let issue
+    #405 through: the table looked fine against a timestamp shorter than any
+    real run ever produces. Delegating to ``write_pid_file`` means the widths
+    under test are the widths production actually writes. The ``pid_dir``
+    parameter is otherwise unused here, so asserting the returned path's
+    parent against it pins that the ``conductor.cli.pid.pid_dir`` monkeypatch
+    is actually honoured by ``write_pid_file`` (which resolves ``pid_dir()``
+    from module globals at call time).
+    """
+    from conductor.cli.pid import write_pid_file
+
+    filepath = write_pid_file(
+        pid,
+        port,
+        workflow,
+        run_id=_RUN_ID,
+        stderr_log=stderr_log,
+        stdout_log=stdout_log,
     )
+    assert filepath.parent == pid_dir
     return filepath
 
 
@@ -264,21 +286,12 @@ class TestStatusJson:
         ``stderr_log``/``stdout_log`` parameters already defaulted to ``""``
         before this fix; the bug was that the caller never passed real
         values, not that the keys were absent. This must report ``null`` too.
+        Going through ``write_pid_file`` with its defaults pins the real
+        default rather than a hand-transcribed copy of it.
         """
-        filepath = pid_tmpdir / "wf-8080.pid"
-        filepath.write_text(
-            json.dumps(
-                {
-                    "pid": 4242,
-                    "port": 8080,
-                    "workflow": "/tmp/wf.yaml",
-                    "started_at": "2026-03-03T00:00:00",
-                    "run_id": "",
-                    "stderr_log": "",
-                    "stdout_log": "",
-                }
-            )
-        )
+        from conductor.cli.pid import write_pid_file
+
+        write_pid_file(4242, 8080, "/tmp/wf.yaml")
 
         with patch("conductor.cli.pid._is_process_alive", return_value=True):
             result = runner.invoke(app, ["status", "--json"])
@@ -304,6 +317,22 @@ class TestStatusJson:
         result.stdout.encode("ascii")  # must not raise
         assert json.loads(result.stdout)["running"][0]["port"] == 8080
 
+    def test_json_keeps_the_full_recorded_timestamp(self, pid_tmpdir: Path) -> None:
+        """The table's minute-precision ``Started`` must not leak into ``--json``.
+
+        Reads the on-disk PID file directly so this pins the exact recorded
+        value, not a re-derived one.
+        """
+        filepath = _write_pid(pid_tmpdir, 4242, 8080)
+        on_disk = json.loads(filepath.read_text())["started_at"]
+
+        with patch("conductor.cli.pid._is_process_alive", return_value=True):
+            result = runner.invoke(app, ["status", "--json"])
+
+        assert result.exit_code == 0
+        entry = json.loads(result.stdout)["running"][0]
+        assert entry["started_at"] == on_disk
+
 
 class TestStatusSurvivesMalformedFiles:
     """One unusable file must not cost the user every other run."""
@@ -328,3 +357,82 @@ class TestStatusSurvivesMalformedFiles:
             runner.invoke(app, ["status", "--json"])
 
         assert bad.exists()
+
+
+class TestStatusFitsAnEightyColumnTerminal:
+    """Issue #405: the Dashboard column — the field the command exists to
+    surface — was the one that got cropped at a default 80-column terminal.
+    """
+
+    def test_the_dashboard_url_survives_at_eighty_columns(self, pid_tmpdir: Path) -> None:
+        """Production-shaped fixture: a realistic workflow stem and port.
+
+        ``Dashboard`` is the last column, so a folded continuation line has
+        only empty cells before it and squashing rejoins the URL
+        contiguously. An ellipsis breaks contiguity, so this assertion fails
+        against today's cropping behaviour.
+        """
+        _write_pid(pid_tmpdir, 4242, 53941, "/home/u/workflows/code-review-pipeline.yaml")
+
+        with patch("conductor.cli.pid._is_process_alive", return_value=True):
+            result = runner.invoke(app, ["status"], env=_NARROW)
+
+        assert result.exit_code == 0
+        assert "http://127.0.0.1:53941" in _squash(result.output)
+
+    def test_two_runs_both_keep_their_urls_at_eighty_columns(self, pid_tmpdir: Path) -> None:
+        _write_pid(pid_tmpdir, 4242, 53941, "/home/u/workflows/code-review-pipeline.yaml")
+        _write_pid(pid_tmpdir, 4243, 61200, "/home/u/workflows/another-long-workflow-name.yaml")
+
+        with patch("conductor.cli.pid._is_process_alive", return_value=True):
+            result = runner.invoke(app, ["status"], env=_NARROW)
+
+        assert result.exit_code == 0
+        squashed = _squash(result.output)
+        assert "http://127.0.0.1:53941" in squashed
+        assert "http://127.0.0.1:61200" in squashed
+
+    def test_started_is_rendered_to_minute_precision(self, pid_tmpdir: Path) -> None:
+        filepath = _write_pid(
+            pid_tmpdir, 4242, 53941, "/home/u/workflows/code-review-pipeline.yaml"
+        )
+        on_disk = json.loads(filepath.read_text())["started_at"]
+
+        with patch("conductor.cli.pid._is_process_alive", return_value=True):
+            result = runner.invoke(app, ["status"], env=_NARROW)
+
+        assert result.exit_code == 0
+        assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}Z", result.output)
+        assert on_disk not in result.output
+
+
+class TestStartedColumnFormatting:
+    """Direct unit tests for ``_format_started_at``'s five input shapes.
+
+    The realistic fixture used above records ``now()`` and cannot assert a
+    fixed timestamp string, so the exact-string assertions live here instead.
+    """
+
+    def test_microsecond_aware_utc(self) -> None:
+        assert _format_started_at("2026-08-11T12:48:33.123456+00:00") == "2026-08-11 12:48Z"
+
+    def test_legacy_naive_value_is_treated_as_utc(self) -> None:
+        assert _format_started_at("2026-08-11T12:48:33") == "2026-08-11 12:48Z"
+
+    def test_z_suffixed_value(self) -> None:
+        assert _format_started_at("2026-08-11T12:48:33Z") == "2026-08-11 12:48Z"
+
+    def test_non_utc_offset_is_converted_to_utc(self) -> None:
+        assert _format_started_at("2026-08-11T12:48:33-04:00") == "2026-08-11 16:48Z"
+
+    def test_unparseable_value_is_returned_verbatim(self) -> None:
+        assert _format_started_at("not-a-timestamp") == "not-a-timestamp"
+
+    def test_none_becomes_a_question_mark(self) -> None:
+        assert _format_started_at(None) == "?"
+
+    def test_empty_string_becomes_a_question_mark(self) -> None:
+        assert _format_started_at("") == "?"
+
+    def test_non_string_becomes_a_question_mark(self) -> None:
+        assert _format_started_at(12345) == "?"

--- a/tests/test_cli/test_stop.py
+++ b/tests/test_cli/test_stop.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
@@ -164,6 +165,25 @@ class TestStopAutoDetect:
         assert "Multiple background workflows" in result.output
         assert "8080" in result.output
         assert "9090" in result.output
+
+    def test_lists_started_at_minute_precision(self, pid_tmpdir: Path) -> None:
+        """``stop``'s ambiguous listing shares ``_print_running_list`` with
+        ``status``, so it should render ``Started`` at the same minute
+        precision rather than a raw microsecond timestamp.
+        """
+        from conductor.cli.pid import write_pid_file
+
+        pid = os.getpid()
+        first = write_pid_file(pid, 8080, "/tmp/wf1.yaml")
+        write_pid_file(pid, 9090, "/tmp/wf2.yaml")
+        on_disk = json.loads(first.read_text())["started_at"]
+
+        with patch("conductor.cli.pid._is_process_alive", return_value=True):
+            result = runner.invoke(app, ["stop"])
+
+        assert result.exit_code == 1
+        assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}Z", result.output)
+        assert on_disk not in result.output
 
 
 class TestStopProcessGone:


### PR DESCRIPTION
## Summary

At a default 80-column terminal, the `Dashboard` column of `conductor status` (and the running-list table shared with `conductor stop`) was elided by rich to a bare `…` — the one field the command exists to surface, recoverable only by hand from the `Port` column.

## Changes

- Added `_format_started_at` to render `Started` at minute precision in UTC (e.g. `2026-08-11 12:48Z`), down from a 32-character microsecond-precision timestamp.
- Set `overflow="fold"` on the `Dashboard` column so a long URL wraps onto a second line instead of cropping. A folded URL is complete and readable; a cropped one is not.
- `--json` output is untouched — only the human-readable table rendering changed.
- `_print_running_list` is shared with `conductor stop`, so its listing gets the shorter timestamp too.
- Updated `docs/cli-reference.md` and `CHANGELOG.md`.
- Test fixtures now write PID files via the real `write_pid_file` instead of hand-built JSON with a shorter synthetic `started_at` — the shortcut that let this through undetected in the first place.

Closes #405