### PR TITLE
feat(doctor): surface model pricing source in doctor diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `claude-haiku-4.5` at the published Anthropic rates. Both spellings are
   kept: the dashed keys are what price the date-suffixed Anthropic ids
   (`claude-haiku-4-5-20251001`).
+- **`gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` are no longer unpriced**
+  (#386). Added to `DEFAULT_PRICING` as exact keys at the existing GPT-5.x
+  family rate ($2.00 in / $8.00 out per million tokens) — exact keys rather
+  than a `gpt-5.6` prefix key so the three resolve silently instead of
+  through `get_pricing`'s fuzzy-match warning path. `grok-4.5`,
+  `gemini-3.6-flash`, `mai-code-1.1-flash`, and `mai-code-1-flash-picker`
+  remain **deliberately** unpriced in the static table pending a published
+  rate; an invented rate would print as a confident cost, which is worse
+  than the honest `(N unpriced)` marker. With a Copilot SDK `>=1.0.9`
+  (#418), the live provider-pricing hook now prices all of these anyway —
+  the static-table gap only matters when that hook is unavailable.
 
-## [0.1.28](https://github.com/microsoft/conductor/compare/v0.1.27...v0.1.28) - 2026-08-12
+### Added
+
+- **`conductor doctor --models` now shows per-model pricing** (#386). The
+  Models detail table gained `Input $/Mtok`, `Output $/Mtok`, and `Pricing`
+  columns — the last distinguishing `provider` (live
+  `get_model_pricing` hook), `table` (static `DEFAULT_PRICING` fallback),
+  and `none` (genuinely unpriced) so "why is my run unpriced" is answerable
+  with one read-only, network-free command (the probe reuses the same
+  `list_models()` call `--models` already makes). `--json` gains matching
+  `input_per_mtok` / `output_per_mtok` / `pricing_source` fields on each
+  model object.
+
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `gemini-3.6-flash`, `mai-code-1.1-flash`, and `mai-code-1-flash-picker`
   remain **deliberately** unpriced in the static table pending a published
   rate; an invented rate would print as a confident cost, which is worse
-  than the honest `(N unpriced)` marker. With a Copilot SDK `>=1.0.9`
-  (#418), the live provider-pricing hook now prices all of these anyway —
-  the static-table gap only matters when that hook is unavailable.
+  than the honest `(N unpriced)` marker. The live provider-pricing hook
+  prices any model whose SDK metadata carries `billing.token_prices`
+  (verified for `claude-opus-5` in #418, on Copilot SDK `>=1.0.9` —
+  already the hard floor pinned in `pyproject.toml`) — the static-table
+  gap only matters when that hook is unavailable or the model's metadata
+  lacks a rate.
 
 ### Added
 
@@ -89,12 +92,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   columns — the last distinguishing `provider` (live
   `get_model_pricing` hook), `table` (static `DEFAULT_PRICING` fallback),
   and `none` (genuinely unpriced) so "why is my run unpriced" is answerable
-  with one read-only, network-free command (the probe reuses the same
-  `list_models()` call `--models` already makes). `--json` gains matching
+  with one read-only command (pricing resolution adds no new network
+  round-trip — the Copilot SDK memoizes `list_models()` for the process).
+  `--json` gains matching
   `input_per_mtok` / `output_per_mtok` / `pricing_source` fields on each
   model object.
 
-
+## [0.1.28](https://github.com/microsoft/conductor/compare/v0.1.27...v0.1.28) - 2026-08-12
 
 ### Added
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -725,8 +725,8 @@ support and context-window limits:
 | Reasoning efforts | `reasoning.effort` levels the model accepts (e.g. `low, medium, high, xhigh`), `none` when the model definitively supports none (e.g. a non-thinking Claude model), or `n/a` when the provider can't determine support. |
 | Default | The model's default reasoning-effort level, or `—` when unknown/not applicable. |
 | Prompt / Output / Context | Maximum prompt (input), output (completion), and total context-window tokens, or `—` when the provider doesn't expose that limit. |
-| Input $/Mtok / Output $/Mtok | Resolved per-million-token input/output rate (USD), or `—` when unpriced (never `0.00` — a zero would read as "free"). |
-| Pricing | Where the rate came from (see #386): `provider` (live rate from the provider's `get_model_pricing` hook), `table` (static `DEFAULT_PRICING` fallback), `none` (unpriced — the run's cost summary will show `~$X (N unpriced)`), or `—` when pricing resolution itself failed. |
+| Input $/Mtok / Output $/Mtok | Resolved per-million-token input/output rate (USD), or `—` when unpriced; a displayed `0.00` means a genuinely free rate reported by the provider, never "unknown". |
+| Pricing | Where the rate came from (see #386): `provider` (live rate from the provider's `get_model_pricing` hook), `table` (static `DEFAULT_PRICING` fallback), `none` (unpriced — the run's cost summary will show `~$X (N unpriced)`), or `error` when pricing resolution itself failed. |
 
 Coverage varies by provider — every field degrades independently to `n/a` /
 `—` rather than failing the command:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -725,13 +725,18 @@ support and context-window limits:
 | Reasoning efforts | `reasoning.effort` levels the model accepts (e.g. `low, medium, high, xhigh`), `none` when the model definitively supports none (e.g. a non-thinking Claude model), or `n/a` when the provider can't determine support. |
 | Default | The model's default reasoning-effort level, or `—` when unknown/not applicable. |
 | Prompt / Output / Context | Maximum prompt (input), output (completion), and total context-window tokens, or `—` when the provider doesn't expose that limit. |
+| Input $/Mtok / Output $/Mtok | Resolved per-million-token input/output rate (USD), or `—` when unpriced (never `0.00` — a zero would read as "free"). |
+| Pricing | Where the rate came from (see #386): `provider` (live rate from the provider's `get_model_pricing` hook), `table` (static `DEFAULT_PRICING` fallback), `none` (unpriced — the run's cost summary will show `~$X (N unpriced)`), or `—` when pricing resolution itself failed. |
 
 Coverage varies by provider — every field degrades independently to `n/a` /
 `—` rather than failing the command:
 
 - **Copilot** reports reasoning-effort levels + default, and prompt/context
   token limits, from the SDK's per-model metadata (`Output` is frequently
-  `—` — the live API does not currently populate it for most models).
+  `—` — the live API does not currently populate it for most models). It is
+  also currently the only provider that implements the `get_model_pricing`
+  hook, so `Pricing` shows `provider` for models the SDK prices live; other
+  providers legitimately show `table` or `none`.
 - **Claude** derives reasoning-effort support from a static heuristic
   (Claude 3.7+ / 4.x models support all five levels; older models support
   none) and reports only `Prompt` (via the Anthropic API's
@@ -752,7 +757,10 @@ id strings):
   "default_reasoning_effort": "medium",
   "max_prompt_tokens": 128000,
   "max_output_tokens": 64000,
-  "max_context_window_tokens": 192000
+  "max_context_window_tokens": 192000,
+  "input_per_mtok": 2.00,
+  "output_per_mtok": 8.00,
+  "pricing_source": "table"
 }
 ```
 

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -1514,6 +1514,10 @@ and unpriced agents, the total is shown as a partial (e.g. `Total: ~$0.4200
 hides missing spend. The web dashboard shows the same `~$X (N unpriced)` marker.
 When *no* model can be priced, the summary reads `Cost data unavailable`.
 
+Run `conductor doctor --models` to see which models are priced and from
+where — the Models detail table's `Pricing` column shows `provider` / `table`
+/ `none` per model (see [`conductor doctor`](cli-reference.md#conductor-doctor)).
+
 To price an unknown model yourself, add a `cost.pricing` override:
 
 ```yaml

--- a/src/conductor/cli/doctor.py
+++ b/src/conductor/cli/doctor.py
@@ -329,11 +329,15 @@ _PRICING_SOURCE_CELLS: dict[str, Text] = {
     "provider": Text.from_markup("[green]provider[/green]"),
     "table": Text.from_markup("[dim]table[/dim]"),
     "none": Text.from_markup("[red]none[/red]"),
+    "error": Text.from_markup("[yellow]error[/yellow]"),
 }
 """Pre-built cells for each :attr:`ModelDiagnostic.pricing_source` literal
-(issue #386). Built as module-level constants rather than interpolated at
-render time — no runtime value ever reaches the markup parser, keeping this
-inside the repo's console rules (see AGENTS.md "Console Output")."""
+(issue #386), plus the synthetic ``"error"`` key used for ``None`` (pricing
+resolution itself failed). Built as module-level constants to avoid
+re-parsing the same markup literal on every table row (matching the
+``_CHECK``/``_CROSS``/``_DASH`` constants above) — each markup argument is
+still a literal template, not an interpolated value, keeping this inside the
+repo's console rules (see AGENTS.md "Console Output")."""
 
 
 def _rate_cell(value: float | None) -> Text:
@@ -349,9 +353,16 @@ def _rate_cell(value: float | None) -> Text:
 
 
 def _pricing_source_cell(model: ModelDiagnostic) -> Text:
-    """Format the pricing-source cell (``provider`` / ``table`` / ``none`` / ``—``)."""
+    """Format the pricing-source cell (``provider`` / ``table`` / ``none`` / ``error``).
+
+    ``None`` means resolution itself failed (distinct from the determined
+    ``"none"``) and renders as a visible ``error`` rather than the same
+    ``—`` glyph used elsewhere for "provider doesn't expose this" — that
+    glyph would make a systemic pricing-hook break indistinguishable from a
+    boring provider.
+    """
     if model.pricing_source is None:
-        return _DASH
+        return _PRICING_SOURCE_CELLS["error"]
     return _PRICING_SOURCE_CELLS.get(model.pricing_source, Text(model.pricing_source))
 
 

--- a/src/conductor/cli/doctor.py
+++ b/src/conductor/cli/doctor.py
@@ -325,13 +325,44 @@ def _default_effort_cell(model: ModelDiagnostic) -> Text:
     return Text(model.default_reasoning_effort)
 
 
+_PRICING_SOURCE_CELLS: dict[str, Text] = {
+    "provider": Text.from_markup("[green]provider[/green]"),
+    "table": Text.from_markup("[dim]table[/dim]"),
+    "none": Text.from_markup("[red]none[/red]"),
+}
+"""Pre-built cells for each :attr:`ModelDiagnostic.pricing_source` literal
+(issue #386). Built as module-level constants rather than interpolated at
+render time — no runtime value ever reaches the markup parser, keeping this
+inside the repo's console rules (see AGENTS.md "Console Output")."""
+
+
+def _rate_cell(value: float | None) -> Text:
+    """Format a per-Mtok rate, or ``—`` when unknown.
+
+    Deliberately never renders ``0.00`` for ``None`` — a zero would read as
+    "free", which is exactly the silent-wrong-number class of bug issue
+    #386 is about.
+    """
+    if value is None:
+        return _DASH
+    return Text(f"{value:,.2f}")
+
+
+def _pricing_source_cell(model: ModelDiagnostic) -> Text:
+    """Format the pricing-source cell (``provider`` / ``table`` / ``none`` / ``—``)."""
+    if model.pricing_source is None:
+        return _DASH
+    return _PRICING_SOURCE_CELLS.get(model.pricing_source, Text(model.pricing_source))
+
+
 def _render_models(providers: list[ProviderDiagnostic], console: Console) -> None:
     """Render a per-provider Models detail table (``--models`` only).
 
     One table per provider that returned at least one model, with columns
-    for reasoning-effort support and prompt/output/context token limits.
-    Providers with no models (``None``/empty/error) are already summarized
-    in the Providers table and are skipped here — there is nothing to detail.
+    for reasoning-effort support, prompt/output/context token limits, and
+    per-Mtok pricing plus its source (issue #386). Providers with no models
+    (``None``/empty/error) are already summarized in the Providers table and
+    are skipped here — there is nothing to detail.
     """
     for diag in providers:
         if not diag.models:
@@ -343,6 +374,9 @@ def _render_models(providers: list[ProviderDiagnostic], console: Console) -> Non
         table.add_column("Prompt", justify="right")
         table.add_column("Output", justify="right")
         table.add_column("Context", justify="right")
+        table.add_column("Input $/Mtok", justify="right")
+        table.add_column("Output $/Mtok", justify="right")
+        table.add_column("Pricing")
 
         for model in diag.models:
             table.add_row(
@@ -352,6 +386,9 @@ def _render_models(providers: list[ProviderDiagnostic], console: Console) -> Non
                 _format_tokens(model.max_prompt_tokens),
                 _format_tokens(model.max_output_tokens),
                 _format_tokens(model.max_context_window_tokens),
+                _rate_cell(model.input_per_mtok),
+                _rate_cell(model.output_per_mtok),
+                _pricing_source_cell(model),
             )
 
         console.print(table)

--- a/src/conductor/engine/pricing.py
+++ b/src/conductor/engine/pricing.py
@@ -118,6 +118,12 @@ DEFAULT_PRICING: dict[str, ModelPricing] = {
     "gpt-5.1": ModelPricing(input_per_mtok=2.00, output_per_mtok=8.00),
     "gpt-5.4-mini": ModelPricing(input_per_mtok=0.15, output_per_mtok=0.60),
     "gpt-5-mini": ModelPricing(input_per_mtok=0.15, output_per_mtok=0.60),
+    # GPT-5.6 variants priced at the existing GPT-5.x family rate (#386). Grok,
+    # Gemini-3.6, and the MAI-Code ids are deliberately absent pending a
+    # published rate — do not "complete" this set by guessing.
+    "gpt-5.6-sol": ModelPricing(input_per_mtok=2.00, output_per_mtok=8.00),
+    "gpt-5.6-terra": ModelPricing(input_per_mtok=2.00, output_per_mtok=8.00),
+    "gpt-5.6-luna": ModelPricing(input_per_mtok=2.00, output_per_mtok=8.00),
     # O-series
     "o1": ModelPricing(input_per_mtok=15.00, output_per_mtok=60.00),
     "o1-mini": ModelPricing(input_per_mtok=3.00, output_per_mtok=12.00),

--- a/src/conductor/engine/pricing.py
+++ b/src/conductor/engine/pricing.py
@@ -101,6 +101,10 @@ class ModelPricing:
 # Context-window metadata is sourced from each provider's SDK at runtime via
 # ``AgentProvider.get_max_prompt_tokens()`` — see ``providers/base.py``.
 # Sources: OpenAI pricing page, Anthropic pricing page, provider docs.
+# A model absent from this table is deliberately unpriced pending a published
+# rate — do not "complete" a family by guessing an unpublished price; an
+# invented rate would print as a confident cost, which is worse than the
+# honest unpriced state (#386).
 DEFAULT_PRICING: dict[str, ModelPricing] = {
     # OpenAI / Copilot models
     "gpt-4-turbo": ModelPricing(input_per_mtok=10.00, output_per_mtok=30.00),
@@ -118,9 +122,7 @@ DEFAULT_PRICING: dict[str, ModelPricing] = {
     "gpt-5.1": ModelPricing(input_per_mtok=2.00, output_per_mtok=8.00),
     "gpt-5.4-mini": ModelPricing(input_per_mtok=0.15, output_per_mtok=0.60),
     "gpt-5-mini": ModelPricing(input_per_mtok=0.15, output_per_mtok=0.60),
-    # GPT-5.6 variants priced at the existing GPT-5.x family rate (#386). Grok,
-    # Gemini-3.6, and the MAI-Code ids are deliberately absent pending a
-    # published rate — do not "complete" this set by guessing.
+    # GPT-5.6 variants priced at the existing GPT-5.x family rate (#386).
     "gpt-5.6-sol": ModelPricing(input_per_mtok=2.00, output_per_mtok=8.00),
     "gpt-5.6-terra": ModelPricing(input_per_mtok=2.00, output_per_mtok=8.00),
     "gpt-5.6-luna": ModelPricing(input_per_mtok=2.00, output_per_mtok=8.00),

--- a/src/conductor/providers/diagnostics.py
+++ b/src/conductor/providers/diagnostics.py
@@ -47,9 +47,17 @@ Section = Literal["env", "providers", "registries"]
 ALL_SECTIONS: tuple[Section, ...] = ("env", "providers", "registries")
 """Default set of sections rendered when no positional ``SECTION`` is given."""
 
+PricingSource = Literal["provider", "table", "none"]
+"""How a model's per-Mtok rates were resolved (see #386)."""
+
 # Provider names that are known to the schema/factory but not yet implemented.
 # Surfaced as an informational note, not an error.
 _NOT_IMPLEMENTED: frozenset[str] = frozenset({"openai-agents"})
+
+# One-shot latch so a systemically-raising get_model_pricing hook logs once
+# per process rather than once per model (mirrors
+# WorkflowEngine._pricing_hook_failed_warned in engine/workflow.py).
+_pricing_hook_failed_warned = False
 
 
 @dataclass(frozen=True)
@@ -151,7 +159,7 @@ class ModelDiagnostic:
     max_context_window_tokens: int | None = None
     input_per_mtok: float | None = None
     output_per_mtok: float | None = None
-    pricing_source: str | None = None
+    pricing_source: PricingSource | None = None
     """How ``input_per_mtok``/``output_per_mtok`` were resolved (see #386):
     ``"provider"`` (live :meth:`~conductor.providers.base.AgentProvider.get_model_pricing`
     hook), ``"table"`` (static ``DEFAULT_PRICING`` fallback), ``"none"``
@@ -430,7 +438,7 @@ def gather_registries() -> RegistryDiagnostic:
 
 async def _resolve_model_pricing(
     provider: Any, model_id: str
-) -> tuple[float | None, float | None, str | None]:
+) -> tuple[float | None, float | None, PricingSource | None]:
     """Resolve a model's per-Mtok rates and where they came from (never raises).
 
     Mirrors the cost-resolution chain in ``engine/pricing.py::get_pricing``
@@ -438,10 +446,13 @@ async def _resolve_model_pricing(
     minus the workflow override — ``doctor`` has no workflow context.
 
     Note ``get_pricing`` may resolve via its versioned-suffix fuzzy path and
-    log a one-time warning (see #137); ``doctor`` already runs the whole
-    gather inside ``_suppressed_logging`` (``cli/doctor.py``), and the
-    process is short-lived, so the module-level fuzzy-match latch cannot
-    leak into a workflow run.
+    log a one-time warning (see #137). Any such warning is invisible during
+    ``doctor`` because ``gather`` runs under ``_suppressed_logging``
+    (``cli/doctor.py``) whenever pricing is resolved. The module-level
+    fuzzy-match latch IS still mutated by that call — logging suppression
+    has no effect on it — but that is harmless only because ``doctor`` is a
+    standalone, short-lived CLI process (``gather`` has exactly one caller)
+    that never shares a process with a workflow run.
 
     Returns:
         A ``(input_per_mtok, output_per_mtok, source)`` tuple. ``source`` is
@@ -449,21 +460,43 @@ async def _resolve_model_pricing(
         (with rates ``None`` in the ``"none"`` case), or ``None`` when
         resolution itself failed — distinct from the determined ``"none"``.
     """
+    from conductor.engine.pricing import get_pricing
+
+    global _pricing_hook_failed_warned
+
+    hook_failed = False
+    provider_pricing = None
     try:
-        from conductor.engine.pricing import get_pricing
-
         provider_pricing = await provider.get_model_pricing(model_id)
-        if provider_pricing is not None:
-            return provider_pricing.input_per_mtok, provider_pricing.output_per_mtok, "provider"
-
-        table_pricing = get_pricing(model_id)
-        if table_pricing is not None:
-            return table_pricing.input_per_mtok, table_pricing.output_per_mtok, "table"
-
-        return None, None, "none"
     except Exception as e:  # noqa: BLE001 - diagnostics must never raise
-        logger.debug("Failed to resolve pricing for %r: %s", model_id, e)
+        hook_failed = True
+        logger.debug("Failed to resolve provider pricing for %r: %s", model_id, e)
+        # A raising hook usually means a systemic break (SDK auth /
+        # model-listing failure) rather than a per-model fluke, and doctor's
+        # `_suppressed_logging` disables this logger entirely — so warn
+        # once here too, matching the same one-shot warning
+        # engine/workflow.py emits for the identical exception.
+        if not _pricing_hook_failed_warned:
+            _pricing_hook_failed_warned = True
+            logger.warning(
+                "Provider pricing hook failed for model %r (%s); live pricing is "
+                "unavailable and rates will fall back to the static table or show "
+                "as unresolvable. Further failures are logged at debug level.",
+                model_id,
+                e,
+            )
+
+    if provider_pricing is not None:
+        return provider_pricing.input_per_mtok, provider_pricing.output_per_mtok, "provider"
+
+    table_pricing = get_pricing(model_id)
+    if table_pricing is not None:
+        return table_pricing.input_per_mtok, table_pricing.output_per_mtok, "table"
+
+    if hook_failed:
         return None, None, None
+
+    return None, None, "none"
 
 
 async def _build_model_diagnostics(provider: Any, model_ids: list[str]) -> list[ModelDiagnostic]:
@@ -486,40 +519,27 @@ async def _build_model_diagnostics(provider: Any, model_ids: list[str]) -> list[
     """
     result: list[ModelDiagnostic] = []
     for model_id in model_ids:
+        input_per_mtok, output_per_mtok, pricing_source = await _resolve_model_pricing(
+            provider, model_id
+        )
+        pricing_fields: dict[str, Any] = {
+            "input_per_mtok": input_per_mtok,
+            "output_per_mtok": output_per_mtok,
+            "pricing_source": pricing_source,
+        }
         try:
             caps = await provider.get_model_capabilities(model_id)
             # ModelCapabilityInfo.to_dict() keys mirror ModelDiagnostic's
             # capability fields exactly, so it doubles as the kwargs for
-            # constructing this model's diagnostic. A misbehaving provider
-            # whose return value lacks to_dict() (or isn't None) is caught
-            # below and degrades to id-only, same as any other failure.
+            # constructing this model's diagnostic. The try wraps both the
+            # call and the construction below: a misbehaving provider whose
+            # return value lacks to_dict() (or isn't None) is caught below
+            # and degrades to id-only, same as any other failure.
             fields = caps.to_dict() if caps is not None else {}
+            result.append(ModelDiagnostic(id=model_id, **pricing_fields, **fields))
         except Exception as e:  # noqa: BLE001 - diagnostics must never raise
             logger.debug("Failed to get model capabilities for %r: %s", model_id, e)
-            fields = None
-
-        input_per_mtok, output_per_mtok, pricing_source = await _resolve_model_pricing(
-            provider, model_id
-        )
-        if fields is None:
-            result.append(
-                ModelDiagnostic(
-                    id=model_id,
-                    input_per_mtok=input_per_mtok,
-                    output_per_mtok=output_per_mtok,
-                    pricing_source=pricing_source,
-                )
-            )
-        else:
-            result.append(
-                ModelDiagnostic(
-                    id=model_id,
-                    input_per_mtok=input_per_mtok,
-                    output_per_mtok=output_per_mtok,
-                    pricing_source=pricing_source,
-                    **fields,
-                )
-            )
+            result.append(ModelDiagnostic(id=model_id, **pricing_fields))
     return result
 
 

--- a/src/conductor/providers/diagnostics.py
+++ b/src/conductor/providers/diagnostics.py
@@ -149,6 +149,14 @@ class ModelDiagnostic:
     max_prompt_tokens: int | None = None
     max_output_tokens: int | None = None
     max_context_window_tokens: int | None = None
+    input_per_mtok: float | None = None
+    output_per_mtok: float | None = None
+    pricing_source: str | None = None
+    """How ``input_per_mtok``/``output_per_mtok`` were resolved (see #386):
+    ``"provider"`` (live :meth:`~conductor.providers.base.AgentProvider.get_model_pricing`
+    hook), ``"table"`` (static ``DEFAULT_PRICING`` fallback), ``"none"``
+    (genuinely unpriced), or ``None`` (pricing resolution itself failed —
+    distinct from the determined ``"none"``)."""
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-safe representation."""
@@ -159,6 +167,9 @@ class ModelDiagnostic:
             "max_prompt_tokens": self.max_prompt_tokens,
             "max_output_tokens": self.max_output_tokens,
             "max_context_window_tokens": self.max_context_window_tokens,
+            "input_per_mtok": self.input_per_mtok,
+            "output_per_mtok": self.output_per_mtok,
+            "pricing_source": self.pricing_source,
         }
 
 
@@ -417,6 +428,44 @@ def gather_registries() -> RegistryDiagnostic:
     return RegistryDiagnostic(default=config.default, registries=registries)
 
 
+async def _resolve_model_pricing(
+    provider: Any, model_id: str
+) -> tuple[float | None, float | None, str | None]:
+    """Resolve a model's per-Mtok rates and where they came from (never raises).
+
+    Mirrors the cost-resolution chain in ``engine/pricing.py::get_pricing``
+    (workflow override → provider hook → ``DEFAULT_PRICING`` → ``None``),
+    minus the workflow override — ``doctor`` has no workflow context.
+
+    Note ``get_pricing`` may resolve via its versioned-suffix fuzzy path and
+    log a one-time warning (see #137); ``doctor`` already runs the whole
+    gather inside ``_suppressed_logging`` (``cli/doctor.py``), and the
+    process is short-lived, so the module-level fuzzy-match latch cannot
+    leak into a workflow run.
+
+    Returns:
+        A ``(input_per_mtok, output_per_mtok, source)`` tuple. ``source`` is
+        ``"provider"``, ``"table"``, or ``"none"`` when resolution completed
+        (with rates ``None`` in the ``"none"`` case), or ``None`` when
+        resolution itself failed — distinct from the determined ``"none"``.
+    """
+    try:
+        from conductor.engine.pricing import get_pricing
+
+        provider_pricing = await provider.get_model_pricing(model_id)
+        if provider_pricing is not None:
+            return provider_pricing.input_per_mtok, provider_pricing.output_per_mtok, "provider"
+
+        table_pricing = get_pricing(model_id)
+        if table_pricing is not None:
+            return table_pricing.input_per_mtok, table_pricing.output_per_mtok, "table"
+
+        return None, None, "none"
+    except Exception as e:  # noqa: BLE001 - diagnostics must never raise
+        logger.debug("Failed to resolve pricing for %r: %s", model_id, e)
+        return None, None, None
+
+
 async def _build_model_diagnostics(provider: Any, model_ids: list[str]) -> list[ModelDiagnostic]:
     """Build a :class:`ModelDiagnostic` per model id (never raises).
 
@@ -430,6 +479,10 @@ async def _build_model_diagnostics(provider: Any, model_ids: list[str]) -> list[
     ``ModelCapabilityInfo`` (or ``None``) must degrade only that one model,
     not raise out of the loop and silently discard every already-built
     entry for models processed earlier in this same list.
+
+    Pricing (see #386) is resolved independently via :func:`_resolve_model_pricing`
+    for every model, including one whose capabilities call failed — a
+    degraded capabilities row still gets its pricing columns.
     """
     result: list[ModelDiagnostic] = []
     for model_id in model_ids:
@@ -441,10 +494,32 @@ async def _build_model_diagnostics(provider: Any, model_ids: list[str]) -> list[
             # whose return value lacks to_dict() (or isn't None) is caught
             # below and degrades to id-only, same as any other failure.
             fields = caps.to_dict() if caps is not None else {}
-            result.append(ModelDiagnostic(id=model_id, **fields))
         except Exception as e:  # noqa: BLE001 - diagnostics must never raise
             logger.debug("Failed to get model capabilities for %r: %s", model_id, e)
-            result.append(ModelDiagnostic(id=model_id))
+            fields = None
+
+        input_per_mtok, output_per_mtok, pricing_source = await _resolve_model_pricing(
+            provider, model_id
+        )
+        if fields is None:
+            result.append(
+                ModelDiagnostic(
+                    id=model_id,
+                    input_per_mtok=input_per_mtok,
+                    output_per_mtok=output_per_mtok,
+                    pricing_source=pricing_source,
+                )
+            )
+        else:
+            result.append(
+                ModelDiagnostic(
+                    id=model_id,
+                    input_per_mtok=input_per_mtok,
+                    output_per_mtok=output_per_mtok,
+                    pricing_source=pricing_source,
+                    **fields,
+                )
+            )
     return result
 
 

--- a/tests/test_cli/test_doctor.py
+++ b/tests/test_cli/test_doctor.py
@@ -590,7 +590,117 @@ class TestDoctorFlags:
             "max_prompt_tokens": 128_000,
             "max_output_tokens": 64_000,
             "max_context_window_tokens": 192_000,
+            "input_per_mtok": None,
+            "output_per_mtok": None,
+            "pricing_source": None,
         }
+
+
+class TestDoctorModelsPricing:
+    """Tests for the pricing columns added to the Models detail table (#386)."""
+
+    def test_pricing_columns_render_in_detail_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[
+                        ModelDiagnostic(
+                            id="gpt-4o",
+                            input_per_mtok=2.50,
+                            output_per_mtok=10.00,
+                            pricing_source="table",
+                        )
+                    ],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        monkeypatch.setattr(_app_module, "output_console", Console(width=200))
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        model_lines = [line for line in result.output.splitlines() if "gpt-4o" in line]
+        assert model_lines, "model row not found in output"
+        assert "2.50" in model_lines[0]
+        assert "10.00" in model_lines[0]
+        assert "table" in model_lines[0]
+
+    def test_provider_source_renders(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[
+                        ModelDiagnostic(
+                            id="gpt-5.6-sol",
+                            input_per_mtok=2.00,
+                            output_per_mtok=8.00,
+                            pricing_source="provider",
+                        )
+                    ],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        monkeypatch.setattr(_app_module, "output_console", Console(width=200))
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        model_lines = [line for line in result.output.splitlines() if "gpt-5.6-sol" in line]
+        assert model_lines, "model row not found in output"
+        assert "provider" in model_lines[0]
+
+    def test_unpriced_model_renders_dash_not_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unpriced model must render `—`, never `0.00` — a zero would
+        read as "free", the exact silent-wrong-number bug #386 is about."""
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[ModelDiagnostic(id="grok-4.5", pricing_source="none")],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        monkeypatch.setattr(_app_module, "output_console", Console(width=200))
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        model_lines = [line for line in result.output.splitlines() if "grok-4.5" in line]
+        assert model_lines, "model row not found in output"
+        assert "0.00" not in model_lines[0]
+        assert "none" in model_lines[0]
+
+    def test_json_includes_pricing_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[
+                        ModelDiagnostic(
+                            id="gpt-4o",
+                            input_per_mtok=2.50,
+                            output_per_mtok=10.00,
+                            pricing_source="table",
+                        )
+                    ],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        result = runner.invoke(app, ["doctor", "--models", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        model = data["providers"][0]["models"][0]
+        assert model["input_per_mtok"] == 2.50
+        assert model["output_per_mtok"] == 10.00
+        assert model["pricing_source"] == "table"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_doctor.py
+++ b/tests/test_cli/test_doctor.py
@@ -675,6 +675,95 @@ class TestDoctorModelsPricing:
         assert "0.00" not in model_lines[0]
         assert "none" in model_lines[0]
 
+    def test_genuine_zero_rate_renders_as_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A genuinely free model (rate 0.0, distinct from unpriced ``None``)
+        must render `0.00`, not `—` — ``CopilotProvider.get_model_pricing``
+        returns exactly this for free models (see test_copilot.py)."""
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[
+                        ModelDiagnostic(
+                            id="free-model",
+                            input_per_mtok=0.0,
+                            output_per_mtok=0.0,
+                            pricing_source="provider",
+                        )
+                    ],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        monkeypatch.setattr(_app_module, "output_console", Console(width=200))
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        model_lines = [line for line in result.output.splitlines() if "free-model" in line]
+        assert model_lines, "model row not found in output"
+        assert "0.00" in model_lines[0]
+
+    def test_pricing_resolution_failure_renders_distinct_from_unpriced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``pricing_source=None`` (resolution itself failed) must render
+        distinctly from the determined ``"none"`` — both used to collapse
+        to the same `—` glyph the table uses for "provider doesn't expose
+        this", hiding a systemic pricing-hook break behind a boring-looking
+        row."""
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[ModelDiagnostic(id="broken-model", pricing_source=None)],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        monkeypatch.setattr(_app_module, "output_console", Console(width=200))
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        model_lines = [line for line in result.output.splitlines() if "broken-model" in line]
+        assert model_lines, "model row not found in output"
+        assert "error" in model_lines[0]
+
+    def test_degraded_capabilities_still_gets_pricing_columns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A model whose capabilities call failed (all capability fields
+        ``None``) must still render its independently-resolved pricing."""
+        report = DoctorReport(
+            providers=[
+                _prov(
+                    "copilot",
+                    checked=True,
+                    connection_ok=True,
+                    models=[
+                        ModelDiagnostic(
+                            id="gpt-4o",
+                            supported_reasoning_efforts=None,
+                            input_per_mtok=2.50,
+                            output_per_mtok=10.00,
+                            pricing_source="table",
+                        )
+                    ],
+                )
+            ]
+        )
+        _patch_gather(monkeypatch, report)
+        monkeypatch.setattr(_app_module, "output_console", Console(width=200))
+        result = runner.invoke(app, ["doctor", "--models"])
+        assert result.exit_code == 0
+        model_lines = [line for line in result.output.splitlines() if "gpt-4o" in line]
+        assert model_lines, "model row not found in output"
+        assert "n/a" in model_lines[0]
+        assert "2.50" in model_lines[0]
+        assert "10.00" in model_lines[0]
+        assert "table" in model_lines[0]
+
     def test_json_includes_pricing_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
         report = DoctorReport(
             providers=[

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -196,6 +196,54 @@ class TestGetPricing:
         assert pricing.output_per_mtok == output_per_mtok
 
 
+class TestGpt56Pricing:
+    """Tests for the GPT-5.6 pricing entries added in #386."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_warned(self) -> None:
+        """Clear the per-process warning de-dupe set between tests."""
+        from conductor.engine.pricing import _FUZZY_MATCH_WARNED
+
+        _FUZZY_MATCH_WARNED.clear()
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
+    def test_gpt_56_variants_priced_at_family_rate(self, model: str) -> None:
+        """Each GPT-5.6 id resolves via an exact key at the GPT-5.x family rate."""
+        pricing = get_pricing(model)
+        assert pricing is not None
+        assert pricing.input_per_mtok == 2.00
+        assert pricing.output_per_mtok == 8.00
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
+    def test_gpt_56_variants_do_not_fuzzy_warn(
+        self, model: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Exact keys resolve silently — pins the "explicit ids, not a prefix
+        key" decision so a later well-meaning `gpt-5.6` prefix key cannot
+        reintroduce a fuzzy-match warning for these ids without a test
+        failure calling it out."""
+        with caplog.at_level("WARNING", logger="conductor.engine.pricing"):
+            get_pricing(model)
+        assert caplog.records == []
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "grok-4.5",
+            "gemini-3.6-flash",
+            "mai-code-1.1-flash",
+            "mai-code-1-flash-picker",
+        ],
+    )
+    def test_unconfirmed_models_remain_unpriced(self, model: str) -> None:
+        """These ids are deliberately absent pending a published rate (#386).
+
+        Load-bearing regression guard: it stops a later fuzzy key silently
+        inventing rates for them.
+        """
+        assert get_pricing(model) is None
+
+
 class TestFuzzyMatchWarnings:
     """Tests for the fuzzy-match warning behavior (#137)."""
 

--- a/tests/test_providers/test_diagnostics.py
+++ b/tests/test_providers/test_diagnostics.py
@@ -504,6 +504,76 @@ class TestGatherProviderCheck:
         by_id = {m.id: m for m in diag.models}
         assert by_id["gpt-4"].supported_reasoning_efforts is None
 
+    async def test_to_dict_with_unexpected_key_degrades_to_id_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``to_dict()`` returning a key ``ModelDiagnostic`` doesn't accept
+        must degrade only that model — regression guard for a bug where
+        ``ModelDiagnostic(...)`` construction moved outside the per-model
+        try/except, so the resulting ``TypeError`` escaped the loop and
+        discarded every already-built entry for the whole provider."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["gpt-5", "gpt-4", "gpt-3"])
+        good_caps = SimpleNamespace(
+            to_dict=lambda: {"supported_reasoning_efforts": ["low", "medium"]}
+        )
+        bad_caps = SimpleNamespace(
+            to_dict=lambda: {
+                "supported_reasoning_efforts": ["low"],
+                "bogus_extra_key": 1,
+            }
+        )
+
+        def _capabilities_for(model_id: str) -> Any:
+            if model_id == "gpt-4":
+                return bad_caps
+            return good_caps
+
+        provider.get_model_capabilities.side_effect = _capabilities_for
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models_error is None
+        assert diag.models is not None
+        by_id = {m.id: m for m in diag.models}
+        assert set(by_id) == {"gpt-5", "gpt-4", "gpt-3"}
+        assert by_id["gpt-5"].supported_reasoning_efforts == ["low", "medium"]
+        assert by_id["gpt-3"].supported_reasoning_efforts == ["low", "medium"]
+        # The offending model degrades to id-only rather than the loop
+        # raising and discarding gpt-5/gpt-3.
+        assert by_id["gpt-4"].supported_reasoning_efforts is None
+
+    async def test_to_dict_colliding_with_pricing_key_degrades_to_id_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``to_dict()`` returning a key that collides with one of the
+        explicitly-passed pricing kwargs (``input_per_mtok``) must degrade
+        that model rather than raising
+        ``TypeError: got multiple values for keyword argument``."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["gpt-4o"])
+        colliding_caps = SimpleNamespace(to_dict=lambda: {"input_per_mtok": 1.0})
+        provider.get_model_capabilities.side_effect = lambda model_id: colliding_caps
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models_error is None
+        assert diag.models is not None
+        model = diag.models[0]
+        assert model.id == "gpt-4o"
+        assert model.supported_reasoning_efforts is None
+        # Pricing still resolves via the table for the degraded row.
+        assert model.pricing_source == "table"
+        assert model.input_per_mtok == 2.50
+
 
 class TestModelPricingDiagnostics:
     """Tests for per-model pricing resolution in ``--models`` (issue #386)."""
@@ -565,7 +635,11 @@ class TestModelPricingDiagnostics:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A raising get_model_pricing must not fail the whole --models
-        probe — the never-raise contract."""
+        probe — the never-raise contract. It also must not skip the
+        DEFAULT_PRICING fallback: gpt-4o is in the static table, so a
+        raising hook still resolves it via the table (matching what an
+        actual workflow run would price it at); only a model with no
+        table entry genuinely fails to resolve."""
         monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
         provider = _fake_provider(
             ok=True,
@@ -579,25 +653,34 @@ class TestModelPricingDiagnostics:
         diag = await d.gather_provider("copilot", list_models=True)
         assert diag.models is not None
         by_id = {m.id: m for m in diag.models}
-        # Both models degrade to "pricing resolution failed" since the hook
-        # itself raises for every call — pricing_source stays None (distinct
-        # from the determined "none"), and neither model is dropped.
+        # "gpt-5" has no DEFAULT_PRICING entry, so it genuinely fails to
+        # resolve — pricing_source stays None (distinct from "none").
         assert by_id["gpt-5"].pricing_source is None
         assert by_id["gpt-5"].input_per_mtok is None
-        assert by_id["gpt-4o"].pricing_source is None
-        assert by_id["gpt-4o"].input_per_mtok is None
+        # "gpt-4o" IS in DEFAULT_PRICING, so the raising hook must still
+        # fall through to the table rather than reporting unresolvable.
+        assert by_id["gpt-4o"].pricing_source == "table"
+        assert by_id["gpt-4o"].input_per_mtok == 2.50
+        assert by_id["gpt-4o"].output_per_mtok == 10.00
 
     async def test_hook_failure_isolated_to_one_model(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A failure resolving pricing for one model must not affect the
-        pricing already resolved for its neighbors in the same list."""
+        pricing already resolved for its neighbors in the same list. A
+        raising hook falls through to DEFAULT_PRICING when the model has an
+        entry there (gpt-4o), matching engine/workflow.py's handling of the
+        identical exception; only a model absent from the table (here
+        "totally-unknown-model-xyz") reaches the genuine failure state."""
         monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
-        provider = _fake_provider(ok=True, models=["gpt-4.1", "gpt-4o", "gpt-4"])
+        provider = _fake_provider(
+            ok=True,
+            models=["gpt-4.1", "gpt-4o", "gpt-4", "totally-unknown-model-xyz"],
+        )
 
         def _pricing_for(model_id: str) -> Any:
-            if model_id == "gpt-4o":
-                raise RuntimeError("pricing boom for gpt-4o only")
+            if model_id in ("gpt-4o", "totally-unknown-model-xyz"):
+                raise RuntimeError(f"pricing boom for {model_id} only")
             return None  # falls through to the static table for the others
 
         provider.get_model_pricing.side_effect = _pricing_for
@@ -610,8 +693,13 @@ class TestModelPricingDiagnostics:
         by_id = {m.id: m for m in diag.models}
         assert by_id["gpt-4.1"].pricing_source == "table"
         assert by_id["gpt-4"].pricing_source == "table"
-        assert by_id["gpt-4o"].pricing_source is None
-        assert by_id["gpt-4o"].input_per_mtok is None
+        # Raising hook still falls through to the table for a known model.
+        assert by_id["gpt-4o"].pricing_source == "table"
+        assert by_id["gpt-4o"].input_per_mtok == 2.50
+        assert by_id["gpt-4o"].output_per_mtok == 10.00
+        # No table entry either -> genuine failure, distinct from "none".
+        assert by_id["totally-unknown-model-xyz"].pricing_source is None
+        assert by_id["totally-unknown-model-xyz"].input_per_mtok is None
 
     async def test_to_dict_carries_pricing_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)

--- a/tests/test_providers/test_diagnostics.py
+++ b/tests/test_providers/test_diagnostics.py
@@ -257,6 +257,7 @@ def _fake_provider(
     models: list[str] | None = None,
     models_error: Exception | None = None,
     capabilities: dict[str, Any] | None = None,
+    pricing: dict[str, Any] | Exception | None = None,
 ) -> Any:
     """Build an AsyncMock provider for check/model probes.
 
@@ -264,6 +265,11 @@ def _fake_provider(
     (or ``None``) returned by ``get_model_capabilities`` for that id. Ids not
     present in the mapping (or when ``capabilities`` is omitted) resolve to
     ``None``, matching the base-hook default.
+
+    ``pricing`` maps model id -> a ``ModelPricing``-like object (or ``None``)
+    returned by ``get_model_pricing`` for that id (issue #386); omitted ids
+    resolve to ``None``, matching the base-hook default. Pass an
+    ``Exception`` instance to make every call raise it.
     """
     provider = AsyncMock()
     if validate_error is not None:
@@ -277,6 +283,11 @@ def _fake_provider(
     provider.close.return_value = None
     caps_map = capabilities or {}
     provider.get_model_capabilities.side_effect = lambda model_id: caps_map.get(model_id)
+    if isinstance(pricing, Exception):
+        provider.get_model_pricing.side_effect = pricing
+    else:
+        pricing_map = pricing or {}
+        provider.get_model_pricing.side_effect = lambda model_id: pricing_map.get(model_id)
     return provider
 
 
@@ -492,6 +503,129 @@ class TestGatherProviderCheck:
         assert [m.id for m in diag.models] == ["gpt-5", "gpt-4"]
         by_id = {m.id: m for m in diag.models}
         assert by_id["gpt-4"].supported_reasoning_efforts is None
+
+
+class TestModelPricingDiagnostics:
+    """Tests for per-model pricing resolution in ``--models`` (issue #386)."""
+
+    async def test_provider_hook_wins_over_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The provider hook beats DEFAULT_PRICING, proven with a model id
+        that is also in the static table at a different rate."""
+        from conductor.engine.pricing import ModelPricing
+
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        # "gpt-4o" is in DEFAULT_PRICING at 2.50 / 10.00 — the hook must win.
+        provider = _fake_provider(
+            ok=True,
+            models=["gpt-4o"],
+            pricing={"gpt-4o": ModelPricing(input_per_mtok=99.0, output_per_mtok=199.0)},
+        )
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        model = diag.models[0]
+        assert model.pricing_source == "provider"
+        assert model.input_per_mtok == 99.0
+        assert model.output_per_mtok == 199.0
+
+    async def test_falls_back_to_table_when_hook_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["gpt-4o"])  # hook returns None
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        model = diag.models[0]
+        assert model.pricing_source == "table"
+        assert model.input_per_mtok == 2.50
+        assert model.output_per_mtok == 10.00
+
+    async def test_unknown_model_reports_none_source(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["totally-unknown-model-xyz"])
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        model = diag.models[0]
+        assert model.pricing_source == "none"
+        assert model.input_per_mtok is None
+        assert model.output_per_mtok is None
+
+    async def test_hook_failure_degrades_only_that_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A raising get_model_pricing must not fail the whole --models
+        probe — the never-raise contract."""
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(
+            ok=True,
+            models=["gpt-5", "gpt-4o"],
+            pricing=RuntimeError("pricing boom"),
+        )
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        by_id = {m.id: m for m in diag.models}
+        # Both models degrade to "pricing resolution failed" since the hook
+        # itself raises for every call — pricing_source stays None (distinct
+        # from the determined "none"), and neither model is dropped.
+        assert by_id["gpt-5"].pricing_source is None
+        assert by_id["gpt-5"].input_per_mtok is None
+        assert by_id["gpt-4o"].pricing_source is None
+        assert by_id["gpt-4o"].input_per_mtok is None
+
+    async def test_hook_failure_isolated_to_one_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failure resolving pricing for one model must not affect the
+        pricing already resolved for its neighbors in the same list."""
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["gpt-4.1", "gpt-4o", "gpt-4"])
+
+        def _pricing_for(model_id: str) -> Any:
+            if model_id == "gpt-4o":
+                raise RuntimeError("pricing boom for gpt-4o only")
+            return None  # falls through to the static table for the others
+
+        provider.get_model_pricing.side_effect = _pricing_for
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        by_id = {m.id: m for m in diag.models}
+        assert by_id["gpt-4.1"].pricing_source == "table"
+        assert by_id["gpt-4"].pricing_source == "table"
+        assert by_id["gpt-4o"].pricing_source is None
+        assert by_id["gpt-4o"].input_per_mtok is None
+
+    async def test_to_dict_carries_pricing_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("conductor.providers.copilot.COPILOT_SDK_AVAILABLE", True)
+        provider = _fake_provider(ok=True, models=["gpt-4o"])
+        monkeypatch.setattr(
+            "conductor.providers.factory.create_provider",
+            AsyncMock(return_value=provider),
+        )
+        diag = await d.gather_provider("copilot", list_models=True)
+        assert diag.models is not None
+        model_dict = diag.models[0].to_dict()
+        assert model_dict["input_per_mtok"] == 2.50
+        assert model_dict["output_per_mtok"] == 10.00
+        assert model_dict["pricing_source"] == "table"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Resolve per-model input/output $/Mtok pricing in `conductor doctor --models` via the same chain used by `engine/pricing.py::get_pricing` (provider hook → DEFAULT_PRICING table → none)
- Label each model's `pricing_source` (provider/table/none) so an unpriced model is visible instead of silently treated as free
- Add DEFAULT_PRICING entries for GPT-5.6 variants at the existing GPT-5.x rate

Closes #386