### PR TITLE
chore(release): cut 0.1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.30...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.31...HEAD)
+
+## [0.1.31](https://github.com/microsoft/conductor/compare/v0.1.30...v0.1.31) - 2026-08-15
 
 ### Added
 
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scripts, `uv tool install`, or `conductor update`. Conductor ships no default
   mirror and never redirects package resolution on its own; the index is always
   user-supplied configuration.
+
 ### Fixed
 
 - **`--web-bg`/`resume --web-bg`: a failed run-record write no longer kills
@@ -90,7 +93,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (rejecting one this package does not declare, which uv would otherwise
   accept with a warning and a zero exit status), and `--no-preserve-extras` /
   `CONDUCTOR_INSTALL_NO_PRESERVE_EXTRAS` drops back to a bare install.
-
 - **Fleet Manager History no longer accumulates an entire retained event log
   into memory to build one entry** (#436). `_read_full_log` now streams
   parsed events one at a time instead of materializing them into a list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.30"
+version = "0.1.31"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.30"
+version = "0.1.31"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Cuts **0.1.31**. Previous release: **v0.1.30**.

## Commit audit

All **5** commits in `v0.1.30..main` were audited; every one has an explicit disposition.

| SHA | Subject | PR | Disposition |
| --- | --- | --- | --- |
| `0554517` | ci: give the test step room for the Fleet Manager's suite | #434 | Internal — CI `timeout-minutes` 10→20 and AST-parse caching in `test_markup_guards.py`; no user-visible change |
| `2a5cf86` | fix(fleet): stream history event logs instead of materializing full lists | #438 | `Fixed` — already in changelog (#436) |
| `d8ed6b2` | fix(fleet): don't kill a healthy `--web-bg` run on a run-record write failure | #440 | `Fixed` — already in changelog, 2 entries (#435) |
| `967e5f7` | fix(cli): resolve optional-extra install commands and preserve extras on upgrade | #442 | `Fixed` — already in changelog (#441) |
| `992931d` | feat(install): diagnose a blocked package index instead of retrying blindly | #439 | `Added` — already in changelog, 3 entries |

## Changelog

Every user-visible change was already recorded under `[Unreleased]`; nothing was added or removed on content grounds. This PR:

- promotes `[Unreleased]` to `## [0.1.31](.../compare/v0.1.30...v0.1.31) - 2026-08-15` and opens a fresh empty `[Unreleased]` section above it;
- fixes two formatting defects in the promoted section — a missing blank line before `### Fixed`, and a stray blank line between two `Fixed` items (repo style is no blank line between list items).

Release contents in brief:

**Added** — install scripts now classify a blocked package index and stop retrying into it (with the remedy named and the active index echoed, credentials redacted); an unreachable `github.com` is told apart from a blocked index; new README section *Installing behind a proxy or private package index*.

**Fixed** — a failed run-record write no longer kills a healthy `--web-bg` run (#435); the `run_id` format is defined once in `conductor.run_id` (#435); optional-extra install hints now print a command that works and upgrades preserve your extras (#441); Fleet Manager History streams event logs instead of holding a whole parsed log in memory (#436).

## Version and lockfile

- `pyproject.toml`: `0.1.30` → `0.1.31`
- `uv.lock`: regenerated with `uv lock`; the only change is the `conductor-cli` project version. No dependency changes.
- Diff is limited to `CHANGELOG.md`, `pyproject.toml`, `uv.lock`.

## Validation

Run in an isolated release worktree off `origin/main`:

- `make check` — ruff check, ruff format --check (410 files), `ty check src`: all clean
- `make test` — **7213 passed, 54 skipped, 14 deselected** in 4:57
- `make validate-examples` — all example workflows valid (not strictly required; no schema or example changes in range)
- `git diff --check` clean

## After merge

Merging this PR will be followed by tagging the merge commit `v0.1.31` and pushing it, which triggers [`.github/workflows/release.yml`](https://github.com/microsoft/conductor/blob/main/.github/workflows/release.yml) to build and publish the GitHub Release with its artifacts. No `gh release create` is run by hand.
