### PR TITLE
chore(release): cut 0.1.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.28...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.29...HEAD)
+
+## [0.1.29](https://github.com/microsoft/conductor/compare/v0.1.28...v0.1.29) - 2026-08-13
 
 ### Security
 
@@ -31,8 +33,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   token. Read-only routes (`/api/state`, `/api/info`, `/api/logs`,
   `/api/gate-status`, `/api/files/*`, and the replay dashboard) remain
   unauthenticated, protected by Origin/Host only.
+- **Hardened the ACA agent runner's transport surface** (#396). The
+  experimental `aca` provider's in-container runner previously relied
+  entirely on the Azure session-gateway network boundary; it now adds four
+  independent layers, none individually load-bearing. The runner binds
+  `127.0.0.1` by default (the shipped container image sets
+  `ACA_RUNNER_HOST=0.0.0.0` explicitly, so a deployed pool is unaffected —
+  only a runner started by hand changes behaviour). An opt-in transport
+  token, `ACA_RUNNER_AUTH_TOKEN`, makes `/execute` require a matching
+  `X-Conductor-Runner-Token` header — checked before the inner Copilot
+  provider is constructed — and `401` otherwise; the host sends the header
+  automatically when the same value is set on its side. `GET /health` stays
+  unauthenticated (the image's own `HEALTHCHECK` sends no header) but now
+  reports `auth_required` and `auth_token_present`, letting the host warn
+  when a gateway is silently stripping the header or when only one side has
+  a token configured. The runner also rejects any `inner_provider_settings`
+  key outside `base_url` / `api_key` / `bearer_token` / `github_token`,
+  closing off `runtime_url` and `headers` injection, and
+  `ACA_RUNNER_ALLOWED_BASE_URLS` optionally restricts which BYOK `base_url`
+  values are accepted. See `docs/providers/aca.md#security`.
 
 ### Fixed
+
+- **A pathological gate or dialog prompt no longer stalls the event loop**
+  (#395). `linkify_markdown` — which runs on human-gate prompts, dialog
+  turns, and rendered agent prompts — degraded to quadratic time on inputs
+  containing long unterminated runs of backticks/tildes or `[` characters,
+  so agent-generated text could freeze every concurrent agent sharing the
+  loop. The fenced-code opener no longer backtracks character-by-character,
+  and existing-markdown-link detection is now a linear single-pass scanner
+  (fuzz-verified equivalent to the regex it replaces). A defensive 256K
+  character cap skips linkification entirely on anything larger — whitespace
+  is still normalized — so a future pathological shape degrades gracefully
+  rather than hanging.
 
 - **Token cost is no longer massively overstated for cached, tool-calling
   agents.** `AgentOutput.input_tokens` is the *whole* prompt and already

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.28"
+version = "0.1.29"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 0.1.29

Release-prep PR for **0.1.29** (previous tag: `v0.1.28`).

Bumps `[project].version` in `pyproject.toml`, finalizes the `[Unreleased]`
section of `CHANGELOG.md` into a versioned `0.1.29` section, and re-locks
`uv.lock`.

## Commit audit

All **6** commits in `v0.1.28..main` were audited; every one has an explicit
disposition.

| # | SHA | Subject | Closes | Class | Changelog |
|---|-----|---------|--------|-------|-----------|
| 1 | `3fd5f55` | fix(executor): quadratic backtracking in `linkify_markdown` (#423) | #395 | Fixed | **added here** |
| 2 | `3de3457` | fix(web): harden dashboard auth with Origin/Host validation and tokens (#424) | #397 | Security | already present |
| 3 | `d9299a9` | fix(aca): harden agent runner transport security (#426) | #396 | Security | **added here** |
| 4 | `cd33903` | docs(web): document Windows token-file permission behavior (#428) | #425 | Docs | folded into the #397 entry |
| 5 | `77d5126` | fix(pricing): stop billing cached tokens twice (#427) | — | Fixed | already present |
| 6 | `8f22e0a` | feat(doctor): surface model pricing source in doctor diagnostics (#429) | #386 | Added + Fixed | already present |

No entries were stale or inaccurate; nothing was omitted silently.

## Changelog summary

**Security**
- Hardened the web dashboard's HTTP/WebSocket surface (#397) — per-run token
  on every mutating route and the `/ws` handshake, `OriginHostGuard`
  Host/Origin validation, and a required `Content-Type: application/json`
  (breaking for external API callers).
- Hardened the ACA agent runner's transport surface (#396) — loopback-only
  default bind, opt-in `ACA_RUNNER_AUTH_TOKEN` gate on `/execute`, an
  `inner_provider_settings` key allowlist, and optional
  `ACA_RUNNER_ALLOWED_BASE_URLS`.

**Fixed**
- Token cost is no longer massively overstated for cached, tool-calling
  agents — cached buckets are subtracted from the input bucket before the
  input rate applies. **Review `limits.budget_usd` values**, which were
  calibrated against the inflated figures.
- A pathological gate or dialog prompt no longer stalls the event loop (#395).
- `claude-opus-5` and the dotted Claude 4.5 names are no longer unpriced.
- `gpt-5.6-sol` / `-terra` / `-luna` are no longer unpriced (#386).

**Added**
- `conductor doctor --models` now shows per-model pricing and its source
  (#386).

## Validation

All run from the release worktree at `chore/release-0.1.29`:

- `make check` — ruff check, ruff format --check, `ty check` — **passed**
- `make test` — **6402 passed, 39 skipped, 8 deselected**
- `make validate-examples` — **passed** (exit 0; no schema/example files
  changed in this range, run as insurance)
- `git diff --check` — clean
- `uv.lock` diff is exactly the `conductor-cli` project version

Diff is limited to `CHANGELOG.md`, `pyproject.toml`, and `uv.lock`.

## After merge

Merging this PR will be followed by pushing the `v0.1.29` tag at the merge
commit, which triggers `.github/workflows/release.yml` and creates the GitHub
Release with its artifacts. The release is not created manually.