### PR TITLE
fix(aca): harden agent runner transport security

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,9 +477,9 @@ it will pick up the developer's real token (see
   `X-Conductor-Runner-Token` header (compared via the existing
   `web/auth.py::constant_time_match`, reused rather than re-derived) and
   rejects with 401 otherwise — checked *before* the inner Copilot provider
-  is constructed. `/execute` is chosen over `Authorization` because the
-  ACA session gateway consumes that header itself (it carries the AAD
-  token). `GET /health` stays unauthenticated (the image's own
+  is constructed. `X-Conductor-Runner-Token` is chosen over `Authorization`
+  because the ACA session gateway consumes that header itself (it carries
+  the AAD token). `GET /health` stays unauthenticated (the image's own
   `HEALTHCHECK` sends no header) but reports `auth_required` and
   `auth_token_present` — the latter is header *presence* only, never
   validity, so it cannot become a brute-force oracle — letting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,6 +466,47 @@ it will pick up the developer's real token (see
   sandbox session — the same posture `claude_agent_sdk.py` and `hermes.py`
   declare, but for a different underlying reason (remote ephemeral
   filesystem vs. local CLI process state).
+- **Runner hardening (issue #396):** the MVP runner's posture depended
+  entirely on the session-gateway network boundary; five independent,
+  none-load-bearing layers now defend in depth, mirroring
+  `web/auth.py`'s issue #397 framing. (1) `aca_runner/__main__.py` binds
+  `127.0.0.1` by default (the container image's `Dockerfile` sets
+  `ACA_RUNNER_HOST=0.0.0.0` explicitly, so it is unaffected). (2)
+  `aca_runner/auth.py::resolve_runner_token` reads the opt-in
+  `ACA_RUNNER_AUTH_TOKEN`; when set, `/execute` requires a matching
+  `X-Conductor-Runner-Token` header (compared via the existing
+  `web/auth.py::constant_time_match`, reused rather than re-derived) and
+  rejects with 401 otherwise — checked *before* the inner Copilot provider
+  is constructed. `/execute` is chosen over `Authorization` because the
+  ACA session gateway consumes that header itself (it carries the AAD
+  token). `GET /health` stays unauthenticated (the image's own
+  `HEALTHCHECK` sends no header) but reports `auth_required` and
+  `auth_token_present` — the latter is header *presence* only, never
+  validity, so it cannot become a brute-force oracle — letting
+  `AcaRuntimeProvider._warn_on_auth_skew` (alongside the existing
+  `_warn_on_version_skew`, both inside `validate_connection()`'s
+  `contextlib.suppress(Exception)` block) warn when a gateway is silently
+  stripping the header, or when the host has a token configured but the
+  runner doesn't enforce one. (3) `aca_runner/auth.py
+  ::check_inner_provider_settings` rejects any `inner_provider_settings`
+  key outside `ALLOWED_INNER_PROVIDER_SETTINGS_KEYS` (`base_url`/`api_key`/
+  `bearer_token`/`github_token` — the four `AcaRuntimeProvider
+  ._resolve_inner_provider_settings` actually produces), closing off
+  `runtime_url`/`headers` injection that no `base_url` allowlist alone
+  would catch; `ACA_RUNNER_ALLOWED_BASE_URLS` additionally restricts which
+  BYOK `base_url` values are accepted. (4) The runner token header is
+  merged into the `Authorization` headers dict at the three
+  runner-forwarded call sites only (`execute()`, `_send_interrupt()`,
+  `validate_connection()`) — **not** `_stop_session()`, whose `DELETE
+  {endpoint}/session` is an ACA management-plane operation that never
+  reaches the runner, so adding the header there would leak the runner
+  credential to the Azure control plane instead. (5) `identifier` is
+  reconciled by documentation rather than code: it remains gateway
+  routing metadata the runner never inspects as an authentication signal
+  (the runner has no independent source of truth for which identifier it
+  should be serving, and the container `HEALTHCHECK` sends none at all) —
+  see `docs/projects/aca/aca-provider.design.md`'s *Identifier as a
+  capability* bullet and `docs/providers/aca.md#security`.
 
 Full architecture, the runner `/execute`/`/health` contract, the NDJSON
 frame schema, and the credential/security model are documented in

--- a/docker/aca-runner/Dockerfile
+++ b/docker/aca-runner/Dockerfile
@@ -21,6 +21,17 @@
 #   FROM conductor-agent-runner:<tag>
 #   RUN pip install --no-cache-dir my-extra-mcp-server
 #
+# Optional pool-level hardening env vars (issue #396 — none required, the
+# image works unchanged with neither set):
+#   ACA_RUNNER_AUTH_TOKEN         — opt-in transport-token gate on /execute;
+#                                   set the same value on both the pool and
+#                                   the host (COPILOT_PROVIDER_RUNTIME_TOKEN
+#                                   is unrelated — this is the runner's own
+#                                   credential, not the inner Copilot's).
+#   ACA_RUNNER_ALLOWED_BASE_URLS  — comma-separated allowlist restricting
+#                                   which BYOK inner_provider_settings
+#                                   base_url values the runner accepts.
+#
 # `CONDUCTOR_VERSION` is any git ref (tag or commit SHA) accepted by
 # `pip install pkg @ git+https://...@<ref>` that must include the
 # `conductor.aca_runner` module added by epic E4 — pin it explicitly (rather
@@ -109,6 +120,11 @@ RUN pip install --no-cache-dir \
     "conductor-cli @ git+https://github.com/microsoft/conductor.git@${CONDUCTOR_VERSION}"
 
 ARG TARGET_PORT
+# Issue #396: the runner binds loopback (127.0.0.1) by default now — this
+# override is load-bearing here, not redundant, since ACA must reach the
+# port from outside the container's network namespace. The port must never
+# be reachable from anywhere except the session gateway; see
+# docs/providers/aca.md#security.
 ENV ACA_RUNNER_HOST=0.0.0.0
 ENV ACA_RUNNER_PORT=${TARGET_PORT}
 

--- a/docs/projects/aca/aca-provider.design.md
+++ b/docs/projects/aca/aca-provider.design.md
@@ -755,11 +755,22 @@ the architecture; it follows directly from ACA's documented model.
 - **Secret hygiene.** Forwarded credentials are `SecretStr`, redacted in events,
   checkpoints, and the dashboard via existing `ProviderSettings` redaction.
 - **Identifier as a capability.** The `identifier` is the routing/isolation key:
-  cryptographically salted, never guessable, always over HTTPS.
+  cryptographically salted, never guessable, always over HTTPS. It is a
+  gateway routing/isolation key consumed by the ACA session gateway, **not**
+  a caller-authentication signal — the runner deliberately does not inspect
+  it (issue #396). The runner-side authentication control is the optional
+  `ACA_RUNNER_AUTH_TOKEN` transport-token gate on `/execute`, checked via a
+  dedicated `X-Conductor-Runner-Token` header (the `Authorization` header is
+  unavailable for this — the ACA session gateway consumes it itself, since
+  it carries the AAD bearer token).
 - **Attack-surface delta.** New: a host→ACA management call and an in-container HTTP
   server. The *agent's* attack surface moves
   off-host into an ephemeral isolated VM (the point); the new host-side surface
-  must stay minimal and credential-light.
+  must stay minimal and credential-light. Issue #396 hardens that in-container
+  HTTP server so it does not depend *solely* on the session-gateway network
+  boundary: the runner binds loopback by default, optionally gates `/execute`
+  behind a transport token, and rejects any `inner_provider_settings` key
+  outside the four the host actually sends.
 
 ## Risks and Mitigations
 

--- a/docs/providers/aca.md
+++ b/docs/providers/aca.md
@@ -312,16 +312,38 @@ exposes two HTTP endpoints:
 ### `GET /health`
 
 Readiness + version probe, used by `validate_connection()` to detect
-host/runner version skew and by the image's own `HEALTHCHECK`.
+host/runner version skew and by the image's own `HEALTHCHECK`. Deliberately
+unauthenticated (issue #396) — the image's `HEALTHCHECK` sends no header at
+all, so gating this endpoint would break it.
 
 ```json
-{"ready": true, "conductor_version": "0.4.0", "runner_version": "0.1.0"}
+{
+  "ready": true,
+  "conductor_version": "0.4.0",
+  "runner_version": "0.1.0",
+  "auth_required": false,
+  "auth_token_present": false
+}
 ```
+
+- `auth_required` — whether the runner has `ACA_RUNNER_AUTH_TOKEN`
+  configured (the transport-token gate on `/execute` is opt-in — see
+  below).
+- `auth_token_present` — whether *a* `X-Conductor-Runner-Token` header
+  arrived on **this** request, never whether it matched. This is what
+  actually detects a gateway that strips custom headers: the caller already
+  knows whether it sent a header, so this leaks nothing and cannot be used
+  as a brute-force oracle. `validate_connection()` warns when this
+  disagrees with the host's own configured posture in either direction.
 
 ### `POST /execute?identifier=<id>&api-version=<v>`
 
 Runs one agent turn and streams the result back as
-`application/x-ndjson`. Request body:
+`application/x-ndjson`. Optionally gated by an
+`X-Conductor-Runner-Token` header (see [Security](#security)) — a
+missing/incorrect header when `ACA_RUNNER_AUTH_TOKEN` is configured returns
+a `401` with `{"error": {"message": "..."}}` before the inner Copilot
+provider is ever constructed. Request body:
 
 ```json
 {
@@ -364,7 +386,18 @@ Runs one agent turn and streams the result back as
   Copilot capacity) or BYOK custom-routing settings (fallback), resolved
   host-side and delivered in-memory per request. See
   [Inner Copilot Authentication](#inner-copilot-authentication) and the
-  design's Security Considerations.
+  design's Security Considerations. The runner rejects (`400`) any key
+  outside `base_url`/`api_key`/`bearer_token`/`github_token` — the four the
+  host ever sends — and, when `ACA_RUNNER_ALLOWED_BASE_URLS` is configured,
+  any `base_url` not on that allowlist (issue #396).
+- `identifier` (query parameter) — gateway routing metadata **only**. ACA
+  routes by it, auto-allocating a session if none exists yet; it is
+  deliberately never validated as a caller-authentication signal — the
+  runner has no independent source of truth for which identifier it should
+  be serving, and the container's own `HEALTHCHECK` sends none at all. The
+  `X-Conductor-Runner-Token` header above is the actual runner-side
+  authentication control.
+
 
 ## NDJSON Event Frame Schema
 
@@ -703,6 +736,46 @@ lifetime** instead of trying to keep it out entirely:
 See the design's [Security Considerations](../projects/aca/aca-provider.design.md#security-considerations)
 section for the full threat model.
 
+### Runner transport hardening (issue #396)
+
+The MVP runner's posture depended entirely on the assumption that the
+runner port is unreachable except through the ACA session gateway. That
+boundary is now defended in depth, though every added layer is opt-in
+except the two that are pure narrowing (binding loopback, the
+`inner_provider_settings` key allowlist):
+
+- **The runner port must never be reachable outside the session gateway.**
+  This was always the intended posture; issue #396 hardens the runner so
+  it does not depend *solely* on that boundary holding.
+- **Transport credential vs. model credential.** `ACA_RUNNER_AUTH_TOKEN`
+  (below) is a **transport** credential — it authenticates a caller
+  reaching the runner's HTTP endpoints at all. It is a distinct concern
+  from `inner_provider_settings` (the **model** credential, DD4) covered
+  above. Setting `ACA_RUNNER_AUTH_TOKEN` as a pool-level environment
+  variable is *not* an instance of the "never bake a long-lived secret as a
+  pool secret" anti-pattern above — that bullet is about the model
+  credential, which authorizes Copilot inference spend; the transport token
+  only gates reachability of the runner's own HTTP surface.
+- **Opt-in transport-token gate.** Set `ACA_RUNNER_AUTH_TOKEN` to the same
+  value on both the runner pool and the host to require an
+  `X-Conductor-Runner-Token` header on `/execute`. `GET /health` stays
+  unauthenticated (the image's own `HEALTHCHECK` sends no header) but
+  reports `auth_required`/`auth_token_present` so `validate_connection()`
+  can detect a gateway silently stripping the header before you rely on
+  the gate. Not mandatory — the runner works unchanged with this unset.
+- **`inner_provider_settings` key allowlist.** The runner rejects any key
+  outside `base_url`/`api_key`/`bearer_token`/`github_token` (the four the
+  host ever sends), closing off a caller sending e.g. `runtime_url` or
+  `headers` directly at the runner. Set `ACA_RUNNER_ALLOWED_BASE_URLS`
+  (comma-separated) on the pool to additionally restrict which BYOK
+  `base_url` values are accepted.
+- **`identifier` is routing metadata, not authentication.** The runner has
+  no independent source of truth for which identifier it should be
+  serving — Azure allocates/reuses sessions from a warm pool and routes to
+  the container — so `identifier` is deliberately never validated as a
+  caller-authentication signal; the transport-token gate above is the
+  runner-side control for that.
+
 ## Troubleshooting
 
 ### `aca provider requires the azure-identity package`
@@ -752,6 +825,33 @@ available.
 Confirm the identity `DefaultAzureCredential` resolves (`az login`, or the
 appropriate managed-identity / service-principal environment variables) has
 been granted the *Session Executor* role on the pool.
+
+### `aca runner: missing or invalid runner auth token`
+
+The runner has `ACA_RUNNER_AUTH_TOKEN` configured and rejected the
+request's `X-Conductor-Runner-Token` header (missing or not matching).
+Set the same `ACA_RUNNER_AUTH_TOKEN` value on both the host and the runner
+pool, or unset it on the pool if you don't need the transport-token gate.
+
+### `aca runner: unsupported inner_provider_settings key`
+
+The request's `inner_provider_settings` carried a key outside the runner's
+allowlist (`base_url`/`api_key`/`bearer_token`/`github_token`), or a
+`base_url` not on the pool's configured `ACA_RUNNER_ALLOWED_BASE_URLS`. No
+in-repo caller produces an unlisted key — `AcaRuntimeProvider
+._resolve_inner_provider_settings` only ever returns those four — so this
+means either a hand-rolled request or a stale/mismatched host and runner
+version. See [Runner transport hardening](#runner-transport-hardening-issue-396).
+
+### Runner requires an auth token but the header didn't arrive
+
+`validate_connection()` logged a warning that the runner reports
+`auth_required: true` but `auth_token_present: false` on the `/health`
+probe. This means a gateway between the host and the runner is stripping
+the `X-Conductor-Runner-Token` header — every `/execute` call will fail
+with a 401 until that's fixed. If the header provably cannot survive the
+trip, unset `ACA_RUNNER_AUTH_TOKEN` on the runner pool (the gate is opt-in;
+the runner works unchanged without it).
 
 ### A declared MCP server / tool isn't available in the sandbox
 

--- a/src/conductor/aca_runner/__main__.py
+++ b/src/conductor/aca_runner/__main__.py
@@ -17,13 +17,18 @@ from conductor.aca_runner.server import create_app
 def main() -> None:
     """Run the runner's FastAPI app under uvicorn.
 
-    Binds to all interfaces by default (the process runs inside an Azure
-    Container Apps dynamic-sessions custom container, not on a developer's
-    machine). The port must match the custom container pool's configured
-    target port (``<TARGET_PORT>`` in the design's *API Contracts*) —
-    override both via `ACA_RUNNER_HOST` / `ACA_RUNNER_PORT` for local testing.
+    Binds loopback (``127.0.0.1``) by default (issue #396) — the safe
+    default for an ad-hoc local run, since a bare `python -m
+    conductor.aca_runner` should not listen on every interface. The
+    container image (`docker/aca-runner/Dockerfile`) sets
+    ``ACA_RUNNER_HOST=0.0.0.0`` explicitly: ACA must reach the port from
+    outside the container's network namespace, so that override is
+    load-bearing there, not redundant with this default. The port must
+    match the custom container pool's configured target port
+    (``<TARGET_PORT>`` in the design's *API Contracts*) — override both via
+    `ACA_RUNNER_HOST` / `ACA_RUNNER_PORT` for local testing.
     """
-    host = os.environ.get("ACA_RUNNER_HOST", "0.0.0.0")  # noqa: S104 - in-container by design
+    host = os.environ.get("ACA_RUNNER_HOST", "127.0.0.1")
     port = int(os.environ.get("ACA_RUNNER_PORT", "8080"))
     uvicorn.run(create_app(), host=host, port=port, log_level="info")
 

--- a/src/conductor/aca_runner/auth.py
+++ b/src/conductor/aca_runner/auth.py
@@ -1,0 +1,182 @@
+"""Transport-token gate and request-body narrowing for the runner (issue #396).
+
+A small leaf module (stdlib + Pydantic + `conductor.web.auth`), matching the
+repository's convention of single-purpose leaves (`rundir.py`, `console.py`,
+`duration.py`, `web/auth.py`). Keeps `server.py` focused on the wire contract
+while giving this policy a directly unit-testable surface, and lets both the
+runner (`server.py`) and the host provider (`providers/aca.py`) import the
+same header name so the two can never drift.
+
+Five independent hardening layers, none individually load-bearing (mirroring
+`web/auth.py`'s own framing for issue #397):
+
+1. Bind loopback by default (see `aca_runner/__main__.py`) — narrows the
+   attack surface for an ad-hoc local run; the container image sets
+   `ACA_RUNNER_HOST=0.0.0.0` explicitly, so it is unaffected.
+2. An optional transport-token gate on `/execute`, via
+   `RUNNER_TOKEN_HEADER`, opt-in via `ACA_RUNNER_AUTH_TOKEN`. `/health`
+   stays unauthenticated — the image `HEALTHCHECK` sends no header at all.
+3. `/health` reports `auth_required` / `auth_token_present` (presence, never
+   validity) so an operator can detect a gateway that strips custom headers
+   before relying on the gate.
+4. A four-key allowlist on `inner_provider_settings` (`check_inner_provider_settings`)
+   plus an optional `base_url` allowlist (`ACA_RUNNER_ALLOWED_BASE_URLS`).
+5. `identifier` remains gateway routing metadata, not a caller-authentication
+   signal — deliberately not enforced here; see `server.py`'s endpoint
+   docstrings.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from pydantic import SecretStr
+
+from conductor.exceptions import ProviderError
+from conductor.web.auth import constant_time_match
+
+# The one definition of the header name, imported by both the runner
+# (`server.py`) and the host provider (`providers/aca.py`) so the two sides
+# of the transport-token gate can never drift apart.
+RUNNER_TOKEN_HEADER = "X-Conductor-Runner-Token"
+
+# The four `inner_provider_settings` keys `AcaRuntimeProvider
+# ._resolve_inner_provider_settings` actually produces: the BYOK branch
+# returns `base_url`/`api_key`/`bearer_token`, the default branch returns
+# `github_token`. Anything else (`runtime_url`, `headers`, `type`,
+# `wire_api`, `azure`, ...) would let a caller repoint the inner Copilot
+# session at an arbitrary external runtime or inject arbitrary HTTP headers
+# — neither of which any `base_url` allowlist alone would catch.
+ALLOWED_INNER_PROVIDER_SETTINGS_KEYS = frozenset(
+    {"base_url", "api_key", "bearer_token", "github_token"}
+)
+
+
+def _clean_env(name: str) -> str | None:
+    """Read an environment variable, normalizing unset/whitespace-only values to `None`.
+
+    Deliberately duplicated from `providers/aca.py::_clean_env` rather than
+    imported: importing `providers.aca` would drag `httpx`/`azure-identity`
+    into the runner's startup path, which must stay lightweight (it runs
+    in-container, not on the host doing the AAD/httpx work).
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def resolve_runner_token() -> str | None:
+    """Return the configured runner auth token, or `None` when the gate is off.
+
+    Reads `ACA_RUNNER_AUTH_TOKEN` (opt-in — see module docstring). Unset,
+    empty, and whitespace-only values are all treated as "not configured".
+    """
+    return _clean_env("ACA_RUNNER_AUTH_TOKEN")
+
+
+def resolve_allowed_base_urls() -> tuple[str, ...] | None:
+    """Return the configured `base_url` allowlist, or `None` for "no restriction".
+
+    Reads `ACA_RUNNER_ALLOWED_BASE_URLS` as a comma-separated list; each
+    entry is stripped and empty entries are dropped. `None` (the env var
+    unset, or set to only whitespace/commas) means every `base_url` is
+    admitted — this is a narrowing control, not a default-deny one.
+    """
+    raw = os.environ.get("ACA_RUNNER_ALLOWED_BASE_URLS")
+    if raw is None:
+        return None
+    entries = tuple(entry.strip() for entry in raw.split(",") if entry.strip())
+    return entries or None
+
+
+def _unwrap(value: Any) -> Any:
+    """Unwrap a `SecretStr`-wrapped value to plain text for comparison.
+
+    `AcaExecuteRequest._redact_inner_provider_secrets` wraps known credential
+    keys in `SecretStr` before the runner ever sees them; `base_url` is not a
+    secret key, so it always arrives as a plain `str` — but this is applied
+    uniformly so a future secret-key addition here can't be forgotten.
+    """
+    return value.get_secret_value() if isinstance(value, SecretStr) else value
+
+
+def check_inner_provider_settings(
+    settings: dict[str, Any] | None,
+    *,
+    allowed_base_urls: tuple[str, ...] | None,
+) -> None:
+    """Reject any `inner_provider_settings` key/value the host doesn't send.
+
+    Raises `ProviderError` naming the offending key(s) for anything outside
+    `ALLOWED_INNER_PROVIDER_SETTINGS_KEYS` — this is what closes off
+    `runtime_url` (repoint the inner Copilot session at an arbitrary
+    external runtime) and `headers` (inject arbitrary HTTP headers), which
+    no `base_url` allowlist alone would catch. When `allowed_base_urls` is
+    given, a present `base_url` must exactly match one of its entries after
+    stripping a trailing `/` from both sides (so a trailing-slash mismatch
+    isn't a false rejection).
+
+    Args:
+        settings: The request's `inner_provider_settings`, or `None`.
+        allowed_base_urls: The configured allowlist, or `None` for no
+            restriction (see `resolve_allowed_base_urls`).
+
+    Raises:
+        ProviderError: When an unrecognized key is present, or `base_url` is
+            set but not in `allowed_base_urls`.
+    """
+    if not settings:
+        return
+
+    disallowed = sorted(set(settings) - ALLOWED_INNER_PROVIDER_SETTINGS_KEYS)
+    if disallowed:
+        raise ProviderError(
+            f"aca runner: unsupported inner_provider_settings key(s): {', '.join(disallowed)}.",
+            suggestion=(
+                "The runner only accepts "
+                f"{sorted(ALLOWED_INNER_PROVIDER_SETTINGS_KEYS)} in "
+                "inner_provider_settings."
+            ),
+            provider_name="aca",
+            is_retryable=False,
+        )
+
+    if allowed_base_urls is None:
+        return
+    base_url = _unwrap(settings.get("base_url"))
+    if base_url is None:
+        return
+    normalized = base_url.rstrip("/")
+    normalized_allowed = {entry.rstrip("/") for entry in allowed_base_urls}
+    if normalized not in normalized_allowed:
+        raise ProviderError(
+            f"aca runner: base_url {base_url!r} is not in the configured allowlist.",
+            suggestion=("Add the base_url to ACA_RUNNER_ALLOWED_BASE_URLS on the runner pool."),
+            provider_name="aca",
+            is_retryable=False,
+        )
+
+
+def token_gate(presented: str | None, expected: str | None) -> bool:
+    """Return whether `presented` satisfies the runner's transport-token gate.
+
+    When `expected` is `None` (the gate is disabled — `ACA_RUNNER_AUTH_TOKEN`
+    unset), every request passes, preserving the zero-configuration default.
+    Otherwise delegates to `conductor.web.auth.constant_time_match`, which
+    encodes with `surrogatepass` so a non-ASCII presented value cannot raise
+    instead of simply failing the comparison.
+
+    Args:
+        presented: The value of the `X-Conductor-Runner-Token` header, or
+            `None` if absent.
+        expected: The configured token, or `None` if the gate is disabled.
+
+    Returns:
+        `True` when the gate is disabled or `presented` matches `expected`.
+    """
+    if expected is None:
+        return True
+    return constant_time_match(presented, expected)

--- a/src/conductor/aca_runner/auth.py
+++ b/src/conductor/aca_runner/auth.py
@@ -1,11 +1,14 @@
 """Transport-token gate and request-body narrowing for the runner (issue #396).
 
-A small leaf module (stdlib + Pydantic + `conductor.web.auth`), matching the
-repository's convention of single-purpose leaves (`rundir.py`, `console.py`,
-`duration.py`, `web/auth.py`). Keeps `server.py` focused on the wire contract
-while giving this policy a directly unit-testable surface, and lets both the
-runner (`server.py`) and the host provider (`providers/aca.py`) import the
-same header name so the two can never drift.
+A small leaf module (stdlib + Pydantic + `conductor.web.auth` +
+`conductor.providers.aca_protocol`), matching the repository's convention of
+single-purpose leaves (`rundir.py`, `console.py`, `duration.py`,
+`web/auth.py`). Keeps `server.py` focused on the wire contract while giving
+this policy a directly unit-testable surface. `RUNNER_TOKEN_HEADER` itself is
+defined in `aca_protocol.py` (a genuine leaf both sides already import) and
+re-exported here, so the runner (`server.py`) and the host provider
+(`providers/aca.py`) share the same header name without either side dragging
+the other's dependency tree in.
 
 Five independent hardening layers, none individually load-bearing (mirroring
 `web/auth.py`'s own framing for issue #397):
@@ -34,12 +37,17 @@ from typing import Any
 from pydantic import SecretStr
 
 from conductor.exceptions import ProviderError
+from conductor.providers.aca_protocol import RUNNER_TOKEN_HEADER
 from conductor.web.auth import constant_time_match
 
-# The one definition of the header name, imported by both the runner
-# (`server.py`) and the host provider (`providers/aca.py`) so the two sides
-# of the transport-token gate can never drift apart.
-RUNNER_TOKEN_HEADER = "X-Conductor-Runner-Token"
+__all__ = [
+    "RUNNER_TOKEN_HEADER",
+    "ALLOWED_INNER_PROVIDER_SETTINGS_KEYS",
+    "resolve_runner_token",
+    "resolve_allowed_base_urls",
+    "check_inner_provider_settings",
+    "token_gate",
+]
 
 # The four `inner_provider_settings` keys `AcaRuntimeProvider
 # ._resolve_inner_provider_settings` actually produces: the BYOK branch
@@ -97,8 +105,9 @@ def _unwrap(value: Any) -> Any:
 
     `AcaExecuteRequest._redact_inner_provider_secrets` wraps known credential
     keys in `SecretStr` before the runner ever sees them; `base_url` is not a
-    secret key, so it always arrives as a plain `str` — but this is applied
-    uniformly so a future secret-key addition here can't be forgotten.
+    secret key, so it is never wrapped here, but it also arrives typed as
+    `Any` — a caller can send any JSON value, not necessarily a `str` — so
+    this unwrap is applied uniformly rather than assuming the shape.
     """
     return value.get_secret_value() if isinstance(value, SecretStr) else value
 
@@ -144,9 +153,18 @@ def check_inner_provider_settings(
             is_retryable=False,
         )
 
+    base_url = _unwrap(settings.get("base_url"))
+    if base_url is not None and not isinstance(base_url, str):
+        raise ProviderError(
+            f"aca runner: inner_provider_settings.base_url must be a string, "
+            f"got {type(base_url).__name__}.",
+            suggestion="Send base_url as a JSON string, or omit it.",
+            provider_name="aca",
+            is_retryable=False,
+        )
+
     if allowed_base_urls is None:
         return
-    base_url = _unwrap(settings.get("base_url"))
     if base_url is None:
         return
     normalized = base_url.rstrip("/")

--- a/src/conductor/aca_runner/server.py
+++ b/src/conductor/aca_runner/server.py
@@ -453,14 +453,19 @@ def create_app() -> FastAPI:
     ) -> Response:
         """Run one agent turn, streaming NDJSON event frames (E4-T2/T3/T4).
 
-        Gated by the optional transport-token check (issue #396) *before*
-        any request parsing: a missing/incorrect `X-Conductor-Runner-Token`
-        header (when `ACA_RUNNER_AUTH_TOKEN` is configured) returns a plain
-        401 in the same `{"error": {"message": ...}}` envelope
+        Gated by the optional transport-token check (issue #396) before any
+        application-level work: the header is checked first thing in the
+        handler, so a missing/incorrect `X-Conductor-Runner-Token` header
+        (when `ACA_RUNNER_AUTH_TOKEN` is configured) returns a plain 401 in
+        the same `{"error": {"message": ...}}` envelope
         `AcaRuntimeProvider._error_from_response` already parses, and never
-        constructs the inner Copilot provider. `identifier` remains gateway
-        routing metadata only, exactly as on `/health` — never inspected as
-        an authentication signal.
+        runs `_validate_execute_request` or constructs the inner Copilot
+        provider. Note FastAPI validates the `AcaExecuteRequest` body
+        parameter *before* this handler runs, so a malformed body from an
+        unauthenticated caller still returns FastAPI's own 422 rather than a
+        401 — the gate protects execution, not the parser. `identifier`
+        remains gateway routing metadata only, exactly as on `/health` —
+        never inspected as an authentication signal.
 
         Review fix: agent reconstruction (`_build_agent`, via
         `_validate_execute_request`) and the provider-cache lookup both run

--- a/src/conductor/aca_runner/server.py
+++ b/src/conductor/aca_runner/server.py
@@ -33,12 +33,19 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Query, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import SecretStr
 from pydantic import ValidationError as PydanticValidationError
 
 from conductor import __version__ as _conductor_version
+from conductor.aca_runner.auth import (
+    RUNNER_TOKEN_HEADER,
+    check_inner_provider_settings,
+    resolve_allowed_base_urls,
+    resolve_runner_token,
+    token_gate,
+)
 from conductor.config.schema import (
     AgentDef,
     OutputField,
@@ -148,14 +155,17 @@ def _check_stdio_binaries(mcp_servers: dict[str, Any] | None) -> None:
         )
 
 
-def _validate_execute_request(request: AcaExecuteRequest) -> AgentDef:
+def _validate_execute_request(
+    request: AcaExecuteRequest, *, allowed_base_urls: tuple[str, ...] | None
+) -> AgentDef:
     """Pre-flight checks run before the streaming response is opened.
 
     Anything detectable synchronously (unsupported inner provider, a missing
-    stdio binary, an invalid agent payload) is surfaced as a non-2xx JSON
-    response — mirroring ``AcaRuntimeProvider._error_from_response`` on the
-    host side — rather than as a mid-stream ``error`` frame, since none of
-    these failures depend on actually starting the inner SDK call.
+    stdio binary, an invalid agent payload, an out-of-allowlist
+    `inner_provider_settings` key or `base_url` — issue #396) is surfaced as
+    a non-2xx JSON response — mirroring ``AcaRuntimeProvider._error_from_response``
+    on the host side — rather than as a mid-stream ``error`` frame, since
+    none of these failures depend on actually starting the inner SDK call.
 
     Returns the reconstructed `AgentDef` (review fix) so the caller can reuse
     it in `_stream_execute` instead of re-running (and re-risking a
@@ -170,6 +180,9 @@ def _validate_execute_request(request: AcaExecuteRequest) -> AgentDef:
             is_retryable=False,
         )
     _check_stdio_binaries(request.mcp_servers)
+    check_inner_provider_settings(
+        request.inner_provider_settings, allowed_base_urls=allowed_base_urls
+    )
     return _build_agent(request.agent)
 
 
@@ -320,7 +333,7 @@ class _InnerProviderCache:
 
 
 async def _stream_execute(
-    provider: CopilotProvider, agent: AgentDef, request: AcaExecuteRequest
+    provider: CopilotProvider, agent: AgentDef, payload: AcaExecuteRequest
 ) -> AsyncIterator[bytes]:
     """Run the inner `execute()` call, yielding NDJSON frames as they arrive.
 
@@ -345,9 +358,9 @@ async def _stream_execute(
         try:
             output = await provider.execute(
                 agent,
-                request.context,
-                request.rendered_prompt,
-                request.tools,
+                payload.context,
+                payload.rendered_prompt,
+                payload.tools,
                 event_callback=emit,
             )
         except Exception as exc:  # broad: forwarded as an error frame, never swallowed
@@ -378,8 +391,15 @@ def create_app() -> FastAPI:
 
     A factory (rather than a module-level singleton) so tests can construct
     a fresh app per test with `CopilotProvider` monkeypatched beforehand.
+
+    The transport-token gate and `base_url` allowlist (issue #396) are
+    resolved **once at startup**, closing over them for the lifetime of the
+    app — tests that need a different value set/clear the env var via
+    `monkeypatch` before calling `create_app()`.
     """
     provider_cache = _InnerProviderCache()
+    runner_token = resolve_runner_token()
+    allowed_base_urls = resolve_allowed_base_urls()
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
@@ -397,23 +417,50 @@ def create_app() -> FastAPI:
 
     @app.get("/health")
     async def health(
+        http_request: Request,
         identifier: str | None = None,
         api_version: str | None = Query(default=None, alias="api-version"),
     ) -> dict[str, Any]:
-        """Readiness + version probe (E4-T1) for `validate_connection` skew checks."""
+        """Readiness + version probe (E4-T1) for `validate_connection` skew checks.
+
+        Deliberately unauthenticated (issue #396): the image's own
+        `HEALTHCHECK` (`curl -fsS http://localhost:$ACA_RUNNER_PORT/health`)
+        sends no header, so gating this endpoint would break it. Reports
+        `auth_required` (whether the transport-token gate is configured) and
+        `auth_token_present` (whether *a* token header arrived on **this**
+        request — never whether it matched) so `validate_connection()` can
+        warn when the two postures disagree (e.g. a gateway silently
+        stripping the header). `identifier` is gateway routing metadata
+        only — ACA routes by it, auto-allocating a session if none exists —
+        and is never treated as a caller-authentication signal; the
+        transport-token gate on `/execute` is the actual runner-side
+        control.
+        """
         return {
             "ready": True,
             "conductor_version": _conductor_version,
             "runner_version": RUNNER_VERSION,
+            "auth_required": runner_token is not None,
+            "auth_token_present": http_request.headers.get(RUNNER_TOKEN_HEADER) is not None,
         }
 
     @app.post("/execute")
     async def execute_endpoint(
-        request: AcaExecuteRequest,
+        payload: AcaExecuteRequest,
+        http_request: Request,
         identifier: str | None = None,
         api_version: str | None = Query(default=None, alias="api-version"),
     ) -> Response:
         """Run one agent turn, streaming NDJSON event frames (E4-T2/T3/T4).
+
+        Gated by the optional transport-token check (issue #396) *before*
+        any request parsing: a missing/incorrect `X-Conductor-Runner-Token`
+        header (when `ACA_RUNNER_AUTH_TOKEN` is configured) returns a plain
+        401 in the same `{"error": {"message": ...}}` envelope
+        `AcaRuntimeProvider._error_from_response` already parses, and never
+        constructs the inner Copilot provider. `identifier` remains gateway
+        routing metadata only, exactly as on `/health` — never inspected as
+        an authentication signal.
 
         Review fix: agent reconstruction (`_build_agent`, via
         `_validate_execute_request`) and the provider-cache lookup both run
@@ -423,18 +470,25 @@ def create_app() -> FastAPI:
         line and headers are not sent until this block returns successfully,
         so nothing here can corrupt an already-started NDJSON stream.
         """
+        presented = http_request.headers.get(RUNNER_TOKEN_HEADER)
+        if not token_gate(presented, runner_token):
+            return JSONResponse(
+                status_code=401,
+                content={"error": {"message": "aca runner: missing or invalid runner auth token"}},
+            )
+
         try:
-            agent = _validate_execute_request(request)
+            agent = _validate_execute_request(payload, allowed_base_urls=allowed_base_urls)
             provider = await provider_cache.get(
-                mcp_servers=request.mcp_servers,
-                inner_provider_settings=request.inner_provider_settings,
-                tool_output=request.tool_output,
+                mcp_servers=payload.mcp_servers,
+                inner_provider_settings=payload.inner_provider_settings,
+                tool_output=payload.tool_output,
             )
         except (ProviderError, PydanticValidationError) as exc:
             return JSONResponse(status_code=400, content={"error": {"message": str(exc)}})
 
         return StreamingResponse(
-            _stream_execute(provider, agent, request), media_type="application/x-ndjson"
+            _stream_execute(provider, agent, payload), media_type="application/x-ndjson"
         )
 
     return app

--- a/src/conductor/providers/aca.py
+++ b/src/conductor/providers/aca.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from pydantic import SecretStr
 
+from conductor.aca_runner.auth import RUNNER_TOKEN_HEADER
 from conductor.exceptions import ProviderError
 from conductor.providers.aca_protocol import (
     AcaAgentPayload,
@@ -646,6 +647,14 @@ class AcaRuntimeProvider(AgentProvider):
         raw dict/JSON payload passed to ``model_validate``), so redaction
         does not depend solely on every caller using this helper.
 
+        Issue #396: the runner enforces a four-key allowlist on this dict's
+        keys (``aca_runner/auth.py::ALLOWED_INNER_PROVIDER_SETTINGS_KEYS`` —
+        exactly ``base_url``/``api_key``/``bearer_token``/``github_token``),
+        rejecting anything else (e.g. ``runtime_url``, ``headers``) with a
+        401/400. A future key added to this method's returned dict must be
+        added to that allowlist too, or the runner will reject every request
+        that carries it.
+
         Raises:
             ProviderError: when no credential of either kind is configured.
         """
@@ -679,6 +688,34 @@ class AcaRuntimeProvider(AgentProvider):
             provider_name="aca",
             is_retryable=False,
         )
+
+    def _resolve_runner_auth_token(self) -> SecretStr | None:
+        """Read the runner transport-token gate's expected value, if configured.
+
+        Issue #396: `ACA_RUNNER_AUTH_TOKEN` is the host-side half of the
+        opt-in transport-token gate on the runner's `/execute` (and
+        `/interrupt`/`/health`, for skew detection) — the runner-side half
+        reads the same env var via `aca_runner/auth.py::resolve_runner_token`.
+        `None` when unset (the gate is disabled by default — no new
+        configuration is required for existing deployments).
+        """
+        value = _clean_env("ACA_RUNNER_AUTH_TOKEN")
+        return SecretStr(value) if value is not None else None
+
+    def _runner_auth_headers(self) -> dict[str, str]:
+        """Build the `X-Conductor-Runner-Token` header dict, or `{}` when unset.
+
+        Issue #396: merged into the `Authorization` headers dict at the
+        three runner-forwarded call sites (`execute()`, `_send_interrupt()`,
+        `validate_connection()`) — never at `_stop_session()`, which is an
+        ACA *management-plane* operation that never reaches the runner
+        (see its own docstring); adding the header there would leak the
+        runner credential to the Azure control plane instead of the runner.
+        """
+        token = self._resolve_runner_auth_token()
+        if token is None:
+            return {}
+        return {RUNNER_TOKEN_HEADER: token.get_secret_value()}
 
     def _serialize_mcp_servers(self) -> dict[str, Any] | None:
         if not self._mcp_servers:
@@ -888,7 +925,7 @@ class AcaRuntimeProvider(AgentProvider):
         response = await client.post(
             self._build_url("interrupt"),
             params={"identifier": identifier, "api-version": self._api_version},
-            headers={"Authorization": f"Bearer {token}"},
+            headers={"Authorization": f"Bearer {token}", **self._runner_auth_headers()},
             timeout=10.0,
         )
         if response.status_code >= 400:
@@ -907,7 +944,10 @@ class AcaRuntimeProvider(AgentProvider):
         image — it is issued anyway, best-effort, in case that restriction
         is lifted for a future pool SKU, and its result never blocks the
         actual local abort: the caller always cancels its own read loop
-        regardless of whether this call succeeds.
+        regardless of whether this call succeeds. Deliberately does **not**
+        include the runner transport-token header (issue #396) — this
+        request never reaches the runner (it is Azure's own control plane),
+        so adding it would leak the runner credential there instead.
         """
         token = await self._get_access_token()
         client = self._ensure_client()
@@ -1054,7 +1094,7 @@ class AcaRuntimeProvider(AgentProvider):
             token = await self._get_access_token()
             url = self._build_url("execute")
             params = {"identifier": identifier, "api-version": self._api_version}
-            headers = {"Authorization": f"Bearer {token}"}
+            headers = {"Authorization": f"Bearer {token}", **self._runner_auth_headers()}
             body = self._wire_body(request)
 
             try:
@@ -1144,7 +1184,13 @@ class AcaRuntimeProvider(AgentProvider):
         `conductor_version` mismatch between host and runner is logged as a
         warning, never raised — version skew is a compatibility hint, not a
         hard failure (mirrors the "safe degradation" convention of the other
-        best-effort provider hooks in `AgentProvider`).
+        best-effort provider hooks in `AgentProvider`). The runner
+        transport-token header (issue #396) is sent here too — not because
+        `/health` requires it (it never does — see
+        `aca_runner/server.py::health`'s docstring) but so a mismatch
+        between the host's configured token and the runner's own posture
+        surfaces as a `_warn_on_auth_skew` warning rather than only at the
+        first `/execute` call.
         """
         try:
             token = await self._get_access_token()
@@ -1169,7 +1215,7 @@ class AcaRuntimeProvider(AgentProvider):
                     "identifier": self._health_identifier,
                     "api-version": self._api_version,
                 },
-                headers={"Authorization": f"Bearer {token}"},
+                headers={"Authorization": f"Bearer {token}", **self._runner_auth_headers()},
                 timeout=10.0,
             )
         except httpx.HTTPError as exc:
@@ -1182,7 +1228,9 @@ class AcaRuntimeProvider(AgentProvider):
             raise await self._error_from_response(response)
 
         with contextlib.suppress(Exception):
-            self._warn_on_version_skew(response.json())
+            health = response.json()
+            self._warn_on_version_skew(health)
+            self._warn_on_auth_skew(health)
         return True
 
     def _warn_on_version_skew(self, health: dict[str, Any]) -> None:
@@ -1197,6 +1245,51 @@ class AcaRuntimeProvider(AgentProvider):
                 "behavior may differ between host and sandbox.",
                 runner_version,
                 host_version,
+            )
+
+    def _warn_on_auth_skew(self, health: dict[str, Any]) -> None:
+        """Warn when the host's and runner's transport-token postures disagree.
+
+        Issue #396: `/health` reports two runner-side facts —
+        `auth_required` (whether `ACA_RUNNER_AUTH_TOKEN` is configured
+        there) and `auth_token_present` (whether *a* token header arrived on
+        this very request — never whether it matched). Comparing those
+        against whether the host has a token configured catches two
+        distinct real misconfigurations, in either direction:
+
+        - The runner requires a token but none arrived: the header did not
+          survive the trip (e.g. a gateway stripping custom headers), so
+          every `/execute` call will fail with a 401.
+        - The host has a token configured but the runner reports no gate:
+          `ACA_RUNNER_AUTH_TOKEN` isn't set there, so the header is being
+          silently ignored and the gate provides no protection.
+
+        A runner predating these fields omits both keys entirely
+        (`.get(...)` returns `None`, which is falsy), so this degrades
+        silently against an old image rather than warning spuriously.
+        """
+        if not isinstance(health, dict):
+            return
+        auth_required = health.get("auth_required")
+        auth_token_present = health.get("auth_token_present")
+        if auth_required is None or auth_token_present is None:
+            return
+
+        host_has_token = self._resolve_runner_auth_token() is not None
+        if auth_required and not auth_token_present:
+            logger.warning(
+                "aca: runner requires an auth token but none arrived on this "
+                "request; a gateway may be stripping the "
+                "X-Conductor-Runner-Token header, so /execute calls will "
+                "fail with 401. Unset ACA_RUNNER_AUTH_TOKEN on the runner "
+                "pool if the header cannot survive the trip."
+            )
+        elif host_has_token and not auth_required:
+            logger.warning(
+                "aca: ACA_RUNNER_AUTH_TOKEN is configured on the host but the "
+                "runner reports auth_required=false; the token is being "
+                "ignored and the transport-token gate is not actually "
+                "enabled. Set ACA_RUNNER_AUTH_TOKEN on the runner pool too."
             )
 
     async def close(self) -> None:

--- a/src/conductor/providers/aca.py
+++ b/src/conductor/providers/aca.py
@@ -38,9 +38,9 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from pydantic import SecretStr
 
-from conductor.aca_runner.auth import RUNNER_TOKEN_HEADER
 from conductor.exceptions import ProviderError
 from conductor.providers.aca_protocol import (
+    RUNNER_TOKEN_HEADER,
     AcaAgentPayload,
     AcaErrorData,
     AcaExecuteRequest,
@@ -651,7 +651,7 @@ class AcaRuntimeProvider(AgentProvider):
         keys (``aca_runner/auth.py::ALLOWED_INNER_PROVIDER_SETTINGS_KEYS`` —
         exactly ``base_url``/``api_key``/``bearer_token``/``github_token``),
         rejecting anything else (e.g. ``runtime_url``, ``headers``) with a
-        401/400. A future key added to this method's returned dict must be
+        400. A future key added to this method's returned dict must be
         added to that allowlist too, or the runner will reject every request
         that carries it.
 
@@ -693,11 +693,16 @@ class AcaRuntimeProvider(AgentProvider):
         """Read the runner transport-token gate's expected value, if configured.
 
         Issue #396: `ACA_RUNNER_AUTH_TOKEN` is the host-side half of the
-        opt-in transport-token gate on the runner's `/execute` (and
-        `/interrupt`/`/health`, for skew detection) — the runner-side half
-        reads the same env var via `aca_runner/auth.py::resolve_runner_token`.
-        `None` when unset (the gate is disabled by default — no new
-        configuration is required for existing deployments).
+        opt-in transport-token gate the runner enforces on `/execute` only
+        — the runner-side half reads the same env var via
+        `aca_runner/auth.py::resolve_runner_token`. The host also sends
+        this header on `validate_connection()`'s `/health` probe (which
+        never requires it) so `_warn_on_auth_skew` can compare the two
+        postures, and on `_send_interrupt()`'s POST — a route the MVP
+        runner does not yet implement, so that header is currently
+        forward-looking. `None` when unset (the gate is disabled by
+        default — no new configuration is required for existing
+        deployments).
         """
         value = _clean_env("ACA_RUNNER_AUTH_TOKEN")
         return SecretStr(value) if value is not None else None

--- a/src/conductor/providers/aca_protocol.py
+++ b/src/conductor/providers/aca_protocol.py
@@ -78,6 +78,12 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
+# The one definition of the transport-token header name (issue #396),
+# imported by both the runner (`aca_runner/server.py`, via
+# `aca_runner/auth.py`) and the host provider (`providers/aca.py`) so the two
+# sides of the transport-token gate can never drift apart.
+RUNNER_TOKEN_HEADER = "X-Conductor-Runner-Token"
+
 # `inner_provider_settings` keys that carry a credential (as opposed to
 # `base_url`, which is not secret). Kept in one place so the redaction
 # validator below and any future field additions stay in sync.
@@ -182,7 +188,7 @@ class AcaExecuteRequest(BaseModel):
 
     Issue #396: the runner rejects any key outside the four named above
     (``aca_runner/auth.py::ALLOWED_INNER_PROVIDER_SETTINGS_KEYS``) with a
-    401/400, and optionally checks ``base_url`` against
+    400, and optionally checks ``base_url`` against
     ``ACA_RUNNER_ALLOWED_BASE_URLS``. See that module's docstring."""
 
     @field_validator("inner_provider_settings", mode="after")

--- a/src/conductor/providers/aca_protocol.py
+++ b/src/conductor/providers/aca_protocol.py
@@ -42,6 +42,16 @@ open questions the design left for this epic:
   cover ``model_construct()`` or ``model_copy(update=...)``, both of which
   bypass validators by design; neither is used to build this model anywhere
   in this codebase.
+
+  Issue #396: the runner (``aca_runner/auth.py::check_inner_provider_settings``)
+  additionally rejects any key outside
+  ``aca_runner/auth.py::ALLOWED_INNER_PROVIDER_SETTINGS_KEYS`` — exactly the
+  four keys named above — closing off a caller sending e.g. ``runtime_url``
+  (repoint the inner Copilot session at an arbitrary external runtime) or
+  ``headers`` (inject arbitrary HTTP headers) directly at the runner. This
+  is a separate control from ``_INNER_PROVIDER_SECRET_KEYS`` below: that
+  list is about which values get redacted, not which keys are permitted at
+  all — ``base_url`` is permitted but not secret.
 - ``AcaExecuteRequest.tool_output`` / ``AcaResultData.cache_read_tokens`` /
   ``AcaResultData.cache_write_tokens`` — review fix: these were captured
   host-side (``ToolOutputConfig`` on the provider; Claude-style prompt-cache
@@ -168,7 +178,12 @@ class AcaExecuteRequest(BaseModel):
     ``SecretStr`` immediately after validation. (Field validators only run
     on validated construction; ``model_construct()``/``model_copy(update=...)``
     bypass them and are not used to build this model anywhere in this
-    codebase.)"""
+    codebase.)
+
+    Issue #396: the runner rejects any key outside the four named above
+    (``aca_runner/auth.py::ALLOWED_INNER_PROVIDER_SETTINGS_KEYS``) with a
+    401/400, and optionally checks ``base_url`` against
+    ``ACA_RUNNER_ALLOWED_BASE_URLS``. See that module's docstring."""
 
     @field_validator("inner_provider_settings", mode="after")
     @classmethod

--- a/tests/test_aca_runner/test_auth.py
+++ b/tests/test_aca_runner/test_auth.py
@@ -1,0 +1,172 @@
+"""Unit tests for `conductor.aca_runner.auth` (issue #396).
+
+Exercises the leaf module in isolation: env-var resolution
+(`resolve_runner_token`, `resolve_allowed_base_urls`), the
+`inner_provider_settings` key/base_url allowlist
+(`check_inner_provider_settings`), and the token comparison
+(`token_gate`).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from conductor.aca_runner.auth import (
+    ALLOWED_INNER_PROVIDER_SETTINGS_KEYS,
+    check_inner_provider_settings,
+    resolve_allowed_base_urls,
+    resolve_runner_token,
+    token_gate,
+)
+from conductor.exceptions import ProviderError
+
+
+class TestResolveRunnerToken:
+    """`resolve_runner_token` — the `_clean_env` contract."""
+
+    def test_returns_none_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ACA_RUNNER_AUTH_TOKEN", raising=False)
+        assert resolve_runner_token() is None
+
+    def test_returns_none_for_empty_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "")
+        assert resolve_runner_token() is None
+
+    def test_returns_none_for_whitespace_only_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "   ")
+        assert resolve_runner_token() is None
+
+    def test_returns_stripped_value_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "  my-token  ")
+        assert resolve_runner_token() == "my-token"
+
+
+class TestResolveAllowedBaseUrls:
+    """`resolve_allowed_base_urls` — comma-separated allowlist parsing."""
+
+    def test_returns_none_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ACA_RUNNER_ALLOWED_BASE_URLS", raising=False)
+        assert resolve_allowed_base_urls() is None
+
+    def test_returns_none_when_only_whitespace_or_commas(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_ALLOWED_BASE_URLS", " , , ")
+        assert resolve_allowed_base_urls() is None
+
+    def test_parses_comma_separated_list_and_strips_entries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "ACA_RUNNER_ALLOWED_BASE_URLS",
+            " http://localhost:11434/v1 , http://example.com/v1 ",
+        )
+        assert resolve_allowed_base_urls() == (
+            "http://localhost:11434/v1",
+            "http://example.com/v1",
+        )
+
+    def test_drops_empty_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "ACA_RUNNER_ALLOWED_BASE_URLS", "http://a.example.com,,http://b.example.com"
+        )
+        assert resolve_allowed_base_urls() == ("http://a.example.com", "http://b.example.com")
+
+
+class TestCheckInnerProviderSettings:
+    """`check_inner_provider_settings` — key allowlist + base_url allowlist."""
+
+    def test_none_settings_is_a_no_op(self) -> None:
+        check_inner_provider_settings(None, allowed_base_urls=None)
+
+    def test_empty_settings_is_a_no_op(self) -> None:
+        check_inner_provider_settings({}, allowed_base_urls=None)
+
+    @pytest.mark.parametrize("key", sorted(ALLOWED_INNER_PROVIDER_SETTINGS_KEYS))
+    def test_each_allowed_key_individually_accepted(self, key: str) -> None:
+        check_inner_provider_settings({key: "value"}, allowed_base_urls=None)
+
+    def test_all_four_allowed_keys_together_accepted(self) -> None:
+        check_inner_provider_settings(
+            {
+                "base_url": "http://localhost:11434/v1",
+                "api_key": "k",
+                "bearer_token": "t",
+                "github_token": "g",
+            },
+            allowed_base_urls=None,
+        )
+
+    @pytest.mark.parametrize("key", ["runtime_url", "headers", "type", "wire_api", "azure"])
+    def test_rejects_disallowed_keys_naming_the_key(self, key: str) -> None:
+        with pytest.raises(ProviderError, match=key):
+            check_inner_provider_settings({key: "value"}, allowed_base_urls=None)
+
+    def test_rejects_base_url_outside_allowlist(self) -> None:
+        with pytest.raises(ProviderError, match="not in the configured allowlist"):
+            check_inner_provider_settings(
+                {"base_url": "http://evil.example.com"},
+                allowed_base_urls=("http://localhost:11434/v1",),
+            )
+
+    def test_accepts_base_url_inside_allowlist(self) -> None:
+        check_inner_provider_settings(
+            {"base_url": "http://localhost:11434/v1"},
+            allowed_base_urls=("http://localhost:11434/v1",),
+        )
+
+    def test_accepts_base_url_inside_allowlist_ignoring_trailing_slash(self) -> None:
+        check_inner_provider_settings(
+            {"base_url": "http://localhost:11434/v1/"},
+            allowed_base_urls=("http://localhost:11434/v1",),
+        )
+
+    def test_no_op_when_allowlist_is_none(self) -> None:
+        check_inner_provider_settings(
+            {"base_url": "http://anything.example.com"}, allowed_base_urls=None
+        )
+
+    def test_no_base_url_key_is_unaffected_by_allowlist(self) -> None:
+        check_inner_provider_settings(
+            {"github_token": "g"}, allowed_base_urls=("http://localhost:11434/v1",)
+        )
+
+    def test_tolerates_secretstr_wrapped_values(self) -> None:
+        check_inner_provider_settings(
+            {
+                "api_key": SecretStr("k"),
+                "bearer_token": SecretStr("t"),
+                "github_token": SecretStr("g"),
+                "base_url": "http://localhost:11434/v1",
+            },
+            allowed_base_urls=("http://localhost:11434/v1",),
+        )
+
+    def test_rejects_disallowed_key_even_when_value_is_secretstr(self) -> None:
+        with pytest.raises(ProviderError, match="runtime_url"):
+            check_inner_provider_settings(
+                {"runtime_url": SecretStr("value")}, allowed_base_urls=None
+            )
+
+
+class TestTokenGate:
+    """`token_gate` — the runner-side comparison wrapper."""
+
+    def test_true_when_expected_is_none(self) -> None:
+        assert token_gate("anything", None) is True
+        assert token_gate(None, None) is True
+
+    def test_false_for_missing_presented_token(self) -> None:
+        assert token_gate(None, "expected-token") is False
+
+    def test_false_for_wrong_presented_token(self) -> None:
+        assert token_gate("wrong-token", "expected-token") is False
+
+    def test_true_for_exact_match(self) -> None:
+        assert token_gate("expected-token", "expected-token") is True
+
+    def test_does_not_raise_on_non_ascii_presented_value(self) -> None:
+        # constant_time_match's own trap: hmac.compare_digest raises TypeError
+        # on a str containing non-ASCII characters unless bytes are compared.
+        assert token_gate("caf\u00e9", "expected-token") is False

--- a/tests/test_aca_runner/test_auth.py
+++ b/tests/test_aca_runner/test_auth.py
@@ -149,6 +149,19 @@ class TestCheckInnerProviderSettings:
                 {"runtime_url": SecretStr("value")}, allowed_base_urls=None
             )
 
+    @pytest.mark.parametrize("base_url", [123, ["a"], {"a": 1}, True])
+    def test_rejects_non_string_base_url(self, base_url: object) -> None:
+        with pytest.raises(ProviderError, match="must be a string"):
+            check_inner_provider_settings({"base_url": base_url}, allowed_base_urls=None)
+
+    @pytest.mark.parametrize("base_url", [123, ["a"], {"a": 1}, True])
+    def test_rejects_non_string_base_url_with_allowlist_configured(self, base_url: object) -> None:
+        with pytest.raises(ProviderError, match="must be a string"):
+            check_inner_provider_settings(
+                {"base_url": base_url},
+                allowed_base_urls=("http://localhost:11434/v1",),
+            )
+
 
 class TestTokenGate:
     """`token_gate` — the runner-side comparison wrapper."""

--- a/tests/test_aca_runner/test_server.py
+++ b/tests/test_aca_runner/test_server.py
@@ -703,6 +703,20 @@ class TestRunnerAuthGate:
             )
         assert _FakeCopilotProvider.instances == []
 
+    def test_malformed_body_from_unauthenticated_caller_returns_422_not_401(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pinned contract (review finding B2): FastAPI validates the
+        `AcaExecuteRequest` body *before* the handler's token check ever
+        runs, so a malformed body with no token header returns FastAPI's own
+        422 rather than the gate's 401 — the gate protects execution, not
+        the parser. See `execute_endpoint`'s docstring."""
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            response = client.post("/execute", json={"bogus": 1})
+            assert response.status_code == 422
+            assert _FakeCopilotProvider.instances == []
+
 
 class TestHealthReportsAuthPosture:
     """`GET /health`'s `auth_required` / `auth_token_present` fields (issue #396)."""
@@ -818,3 +832,20 @@ class TestInnerProviderSettingsAllowlist:
             )
             assert response.status_code == 200
             _parse_ndjson(response.text)
+
+    def test_non_string_base_url_returns_400_not_500_with_allowlist_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: a non-string `base_url` must not crash with an
+        unhandled `AttributeError` -> 500 (review finding B1) — it must
+        return a clean, non-retryable 400 like every other malformed
+        `inner_provider_settings` value."""
+        monkeypatch.setenv("ACA_RUNNER_ALLOWED_BASE_URLS", "http://localhost:11434/v1")
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(inner_provider_settings={"base_url": 123}),
+            )
+            assert response.status_code == 400
+            assert "message" in response.json().get("error", {})
+            assert _FakeCopilotProvider.instances == []

--- a/tests/test_aca_runner/test_server.py
+++ b/tests/test_aca_runner/test_server.py
@@ -104,6 +104,17 @@ def _reset_fake_provider_instances() -> Any:
     _FakeCopilotProvider.instances = []
 
 
+@pytest.fixture(autouse=True)
+def _clear_runner_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure a developer's ambient env cannot flip a test's result (issue #396).
+
+    Mirrors `TestAcaCredentialPrecedence._clear_credential_env`'s discipline
+    in `tests/test_providers/test_aca.py`.
+    """
+    monkeypatch.delenv("ACA_RUNNER_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ACA_RUNNER_ALLOWED_BASE_URLS", raising=False)
+
+
 @pytest.fixture
 def client(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setattr("conductor.aca_runner.server.CopilotProvider", _FakeCopilotProvider)
@@ -112,6 +123,21 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Any:
     app = create_app()
     with TestClient(app) as test_client:
         yield test_client
+
+
+def _build_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Construct a fresh `TestClient` after the caller has set env vars.
+
+    Unlike the `client` fixture above, this is a plain helper (not itself a
+    fixture) so a test can `monkeypatch.setenv(...)` *before* calling it —
+    `create_app()` resolves the token/allowlist once at startup (issue
+    #396), so env vars set after the app already exists would have no
+    effect.
+    """
+    monkeypatch.setattr("conductor.aca_runner.server.CopilotProvider", _FakeCopilotProvider)
+    from conductor.aca_runner.server import create_app
+
+    return TestClient(create_app())
 
 
 def _execute_body(**overrides: Any) -> dict[str, Any]:
@@ -590,3 +616,205 @@ class TestInnerProviderCacheKeyHashing:
         )
         assert len(_FakeCopilotProvider.instances) == 2
         assert _FakeCopilotProvider.instances[0].close.await_count == 1
+
+
+class TestRunnerAuthGate:
+    """Opt-in transport-token gate on `/execute` (issue #396)."""
+
+    def test_execute_succeeds_with_no_header_when_token_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with _build_client(monkeypatch) as client:
+            response = client.post("/execute", json=_execute_body())
+            assert response.status_code == 200
+            _parse_ndjson(response.text)
+
+    def test_execute_returns_401_with_no_header_when_token_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            response = client.post("/execute", json=_execute_body())
+            assert response.status_code == 401
+            body = response.json()
+            assert "message" in body.get("error", body)
+            assert _FakeCopilotProvider.instances == []
+
+    def test_execute_returns_401_with_wrong_header_when_token_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(),
+                headers={"X-Conductor-Runner-Token": "wrong-token"},
+            )
+            assert response.status_code == 401
+            assert _FakeCopilotProvider.instances == []
+
+    def test_execute_succeeds_with_correct_header_when_token_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(),
+                headers={"X-Conductor-Runner-Token": "secret-runner-token"},
+            )
+            assert response.status_code == 200
+            _parse_ndjson(response.text)
+            assert len(_FakeCopilotProvider.instances) == 1
+
+    def test_health_returns_200_regardless_of_auth_gate_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            # No header.
+            assert client.get("/health").status_code == 200
+            # Wrong header.
+            assert (
+                client.get(
+                    "/health", headers={"X-Conductor-Runner-Token": "wrong-token"}
+                ).status_code
+                == 200
+            )
+            # Correct header.
+            assert (
+                client.get(
+                    "/health", headers={"X-Conductor-Runner-Token": "secret-runner-token"}
+                ).status_code
+                == 200
+            )
+
+    def test_rejected_request_never_constructs_the_inner_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gate is a real gate, not just a response filter (review requirement)."""
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            client.post("/execute", json=_execute_body())
+            client.post(
+                "/execute",
+                json=_execute_body(),
+                headers={"X-Conductor-Runner-Token": "wrong-token"},
+            )
+        assert _FakeCopilotProvider.instances == []
+
+
+class TestHealthReportsAuthPosture:
+    """`GET /health`'s `auth_required` / `auth_token_present` fields (issue #396)."""
+
+    def test_auth_required_false_when_token_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with _build_client(monkeypatch) as client:
+            body = client.get("/health").json()
+            assert body["auth_required"] is False
+
+    def test_auth_required_true_when_token_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            body = client.get("/health").json()
+            assert body["auth_required"] is True
+
+    def test_auth_token_present_false_when_no_header_sent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            body = client.get("/health").json()
+            assert body["auth_token_present"] is False
+
+    def test_auth_token_present_true_for_a_wrong_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`auth_token_present` reports presence only — never validity — so
+        it cannot be used as a brute-force oracle (review requirement)."""
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            body = client.get(
+                "/health", headers={"X-Conductor-Runner-Token": "definitely-wrong"}
+            ).json()
+            assert body["auth_token_present"] is True
+
+    def test_auth_token_present_true_for_the_correct_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "secret-runner-token")
+        with _build_client(monkeypatch) as client:
+            body = client.get(
+                "/health", headers={"X-Conductor-Runner-Token": "secret-runner-token"}
+            ).json()
+            assert body["auth_token_present"] is True
+
+
+class TestInnerProviderSettingsAllowlist:
+    """Runner-side `inner_provider_settings` key/base_url allowlist (issue #396)."""
+
+    def test_runtime_url_key_is_rejected_with_400(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(inner_provider_settings={"runtime_url": "http://evil"}),
+            )
+            assert response.status_code == 400
+            assert _FakeCopilotProvider.instances == []
+
+    def test_headers_key_is_rejected_with_400(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(inner_provider_settings={"headers": {"X-Injected": "value"}}),
+            )
+            assert response.status_code == 400
+            assert _FakeCopilotProvider.instances == []
+
+    def test_all_four_allowed_keys_pass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(
+                    inner_provider_settings={
+                        "base_url": "http://localhost:11434/v1",
+                        "api_key": "k",
+                        "bearer_token": "t",
+                        "github_token": "g",
+                    }
+                ),
+            )
+            assert response.status_code == 200
+            _parse_ndjson(response.text)
+
+    def test_allowlist_rejects_off_list_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ACA_RUNNER_ALLOWED_BASE_URLS", "http://localhost:11434/v1")
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(inner_provider_settings={"base_url": "http://evil.example.com"}),
+            )
+            assert response.status_code == 400
+            assert _FakeCopilotProvider.instances == []
+
+    def test_allowlist_admits_on_list_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ACA_RUNNER_ALLOWED_BASE_URLS", "http://localhost:11434/v1")
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(
+                    inner_provider_settings={"base_url": "http://localhost:11434/v1"}
+                ),
+            )
+            assert response.status_code == 200
+            _parse_ndjson(response.text)
+
+    def test_unset_allowlist_admits_any_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with _build_client(monkeypatch) as client:
+            response = client.post(
+                "/execute",
+                json=_execute_body(
+                    inner_provider_settings={"base_url": "http://anything.example.com"}
+                ),
+            )
+            assert response.status_code == 200
+            _parse_ndjson(response.text)

--- a/tests/test_providers/test_aca.py
+++ b/tests/test_providers/test_aca.py
@@ -18,6 +18,7 @@ import httpx
 import pytest
 from pydantic import SecretStr
 
+from conductor.aca_runner.auth import RUNNER_TOKEN_HEADER
 from conductor.config.schema import AgentDef, ProviderSettings, SandboxConfig, ToolOutputConfig
 from conductor.exceptions import ProviderError
 from conductor.providers.aca_protocol import AcaExecuteRequest
@@ -305,6 +306,15 @@ def _default_aca_credential_env(monkeypatch: pytest.MonkeyPatch) -> None:
     real precedence logic.
     """
     monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "test-default-github-token")
+
+
+@pytest.fixture(autouse=True)
+def _clear_runner_auth_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure a developer's ambient `ACA_RUNNER_AUTH_TOKEN` cannot flip a
+    test's result (issue #396) — same discipline as
+    `TestAcaCredentialPrecedence._clear_credential_env`.
+    """
+    monkeypatch.delenv("ACA_RUNNER_AUTH_TOKEN", raising=False)
 
 
 def _make_provider(**settings_kwargs: object):
@@ -1761,3 +1771,306 @@ class TestAcaDialogTurns:
             assert exc.is_retryable is False
         else:
             pytest.fail("expected ProviderError")
+
+
+class TestAcaRunnerTokenHeaderForwarding:
+    """The `X-Conductor-Runner-Token` header (issue #396) on runner-forwarded
+    calls (`/execute`, `/interrupt`, `/health`) — and its deliberate absence
+    from the ACA management-plane `_stop_session` `DELETE /session` call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_sends_header_when_token_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "host-runner-token")
+        frames = [{"type": "result", "data": {"content": {}, "partial": False}}]
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, content=_ndjson_body(frames))
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential):
+            await provider.execute(agent=_agent(), context={}, rendered_prompt="x")
+
+        assert len(captured) == 1
+        assert captured[0].headers[RUNNER_TOKEN_HEADER] == "host-runner-token"
+
+    @pytest.mark.asyncio
+    async def test_execute_omits_header_when_token_not_configured(self) -> None:
+        frames = [{"type": "result", "data": {"content": {}, "partial": False}}]
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, content=_ndjson_body(frames))
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential):
+            await provider.execute(agent=_agent(), context={}, rendered_prompt="x")
+
+        assert len(captured) == 1
+        assert RUNNER_TOKEN_HEADER not in captured[0].headers
+
+    @pytest.mark.asyncio
+    async def test_interrupt_sends_header_when_token_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "host-runner-token")
+        interrupt_signal = asyncio.Event()
+        interrupt_signal.set()
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            if request.url.path == "/interrupt":
+                return httpx.Response(200, json={"status": "ok"})
+            raise AssertionError(f"unexpected path {request.url.path}")
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        fake_response = _FakeInterruptResponse(
+            [json.dumps({"type": "result", "data": {"content": {}, "partial": True}})]
+        )
+        provider._stream_execute = lambda *a, **kw: _FakeStreamContext(fake_response)  # type: ignore[method-assign]
+
+        with patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential):
+            await provider.execute(
+                agent=_agent(), context={}, rendered_prompt="x", interrupt_signal=interrupt_signal
+            )
+
+        interrupt_requests = [r for r in captured if r.url.path == "/interrupt"]
+        assert len(interrupt_requests) == 1
+        assert interrupt_requests[0].headers[RUNNER_TOKEN_HEADER] == "host-runner-token"
+
+    @pytest.mark.asyncio
+    async def test_interrupt_omits_header_when_token_not_configured(self) -> None:
+        interrupt_signal = asyncio.Event()
+        interrupt_signal.set()
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            if request.url.path == "/interrupt":
+                return httpx.Response(200, json={"status": "ok"})
+            raise AssertionError(f"unexpected path {request.url.path}")
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        fake_response = _FakeInterruptResponse(
+            [json.dumps({"type": "result", "data": {"content": {}, "partial": True}})]
+        )
+        provider._stream_execute = lambda *a, **kw: _FakeStreamContext(fake_response)  # type: ignore[method-assign]
+
+        with patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential):
+            await provider.execute(
+                agent=_agent(), context={}, rendered_prompt="x", interrupt_signal=interrupt_signal
+            )
+
+        interrupt_requests = [r for r in captured if r.url.path == "/interrupt"]
+        assert len(interrupt_requests) == 1
+        assert RUNNER_TOKEN_HEADER not in interrupt_requests[0].headers
+
+    @pytest.mark.asyncio
+    async def test_health_sends_header_when_token_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "host-runner-token")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.headers[RUNNER_TOKEN_HEADER] == "host-runner-token"
+            return httpx.Response(200, json={"status": "ok"})
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential):
+            assert await provider.validate_connection() is True
+
+    @pytest.mark.asyncio
+    async def test_health_omits_header_when_token_not_configured(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert RUNNER_TOKEN_HEADER not in request.headers
+            return httpx.Response(200, json={"status": "ok"})
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential):
+            assert await provider.validate_connection() is True
+
+    @pytest.mark.asyncio
+    async def test_stop_session_never_sends_runner_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression test (issue #396): `_stop_session`'s `DELETE /session`
+        is an ACA management-plane operation that never reaches the runner —
+        adding the runner token header there would leak the runner
+        credential to the Azure control plane instead.
+        """
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "host-runner-token")
+        interrupt_signal = asyncio.Event()
+        interrupt_signal.set()
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            if request.url.path == "/interrupt":
+                return httpx.Response(500, json={"error": {"message": "boom"}})
+            if request.url.path == "/session":
+                return httpx.Response(200, json={"status": "stopped"})
+            raise AssertionError(f"unexpected path {request.url.path}")
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        fake_response = _FakeInterruptResponse(
+            [json.dumps({"type": "agent_message", "data": {}}) for _ in range(5)]
+        )
+        provider._stream_execute = lambda *a, **kw: _FakeStreamContext(fake_response)  # type: ignore[method-assign]
+
+        with patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential):
+            await provider.execute(
+                agent=_agent(), context={}, rendered_prompt="x", interrupt_signal=interrupt_signal
+            )
+
+        session_requests = [r for r in captured if r.url.path == "/session"]
+        assert len(session_requests) == 1
+        assert RUNNER_TOKEN_HEADER not in session_requests[0].headers
+        # And the header *was* sent on the sibling /interrupt call — proving
+        # its absence here is deliberate, not a broken test.
+        interrupt_requests = [r for r in captured if r.url.path == "/interrupt"]
+        assert interrupt_requests[0].headers[RUNNER_TOKEN_HEADER] == "host-runner-token"
+
+
+class TestAcaAuthSkewWarnings:
+    """`validate_connection()`'s `_warn_on_auth_skew` (issue #396)."""
+
+    @pytest.mark.asyncio
+    async def test_warns_when_runner_requires_token_but_none_arrived(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "ready": True,
+                    "auth_required": True,
+                    "auth_token_present": False,
+                },
+            )
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with (
+            patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential),
+            caplog.at_level("WARNING", logger="conductor.providers.aca"),
+        ):
+            await provider.validate_connection()
+
+        assert any("stripping" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_warns_when_host_has_token_but_runner_does_not_require_one(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "host-runner-token")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "ready": True,
+                    "auth_required": False,
+                    "auth_token_present": True,
+                },
+            )
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with (
+            patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential),
+            caplog.at_level("WARNING", logger="conductor.providers.aca"),
+        ):
+            await provider.validate_connection()
+
+        assert any("being ignored" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_silent_when_postures_agree_both_off(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"ready": True, "auth_required": False, "auth_token_present": False},
+            )
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with (
+            patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential),
+            caplog.at_level("WARNING", logger="conductor.providers.aca"),
+        ):
+            await provider.validate_connection()
+
+        assert caplog.records == []
+
+    @pytest.mark.asyncio
+    async def test_silent_when_postures_agree_both_on(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("ACA_RUNNER_AUTH_TOKEN", "host-runner-token")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"ready": True, "auth_required": True, "auth_token_present": True},
+            )
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with (
+            patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential),
+            caplog.at_level("WARNING", logger="conductor.providers.aca"),
+        ):
+            await provider.validate_connection()
+
+        assert caplog.records == []
+
+    @pytest.mark.asyncio
+    async def test_silent_when_runner_omits_fields_entirely(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An old runner image predating these fields must not spuriously warn."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ready": True})
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with (
+            patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential),
+            caplog.at_level("WARNING", logger="conductor.providers.aca"),
+        ):
+            await provider.validate_connection()
+
+        assert caplog.records == []
+
+    @pytest.mark.asyncio
+    async def test_silent_when_health_body_is_not_a_dict(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=["not", "a", "dict"])
+
+        provider = _make_provider()
+        provider._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with (
+            patch("conductor.providers.aca._AsyncDefaultAzureCredential", _FakeAsyncCredential),
+            caplog.at_level("WARNING", logger="conductor.providers.aca"),
+        ):
+            assert await provider.validate_connection() is True
+
+        assert caplog.records == []

--- a/tests/test_providers/test_aca.py
+++ b/tests/test_providers/test_aca.py
@@ -18,10 +18,9 @@ import httpx
 import pytest
 from pydantic import SecretStr
 
-from conductor.aca_runner.auth import RUNNER_TOKEN_HEADER
 from conductor.config.schema import AgentDef, ProviderSettings, SandboxConfig, ToolOutputConfig
 from conductor.exceptions import ProviderError
-from conductor.providers.aca_protocol import AcaExecuteRequest
+from conductor.providers.aca_protocol import RUNNER_TOKEN_HEADER, AcaExecuteRequest
 from conductor.providers.capabilities import ProviderCapabilities, get_capabilities
 from conductor.providers.factory import create_provider
 


### PR DESCRIPTION
## Summary
Hardens the ACA agent runner's transport surface: opt-in token auth on `/execute`, an allowlist for `inner_provider_settings`, an optional `base_url` allowlist, and loopback-only binding by default.

Closes #396