### PR TITLE
fix(fleet): stop the TUI freezing at a human gate

### DIFF
--- a/src/conductor/fleet/tui/screens/runs.py
+++ b/src/conductor/fleet/tui/screens/runs.py
@@ -29,6 +29,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
+from textual.timer import Timer
 from textual.widgets import DataTable, Header, Static
 
 from conductor.fleet.records import RunRecord, read_run_records
@@ -585,6 +586,11 @@ class RunsScreen(Screen):
         (E13 review round 1) -- ``action_resolve_gate`` is a non-exclusive
         ``@work`` method, so without this a rapid double-press could open
         two option modals / post two responses for the same gate."""
+        self._anim_timer: Timer | None = None
+        """The ~10fps animation timer, held so it can be paused while this
+        screen is not on top -- see :meth:`on_screen_suspend`. ``None``
+        when animations are disabled (``CONDUCTOR_FLEET_NO_ANIM``), so the
+        suspend/resume hooks no-op."""
 
     def action_quit(self) -> None:
         """Quit the app -- bound to ``q`` (Textual dispatches bindings to the
@@ -667,7 +673,66 @@ class RunsScreen(Screen):
             # animation wants ~10fps and rescanning the run-record
             # directory that often would be gratuitous I/O for the sake of
             # a spinner.
-            self.set_interval(FRAME_INTERVAL, self._tick)
+            self._anim_timer = self.set_interval(FRAME_INTERVAL, self._tick)
+
+    def on_screen_suspend(self) -> None:
+        """Pause the animation while another screen is on top.
+
+        A pushed screen does not stop this one's timers, and a screen that
+        is no longer on top is still *composited*: the compositor keeps
+        painting whatever shows through the screen above it, and for a
+        translucent ``ModalScreen`` -- the gate options dialog (``g``) and
+        the kill confirmation (``k``/``K``) -- that is the whole visible
+        area. So every animated repaint down here re-blends the screen
+        above it, at ~10fps, for a screen nobody is reading.
+
+        The user-visible cost is throughput, not frames: on one 160x45
+        terminal sitting at an open gate this was roughly 2.5x the escape
+        sequences and ~40% more CPU with the modal up than without it.
+        Absolute figures are machine- and emulator-specific and nothing
+        pins them, but the direction is structural -- and on a terminal
+        that cannot absorb the stream (over SSH, in a multiplexer, on a
+        slow emulator) keystrokes queue behind the redraw and the modal
+        appears frozen.
+
+        Note :attr:`~textual.screen.Screen.is_current` does **not** express
+        "on top" and cannot be used to gate this: it means *still being
+        composited*, which is exactly the state being paused here. Textual
+        relies on that meaning -- ``Screen._on_timer_update`` gates the
+        whole update cycle on it, which is why a covered screen keeps
+        repainting at all. Opacity is irrelevant: ``App._background_screens``
+        appends the screen below the top *before* testing the background
+        alpha, so ``is_current`` is ``True`` under an opaque screen too.
+        :attr:`~textual.screen.Screen.is_active` is the top-of-stack test,
+        and is what the guards in :meth:`_tick` and
+        :meth:`_update_gate_detail` use.
+        """
+        if self._anim_timer is not None:
+            self._anim_timer.pause()
+
+    def on_screen_resume(self) -> None:
+        """Restart the animation and repaint whatever went stale.
+
+        Resuming is deliberately done *before* the repaint: a raise out of
+        :meth:`_update_gate_detail` (``query_one`` can fail if the pane is
+        gone mid-teardown) would otherwise strand the timer paused, which
+        is a worse freeze than the one this fixes.
+
+        The repaint relies on ``App.pop_screen`` popping the stack *before*
+        posting ``ScreenResume``, since :meth:`_update_gate_detail` no-ops
+        unless this screen is already back on top. If that order ever
+        inverted, the pane would silently keep showing what it had under
+        the modal until the next ~2s poll.
+
+        This also fires once at startup, before anything has been
+        suspended -- and, because the splash is pushed over this screen
+        immediately, it can arrive while this screen is already covered.
+        That is why :meth:`_tick`'s guard is load-bearing rather than
+        decorative.
+        """
+        if self._anim_timer is not None:
+            self._anim_timer.resume()
+        self._update_gate_detail()
 
     def _tick(self) -> None:
         """Advance the animation clock and repaint only what moves.
@@ -677,6 +742,17 @@ class RunsScreen(Screen):
         each live row in place and re-renders the preview, which owns the
         one other moving thing (the score's live step).
         """
+        # This guard, not `on_screen_suspend`'s pause, is what actually
+        # stops frames landing on a covered screen. `App.push_screen`
+        # appends to the screen stack synchronously but *posts*
+        # `ScreenSuspend` as a message, and this callback is invoked
+        # straight from the timer's own asyncio task rather than queued
+        # behind that message -- so frames keep arriving until the pump
+        # drains, which is longest precisely when the pump is backed up,
+        # the failure this fix is about. The pause is hygiene on top: it
+        # stops a 10fps task waking for a screen nobody is reading.
+        if not self.is_active:
+            return
         self._frame += 1
         table = self.query_one(DataTable)
         if not table.display:
@@ -769,6 +845,11 @@ class RunsScreen(Screen):
             self._displayed_summaries = {}
             self._notifier.prune(set())
             self._update_summary_bar([])
+            # Hidden unconditionally rather than via the visibility-guarded
+            # repaint below: this branch already forces a relayout, and
+            # leaving the pane up would pair the "no runs" empty state with
+            # a preview still offering `g` for a run that is gone.
+            self.query_one("#preview-pane", Vertical).display = False
             self._update_gate_detail()
             return
 
@@ -903,7 +984,19 @@ class RunsScreen(Screen):
         selected run's gate) and on every cursor move
         (:meth:`on_data_table_row_highlighted`), since the selected row can
         change independently of a poll tick.
+
+        A no-op while another screen is on top -- repainting for a reader
+        who is looking at a modal costs a re-blend of that modal for
+        nothing (see :meth:`on_screen_suspend`). Note this defers the
+        footer's :meth:`_refresh_row_bindings` too, not just the pane, so
+        a gate closing under a modal can leave ``g`` advertised in the
+        footer showing through it. Both are recomputed from scratch on
+        every call, so the ~2s poll heals any staleness even if
+        :meth:`on_screen_resume` never fires; resume is the latency
+        optimisation on top of that.
         """
+        if not self.is_active:
+            return
         pane = self.query_one("#preview-pane", Vertical)
         panel = self.query_one("#run-preview", Static)
 

--- a/src/conductor/fleet/tui/screens/splash.py
+++ b/src/conductor/fleet/tui/screens/splash.py
@@ -90,9 +90,15 @@ class SplashScreen(Screen[None]):
             tag.update("")
 
     def _dismiss(self) -> None:
-        # Guarded: the timer and a keypress race, and popping a screen that
-        # is already gone raises.
-        if self.is_current:
+        # `is_active`, not `is_current`: this pops whatever is on top, so it
+        # must only fire while *this* screen is what's on top. `is_current`
+        # means "still being composited", which stays true for a covered
+        # screen -- so a splash covered at the moment its timer fired would
+        # have popped the thing covering it. It also still guards the race
+        # this was written for (the timer and a keypress both dismiss, and
+        # popping an already-popped screen raises), since a popped screen is
+        # neither active nor current.
+        if self.is_active:
             self.app.pop_screen()
 
     def on_key(self) -> None:

--- a/tests/test_fleet/test_tui_runs.py
+++ b/tests/test_fleet/test_tui_runs.py
@@ -24,6 +24,9 @@ from textual.widgets import DataTable, Footer, Static
 
 from conductor.cli import pid as cli_pid
 from conductor.fleet.records import RunRecord, write_run_record
+from conductor.fleet.summary import GateInfo
+from conductor.fleet.tui.actions import GateOptionsModal
+from conductor.fleet.tui.anim import FRAME_INTERVAL
 from conductor.fleet.tui.app import FleetApp
 from conductor.fleet.tui.screens.runs import RunsScreen
 
@@ -105,6 +108,11 @@ async def _rendered_footer(pilot: Any, app: FleetApp) -> str:
             return line
         await pilot.pause()
     return _footer_line(app)
+
+
+def _gate_info(prompt: str = "Approve?") -> GateInfo:
+    """A minimal open gate, for pushing the options modal directly."""
+    return GateInfo(agent_name="ask", prompt=prompt, options=["yes", "no"], option_details=[])
 
 
 def _write_record(
@@ -1002,7 +1010,6 @@ class TestChainedGateResolution:
     async def test_next_question_is_presented_automatically(
         self, fleet_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from conductor.fleet.summary import GateInfo
         from conductor.fleet.tui.actions import GateResolveOutcome
 
         log = tmp_path / "q.events.jsonl"
@@ -1087,3 +1094,224 @@ class TestChainedGateResolution:
                 await asyncio.sleep(0.05)
 
         assert calls == ["Q1?"]
+
+
+class TestRunsScreenPausesWhileNotOnTop:
+    """The Runs screen must stop animating while another screen covers it.
+
+    This is the gate freeze: a covered screen is still composited, so its
+    ~10fps repaints keep re-blending whatever sits on top of it until the
+    terminal cannot absorb the stream and keystrokes queue behind the
+    redraw. The mechanism, the measurements, and why
+    ``Screen.is_current`` cannot express the condition are recorded on
+    :meth:`~conductor.fleet.tui.screens.runs.RunsScreen.on_screen_suspend`
+    rather than repeated here.
+
+    Three independent mechanisms, one test each: the guard in ``_tick``
+    (which covers the window before the pause lands), the guard in
+    ``_update_gate_detail`` (which covers the ~2s poll, deliberately left
+    running), and the timer pause itself. Plus the two things that must
+    keep working while covered: the poll's notifications, and the repaint
+    on resume.
+    """
+
+    @staticmethod
+    def _seed_gated_run(tmp_path: Path) -> None:
+        """One live run sitting at an open gate -- what these tests start from."""
+        log = _write_events(
+            tmp_path / "gate.events.jsonl",
+            [
+                _event("workflow_started", {"workflow_name": "wf"}),
+                _event("agent_started", {"agent_name": "ask"}),
+                _event(
+                    "gate_presented",
+                    {"agent_name": "ask", "prompt": "Approve?", "options": ["yes", "no"]},
+                ),
+            ],
+        )
+        _write_record(tmp_path, "run-gate", workflow_name="wf", event_log_path=str(log))
+
+    async def test_tick_is_a_noop_while_a_modal_is_on_top(
+        self, fleet_env: Path, tmp_path: Path
+    ) -> None:
+        """``push_screen`` appends to the stack synchronously but *posts*
+        ``ScreenSuspend``, and the timer invokes ``_tick`` from its own
+        task rather than through the message pump -- so frames keep
+        arriving until the pump drains. This guard, not the pause, is what
+        stops them."""
+        self._seed_gated_run(tmp_path)
+
+        app = FleetApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, RunsScreen)
+
+            screen._tick()
+            assert screen._frame == 1, "the animation clock advances while on top"
+
+            app.push_screen(GateOptionsModal(_gate_info()))
+            await pilot.pause()
+
+            screen._tick()
+            screen._tick()
+            assert screen._frame == 1, "the animation clock must not advance under a modal"
+
+            app.pop_screen()
+            await pilot.pause()
+
+            screen._tick()
+            assert screen._frame == 2, "the animation clock resumes once the modal is dismissed"
+
+    async def test_preview_is_not_repainted_while_a_modal_is_on_top(
+        self, fleet_env: Path, tmp_path: Path
+    ) -> None:
+        """The ~2s data poll keeps running under a modal (see
+        :meth:`test_the_poll_keeps_running_under_a_modal`), so the guard
+        that stops it repainting has to live in ``_update_gate_detail``
+        itself rather than in the poll."""
+        self._seed_gated_run(tmp_path)
+
+        app = FleetApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, RunsScreen)
+            panel = screen.query_one("#run-preview", Static)
+
+            app.push_screen(GateOptionsModal(_gate_info()))
+            await pilot.pause()
+
+            with patch.object(panel, "update", wraps=panel.update) as painted:
+                screen.refresh_runs()
+                screen._update_gate_detail()
+                # Drained inside the suspended window so any message the
+                # rebuild queued (`table.clear()` emits `RowHighlighted`) is
+                # dispatched here, while the guard still rejects it, rather
+                # than landing after the pop and being mistaken for the
+                # resume repaint.
+                await pilot.pause()
+                assert painted.call_count == 0
+
+    async def test_resume_repaints_what_went_stale(self, fleet_env: Path, tmp_path: Path) -> None:
+        """``on_screen_resume``'s repaint is what makes the guard above safe.
+
+        Asserted against an **empty** fleet on purpose: with no rows there
+        is no ``DataTable.RowHighlighted`` on resume, so ``on_screen_resume``
+        is provably the only caller that can repaint. With a populated
+        table the focus-regain message repaints too, and a call-count
+        assertion passes even if this handler's repaint is deleted.
+        """
+        app = FleetApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, RunsScreen)
+            panel = screen.query_one("#run-preview", Static)
+
+            app.push_screen(GateOptionsModal(_gate_info()))
+            await pilot.pause()
+
+            with patch.object(panel, "update", wraps=panel.update) as painted:
+                await pilot.pause()
+                assert painted.call_count == 0, "nothing repaints while covered"
+
+                app.pop_screen()
+                await pilot.pause()
+                assert painted.call_count >= 1, "resuming repaints whatever went stale"
+
+    async def test_the_poll_keeps_running_under_a_modal(
+        self, fleet_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only the *render* is suppressed while covered, never the poll.
+
+        The obvious next optimisation -- returning early from
+        ``refresh_runs`` too -- would silently stop gate-entry and
+        run-failure notifications at exactly the moment the operator is
+        sitting inside a gate modal, with every other test still green.
+        """
+        notified: list[str] = []
+        monkeypatch.setattr(
+            "conductor.fleet.tui.screens.runs.emit_terminal_notification",
+            lambda app, message: notified.append(message),
+        )
+
+        app = FleetApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, RunsScreen)
+
+            app.push_screen(GateOptionsModal(_gate_info()))
+            await pilot.pause()
+
+            # The run reaches its gate *while* the modal is up.
+            self._seed_gated_run(tmp_path)
+            screen.refresh_runs()
+
+            assert notified == ["wf: waiting at gate (ask)"]
+
+    async def test_the_animation_timer_is_paused_and_resumed(
+        self, fleet_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The timer itself must stop, not merely its repaints.
+
+        Asserted by counting *invocations* of ``_tick`` rather than the
+        frames it produces. ``_tick``'s own guard already stops the frames,
+        so a frame-counting assertion holds whether or not the timer was
+        ever paused -- only an invocation count separates "paused" (never
+        called) from "called, returned early", which is the difference
+        between waking the event loop 10x a second for a covered screen
+        and leaving it alone.
+        """
+        monkeypatch.delenv("CONDUCTOR_FLEET_NO_ANIM", raising=False)
+        self._seed_gated_run(tmp_path)
+
+        ticks: list[int] = []
+        original_tick = RunsScreen._tick
+
+        def _counting_tick(screen: RunsScreen) -> None:
+            ticks.append(1)
+            original_tick(screen)
+
+        monkeypatch.setattr(RunsScreen, "_tick", _counting_tick)
+
+        app = FleetApp()
+        async with app.run_test() as pilot:
+            # Animation is on, so the splash is pushed over the Runs screen.
+            await pilot.pause()
+            # The timer is created by `on_mount` and must already be paused
+            # under the splash -- the launch-time case of the same bug.
+            runs = next(s for s in app.screen_stack if isinstance(s, RunsScreen))
+            assert runs._anim_timer is not None
+            ticks.clear()
+            await asyncio.sleep(FRAME_INTERVAL * 4)
+            assert ticks == [], "the timer must not fire while the splash covers the fleet"
+
+            await pilot.press("x")
+            for _ in range(40):
+                await pilot.pause()
+                if isinstance(app.screen, RunsScreen):
+                    break
+                await asyncio.sleep(0.05)
+            screen = app.screen
+            assert isinstance(screen, RunsScreen)
+
+            ticks.clear()
+            await asyncio.sleep(FRAME_INTERVAL * 4)
+            await pilot.pause()
+            assert ticks, "the timer fires while the Runs screen is on top"
+
+            app.push_screen(GateOptionsModal(_gate_info()))
+            await pilot.pause()
+            ticks.clear()
+            await asyncio.sleep(FRAME_INTERVAL * 6)
+            await pilot.pause()
+            assert ticks == [], "the timer must not fire at all under the gate modal"
+
+            app.pop_screen()
+            await pilot.pause()
+            ticks.clear()
+            await asyncio.sleep(FRAME_INTERVAL * 4)
+            await pilot.pause()
+            assert ticks, "the timer fires again once the gate is answered"

--- a/tests/test_fleet/test_tui_splash.py
+++ b/tests/test_fleet/test_tui_splash.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from textual.screen import ModalScreen
 
 from conductor.fleet.tui.app import FleetApp
 from conductor.fleet.tui.screens.runs import RunsScreen
@@ -113,3 +114,30 @@ class TestSplash:
         async with app.run_test() as pilot:
             await pilot.pause()
             assert isinstance(app.screen, RunsScreen)
+
+    async def test_dismissing_never_pops_a_screen_it_does_not_own(self) -> None:
+        """`_dismiss` pops whatever is on top, so it must only fire while the
+        splash *is* what's on top.
+
+        Nothing covers the splash today, so this is a guard on the guard: it
+        pins the predicate rather than a reachable path. `Screen.is_current`
+        would satisfy the check here -- it means "still being composited",
+        which stays true underneath a translucent screen -- and the splash
+        would then pop the screen covering it instead of itself.
+        """
+        app = FleetApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            splash = app.screen
+            assert isinstance(splash, SplashScreen)
+
+            cover: ModalScreen[None] = ModalScreen()
+            app.push_screen(cover)
+            await pilot.pause()
+            assert splash.is_current, "the splash is still composited under the modal"
+
+            splash._dismiss()
+            await pilot.pause()
+
+            assert app.screen is cover, "the covering screen must not be popped"
+            assert splash in app.screen_stack, "the splash must not have dismissed itself"


### PR DESCRIPTION
## The bug

Opening the gate options modal (`g`) in `conductor fleet` sometimes made the TUI stop responding.

## Cause

The Runs screen kept animating underneath the modal. Pushing a screen in Textual does not stop the covered screen's timers, and a covered screen is still *composited* — so its ~10fps repaints kept re-blending the modal sitting on top of it.

Measured on a synthetic gated run (one live run, 60 KB gate prompt):

| Terminal | State | CPU | Escape sequences |
|---|---|---|---|
| 160x45 | Runs screen, no modal | 46% | 150 KB/s |
| 160x45 | **gate modal open (before)** | **64%** | **370 KB/s** |
| 160x45 | gate modal open (after) | 1.4% | 15.5 KB/s |
| 240x70 | **gate modal open (before)** | **71%** | **551 KB/s** |
| 240x70 | gate modal open (after) | 3.4% | 27 KB/s |

Absolute figures are machine- and emulator-specific, but the direction is structural. On a terminal that cannot absorb that stream — over SSH, in a multiplexer, on a slow emulator — keystrokes queue behind the redraw and the modal appears frozen.

## The fix

Guard `_tick` and `_update_gate_detail` on `Screen.is_active`, and hold the animation timer so it can be paused on `ScreenSuspend` and restarted on `ScreenResume`.

**The guards are the load-bearing half, not the pause.** `App.push_screen` appends to the screen stack synchronously but *posts* `ScreenSuspend` as a message, and the timer invokes its callback from its own asyncio task rather than through the screen's message pump — so frames keep arriving until the pump drains, which takes longest exactly when the pump is backed up. That is the failure being fixed. The pause is what stops a 10fps task waking for a screen nobody is reading.

`Screen.is_current` cannot express this condition: it means *still being composited*, which is the state being suppressed — Textual gates its whole update cycle on it, which is why a covered screen repaints at all. Opacity is irrelevant, since `App._background_screens` appends the screen below the top *before* testing background alpha, so it is `True` under an opaque screen too.

Two deliberate non-changes:

- The ~2s data poll keeps running while covered, so gate-entry and run-failure terminal-bell notifications still fire when the operator is sitting inside a gate modal. Only the render is suppressed. This is now pinned by a test, because the obvious next optimization would silently break it.
- The preview pane is hidden unconditionally on the empty-fleet branch, which otherwise paired the "no runs" empty state with a preview still offering `g` for a run that had gone.

This also stops the screen animating under the splash at launch, and under the run-detail, history, providers, registries, and new-run screens.

## Tests

Five tests, one per mechanism. All seven mutations below are killed:

| Mutation | Result |
|---|---|
| Delete `_tick` guard | killed |
| Delete `_update_gate_detail` guard | killed |
| `is_active` → `is_current` (either guard) | killed |
| Delete the timer pause | killed |
| Delete `on_screen_resume`'s repaint | killed |
| Guard `refresh_runs` too (would kill notifications) | killed |

Two details worth knowing, both found in review:

- The timer test counts `_tick` **invocations**, not frames. `_tick`'s own guard already stops the frames, so a frame-counting assertion holds whether or not the timer was ever paused — only an invocation count separates "paused" from "called, returned early".
- The resume-repaint test runs against an **empty** fleet on purpose. With rows present, `DataTable.RowHighlighted` repaints on focus regain and a call-count assertion passes even when the handler's repaint is deleted.

`ruff check`, `ruff format --check`, `ty check` clean; `tests/test_fleet/` + `tests/test_cli/test_markup_guards.py` = 650 passed.

## Second commit: the same misreading on the splash

`SplashScreen._dismiss` pops whatever is on top, so it must only fire while the splash itself is on top. It guarded on `is_current`, which stays true for a covered screen — so a splash covered at the moment its self-dismiss timer fired would have popped the screen covering it instead of itself.

Not reachable today (nothing is pushed over the splash), so its test is a guard on the guard: it pins the predicate rather than a reachable path. Reverting to `is_current` fails it, with the splash left on top and the modal popped.

Fixed here rather than left alone because it is the identical misreading, and the distinction is in view.

## Notes

No existing issue covers this. #437 is a different fleet TUI performance problem (blocking I/O on the event loop).

Reviewed with the `code-review` skill (7 agents). Findings addressed before this PR was opened, including replacing a hand-rolled `_is_on_top` property that reimplemented `Screen.is_active` with a narrower `except` clause.
