### PR TITLE
chore(release): cut 0.1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.31...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.32...HEAD)
+
+## [0.1.32](https://github.com/microsoft/conductor/compare/v0.1.31...v0.1.32) - 2026-08-16
 
 ### Fixed
 
@@ -54,6 +56,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wording seen alongside the conflict is fixed too — the foreign pid is now
   captured before the child is terminated instead of probed after, when it
   can no longer answer.
+
+- **The Fleet Manager TUI no longer appears to freeze while a modal is
+  open** (#448). Opening the gate options modal (`g`) left the Runs screen
+  animating underneath it — a covered screen is still composited, so its
+  ~10fps repaints kept re-blending the modal sitting on top. Measured on
+  one 160x45 terminal at an open gate, that was roughly 2.5x the escape
+  sequences and ~40% more CPU than the same screen with no modal up. On a
+  terminal that cannot absorb that stream — over SSH, in a multiplexer, on
+  a slow emulator — keystrokes queued behind the redraw and the modal
+  appeared frozen. The animation is now suppressed while a screen is
+  covered and its timer paused, which also stops the Runs screen animating
+  under the splash, run-detail, history, providers, registries, and new-run
+  screens. The ~2s data poll is deliberately left running, so gate-entry
+  and run-failure notifications still fire while a modal is up. The
+  empty-fleet state also no longer pairs "no runs" with a preview pane
+  still offering `g` for a run that had gone.
+
+- **The Fleet Manager TUI's kill confirmation prompt is no longer an empty
+  red box** (#449). `#confirm-dialog` had `width: auto` while both of its
+  children fell back to Textual's base `1fr`, and an auto-width container
+  whose children are all `1fr` resolves to zero — so the dialog collapsed
+  to 0x0 and painted nothing but its border, leaving `k` looking like a
+  broken no-op with no way to see what was about to be killed. The dialog
+  now has a fixed width (capped at 90% of the terminal so it still fits a
+  narrow one), its message scrolls instead of overflowing or being silently
+  truncated, and the confirm/cancel hint is docked to the bottom so a long
+  message cannot push it off screen.
 
 - **Fleet Manager TUI no longer blocks the Textual event loop on the Runs
   screen's ~2s poll, the run-detail screen's poll, History's initial load,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.31"
+version = "0.1.32"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.31"
+version = "0.1.32"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 0.1.32

Cuts release **v0.1.32** (previous release: `v0.1.31`).

## Commit audit

All **5** commits in `v0.1.31..main` were audited; every one has an explicit disposition.

| Commit | PR | Issue | Class | Changelog |
|---|---|---|---|---|
| `c436ab9` fix(cli): stop `--web-bg` false-flagging port conflicts on trampoline re-exec | #445 | #444 | Fixed | already present |
| `97f96b4` fix(fleet): stop the TUI freezing at a human gate | #448 | — | Fixed | **added here** |
| `406cc96` fix(fleet): move Fleet Manager TUI blocking I/O off the Textual event loop | #446 | #437 | Fixed | already present (2 entries) |
| `193cb48` fix(cli): terminate whole `--web-bg` process tree on launch-gate failure | #450 | #447 | Fixed | already present |
| `80d16cd` fix(fleet-tui): fix empty kill confirmation modal box | #451 | #449 | Fixed | **added here** |

No `Added`, `Changed`, or `Removed` entries this cycle — 0.1.32 is a pure fix release. The `web-bg-smoke` CI job added by #450 and the `AGENTS.md`/docs updates carried by #445, #446 and #450 are internal and correctly not called out separately.

The splash-screen `is_current` → `is_active` correction in #448 is deliberately **not** in the changelog: its own commit message records it as unreachable today (nothing is pushed over the splash), so it is hardening rather than a user-visible fix.

## Changelog summary

`[Unreleased]` finalized as `[0.1.32] - 2026-08-16` with a fresh empty `[Unreleased]` above it. Six `Fixed` entries:

- `--web-bg` launch gate now terminates the whole workflow process tree (#447)
- `--web-bg` no longer fails on every port with a false "Port already in use" (#444)
- Fleet Manager TUI no longer appears to freeze while a modal is open (#448) — *new*
- Fleet Manager TUI's kill confirmation prompt is no longer an empty red box (#449) — *new*
- Fleet Manager TUI no longer blocks the Textual event loop (#437)
- Fleet Manager TUI now reports runs it cannot read instead of a false empty state (#437 review)

## Validation

| Gate | Result |
|---|---|
| `make check` (ruff check, ruff format --check, ty) | passed |
| `make test` | passed — 7297 passed, 54 skipped, 14 deselected |

`make validate-examples` was not required: no `examples/` or `config/schema.py` changes in the release range.

## Diff scope

Only `CHANGELOG.md`, `pyproject.toml`, and `uv.lock`. `uv.lock` contains only the `conductor-cli` project-version change (`0.1.31` → `0.1.32`); no dependency movement.

## After merge

Merging this PR will be followed by pushing the `v0.1.32` tag at the squash-merge commit, which triggers [`release.yml`](https://github.com/microsoft/conductor/blob/main/.github/workflows/release.yml) to build and publish the GitHub Release with its artifacts.
