### PR TITLE
chore(release): cut 0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.27...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.28...HEAD)
+
+## [0.1.28](https://github.com/microsoft/conductor/compare/v0.1.27...v0.1.28) - 2026-08-12
 
 ### Added
 
@@ -464,6 +466,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   three of the five sinks; two of those were reachable on a bare `conductor run`
   with no flags. Opening tags such as `[bold]` were the quieter half of the same
   bug: rich consumed them without raising and the text simply disappeared.
+- **Non-ASCII workflow inputs are shown literally in verbose output**
+  ([#391](https://github.com/microsoft/conductor/pull/391)). The verbose
+  "Workflow Inputs" panel serialised inputs with `json.dumps`' default
+  `ensure_ascii=True`, so a Cyrillic, CJK or emoji input was displayed as
+  `\uXXXX` escapes rather than the text the user typed. Every other JSON
+  display path in the repo already passed `ensure_ascii=False` (#356); this
+  was the last one that did not. Machine-readable JSON *results* are
+  unaffected and still ASCII-escaped, which is what keeps them safe on a
+  legacy Windows console (#342).
 - **Structured `runtime.provider` for `name: claude` no longer drops a
   YAML-declared `api_key`** — the schema accepted `api_key` (alongside
   `base_url` and `auth_token`) but the provider factory silently discarded it,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.27"
+version = "0.1.28"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.27"
+version = "0.1.28"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 0.1.28

Cuts release **0.1.28**. Previous release: **v0.1.27** (2026-08-04).

Bumps `[project].version` in `pyproject.toml`, re-locks `uv.lock`, and finalizes
the `[Unreleased]` changelog section into
[`## [0.1.28]`](https://github.com/microsoft/conductor/compare/v0.1.27...v0.1.28)
with a fresh empty `[Unreleased]` above it.

## Commit audit

All **22** commits in `v0.1.27..main` were audited individually; every one has an
explicit disposition. 21 already carried a changelog entry. One gap was found and
filled:

- `abe55b5` — `fix(cli): show non-ASCII workflow inputs literally in verbose output`
  (#391) shipped with no changelog entry. Added under `### Fixed`, noting that
  machine-readable JSON *results* remain ASCII-escaped (#342) so the two changes
  are not confused.

`b3662fe` (`ci: run the test suite on Windows`, #390) is CI infrastructure, but
the user-visible Windows fixes that rode along with it are already documented
(plugin cache keys, concurrent fetch, `_is_local_path`, registry name validation
and TOML escaping, `conductor doctor`'s Claude CLI probe).

## Changelog summary

**Added** — mid-run guidance for `--web`/`--web-bg` runs (#400); read-only
`conductor status` (#384); git-backed plugin sources (#380); output field
constraints — `enum`, `pattern`, range, length, optional, nullable (#372);
plugins as the unit of opt-in (#378); Copilot-convention plugin manifests;
`type: questions` (#376); opt-in multi-line human-gate text.

**Removed** — `skill_discovery.sources: [plugins]` (#378), superseded by
`runtime.plugins`.

**Fixed** — `--web-bg` reporting false success for workflows that never start
(#410); live provider pricing restored by moving the Copilot SDK floor to
`>=1.0.9` (#386); the bracketed-text/Rich-markup class of crashes and silent
deletions (#382, #406); `conductor stop` killing the run it executes inside
(#399) and not confirming the process stopped; the dashboard context-window bar
reporting cumulative tokens as a false red (#412); `resume --web` showing a
running workflow as stopped; subworkflow expansion sliding the graph (#375);
`name: claude` dropping a YAML-declared `api_key`; ASCII-safe JSON results on a
legacy Windows console (#342); non-ASCII verbose inputs (#391); plus six
Windows-specific fixes surfaced by the new Windows CI job (#385).

## Validation

Run from an isolated release worktree on `origin/main`:

- `make check` — `ruff check`, `ruff format --check`, `ty check` all clean
- `make test` — **6205 passed**, 39 skipped, 8 deselected
- `make validate-examples` — all examples valid (the range touched schema and
  examples via #372, #378, #379, #380)
- `git diff --check` clean; the diff is exactly `CHANGELOG.md`, `pyproject.toml`,
  and `uv.lock` (lockfile change is the project version only)

## After merge

Merging this PR will be followed by pushing the **`v0.1.28`** tag on the merge
commit, which triggers
[`.github/workflows/release.yml`](.github/workflows/release.yml) to build and
publish the GitHub Release with its artifacts. No release is created manually.
