### PR TITLE
fix(engine): stop non-LLM steps constructing a provider for a context window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,9 +333,13 @@ jobs:
     # mocking the spawn seam, as the unit tests do, cannot. Runs on Windows
     # (where the trampoline actually happens) and Ubuntu (parity sanity
     # check). `examples/wait-smoke.yaml` needs no provider and caps itself
-    # at `timeout_seconds: 3`, so the run completes well inside the launch
+    # at `timeout_seconds: 15`, so the run completes well inside the launch
     # gate's own window and the assertion is on the *launcher*'s output,
-    # not on workflow correctness.
+    # not on workflow correctness. That cap is deliberately far above the
+    # ~1s the fixture actually waits: a child that fails its *own* workflow
+    # timeout exits non-zero, which the launch gate reports as a launch
+    # failure, so a cap tight enough for a cold Windows runner to miss
+    # would fail this job for a reason it does not test.
     runs-on: ${{ matrix.os }}
     needs: [lint]
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged, so that combination still warns. Workflows that set `max_bytes`
   explicitly are unaffected.
 
+- **`examples/wait-smoke.yaml` now caps itself at `timeout_seconds: 15`,
+  up from `3`.** It doubles as CI's `--web-bg` launcher smoke fixture, and a
+  cold Windows runner spends seconds of that budget on process and step
+  overhead — so a cap sized for the ~1s the workflow actually waits reported
+  a slow runner as a launcher failure. The timeout path it demonstrates is
+  unchanged; drive it with a larger `--input middle_duration_ms`.
+
+### Fixed
+
+- **A step with no model no longer constructs a provider just to report a
+  context window.** Every step type emitted `agent_started` with a
+  `context_window_max` resolved through the provider, and the registry builds
+  providers lazily — so a `wait`, `set`, `script`, `terminate`, or
+  `human_gate` step built an SDK client whose only possible answer was
+  `None`. That construction runs inside the engine's timed loop, so it was
+  charged to `limits.timeout_seconds`: a provider-free wait workflow paid
+  ~0.4s of it locally and enough on a cold Windows CI runner to time the
+  workflow out and fail the `--web-bg` launcher smoke job. Provider-backed
+  agents are unaffected — they still report the window on both
+  `agent_started` and `agent_completed`.
+
 ## [0.1.32](https://github.com/microsoft/conductor/compare/v0.1.31...v0.1.32) - 2026-08-16
 
 ### Fixed

--- a/examples/README.md
+++ b/examples/README.md
@@ -298,7 +298,7 @@ conductor run examples/wait-smoke.yaml
 conductor run examples/wait-smoke.yaml --web
 
 # Trigger the workflow timeout cancelling an in-flight wait:
-conductor run examples/wait-smoke.yaml --input middle_duration_ms=10000
+conductor run examples/wait-smoke.yaml --input middle_duration_ms=30000
 ```
 
 ## Planning and Implementation

--- a/examples/wait-smoke.yaml
+++ b/examples/wait-smoke.yaml
@@ -27,7 +27,7 @@
 #
 #   # Watch the workflow timeout cancel an in-flight wait:
 #   conductor run examples/wait-smoke.yaml --input middle_duration_ms=30000
-#   # → workflow.limits.timeout_seconds (3) fires before middle finishes.
+#   # → workflow.limits.timeout_seconds (15) fires before middle finishes.
 
 workflow:
   name: wait-smoke
@@ -52,7 +52,13 @@ workflow:
     # If the templated middle_duration_ms is set very high, the workflow
     # timeout will fire and cancel the in-flight wait — useful for
     # exercising the timeout path.
-    timeout_seconds: 3
+    #
+    # Deliberately generous relative to the ~1s of default waiting: this
+    # file is also CI's `--web-bg` launcher smoke fixture, and a cold
+    # Windows runner spends multiple seconds on process and step overhead
+    # inside this budget. A cap tight enough to fail there would report a
+    # slow runner as a launcher bug.
+    timeout_seconds: 15
 
 agents:
   # Suffixed string duration — the most common form.

--- a/src/conductor/engine/workflow.py
+++ b/src/conductor/engine/workflow.py
@@ -4463,12 +4463,23 @@ class WorkflowEngine:
                             else agent
                         )
 
+                        # Only an LLM agent has a context window to report, and
+                        # asking for one *constructs the provider* — an SDK
+                        # client build charged to `limits.timeout_seconds`,
+                        # since this runs inside the timed loop. A wait / set /
+                        # script / terminate / human_gate / workflow step has no
+                        # model, so that cost bought a guaranteed ``None``: it
+                        # made a provider-free workflow spawn a provider anyway
+                        # and, on a cold Windows runner, spent seconds of the
+                        # workflow's own timeout budget doing it.
                         started_payload: dict[str, Any] = {
                             "agent_name": agent.name,
                             "iteration": agent_execution_count,
                             "agent_type": agent.type or "agent",
-                            "context_window_max": await self._get_context_window_for_agent(
-                                resolved_agent
+                            "context_window_max": (
+                                await self._get_context_window_for_agent(resolved_agent)
+                                if is_llm_agent
+                                else None
                             ),
                         }
                         if is_llm_agent:

--- a/tests/test_engine/test_context_window_events.py
+++ b/tests/test_engine/test_context_window_events.py
@@ -26,6 +26,7 @@ from conductor.config.schema import (
 from conductor.engine.workflow import WorkflowEngine
 from conductor.events import WorkflowEvent, WorkflowEventEmitter
 from conductor.providers.copilot import CopilotProvider
+from conductor.providers.registry import ProviderRegistry
 
 
 class EventCollector:
@@ -763,3 +764,57 @@ class TestContextWindowResolutionOrder:
 
         # output.model returned None; chain fell back to agent.model.
         assert collector.first("agent_completed").data["context_window_max"] == 200_000
+
+
+class TestNonLlmStepsSkipTheProviderLookup:
+    """A step with no model must not resolve a provider to report a window.
+
+    ``_get_context_window_for_agent`` resolves the provider, and the
+    registry builds it lazily on first use -- so asking on behalf of a
+    ``wait`` / ``set`` / ``script`` / ``terminate`` step constructed an SDK
+    client whose only possible answer was ``None``. That construction runs
+    inside the engine's timed loop, so it is charged to
+    ``limits.timeout_seconds``: on a cold Windows CI runner it consumed
+    enough of a provider-free wait workflow's budget to time the workflow
+    out and fail the ``--web-bg`` launcher smoke job.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_wait_step_never_resolves_a_provider(self) -> None:
+        emitter, collector = _make_emitter_and_collector()
+        config = WorkflowConfig(
+            workflow=WorkflowDef(
+                name="test",
+                entry_point="pause",
+                runtime=RuntimeConfig(provider="copilot"),
+                context=ContextConfig(mode="accumulate"),
+                limits=LimitsConfig(max_iterations=5),
+            ),
+            agents=[
+                AgentDef(
+                    name="pause",
+                    type="wait",
+                    duration="1ms",
+                    routes=[RouteDef(to="$end")],
+                ),
+            ],
+            output={"waited": "{{ pause.output.waited_seconds }}"},
+        )
+
+        registry = ProviderRegistry(config)
+        resolved: list[str] = []
+
+        async def spy_get_provider(agent: AgentDef) -> None:
+            # Records rather than builds: constructing the real provider is
+            # the cost under test, and ``None`` is the documented "metadata
+            # unavailable" answer callers already handle.
+            resolved.append(agent.name)
+            return None
+
+        registry.get_provider = spy_get_provider  # type: ignore[method-assign]
+
+        engine = WorkflowEngine(config, registry=registry, event_emitter=emitter)
+        await engine.run({})
+
+        assert resolved == []
+        assert collector.first("agent_started").data["context_window_max"] is None

--- a/tests/test_fleet/test_tui_runs.py
+++ b/tests/test_fleet/test_tui_runs.py
@@ -69,6 +69,35 @@ def fleet_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
+async def _assert_guard_released(pilot: Any, screen: RunsScreen, *, timeout: float = 5.0) -> None:
+    """Assert ``_refreshing`` *clears*, rather than sampling it once.
+
+    The guard-recovery tests shrink ``POLL_INTERVAL_SECONDS`` so a later
+    tick can be observed unattended, which means the flag legitimately
+    flips back to ``True`` every interval -- including during ``settle()``'s
+    trailing ``pilot.pause()``, where a tick can dispatch a fresh refresh
+    between the last worker finishing and the assertion reading the flag.
+    A single-instant ``assert screen._refreshing is False`` therefore fails
+    at random (it did, on CI and ~20% of local runs) for a reason that has
+    nothing to do with the ``finally`` it is meant to pin.
+
+    What that ``finally`` actually guarantees is that the flag *clears*.
+    Without it the flag latches ``True`` for the rest of the session and
+    every subsequent tick is dropped, so this wait times out -- the
+    regression is still caught, just not by a coin flip.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if screen._refreshing is False:
+            return
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        "_refreshing never cleared -- a transient failure wedged the screen, "
+        "so no later refresh can run"
+    )
+
+
 _BLOCK_RULE = "▏"
 """The glyph Textual's ``vkey`` border paints -- the rule ``BlockFooter``
 draws between the row-scoped and fleet-scoped key blocks (and the same one
@@ -945,7 +974,7 @@ class TestRunsScreenGuardRecovery:
                 screen.refresh_runs()
                 await settle(pilot)
 
-            assert screen._refreshing is False
+            await _assert_guard_released(pilot, screen)
 
             # And it genuinely recovers on a later tick.
             await asyncio.sleep(0.3)
@@ -974,7 +1003,7 @@ class TestRunsScreenGuardRecovery:
                 await settle(pilot)
 
             assert app.is_running
-            assert screen._refreshing is False
+            await _assert_guard_released(pilot, screen)
 
             await asyncio.sleep(0.2)
             await settle(pilot)


### PR DESCRIPTION
Fixes the two failing jobs on `main`: `Web BG Smoke (windows-latest)` (failing 3 of the 4 runs since it was added in #450) and a flaky `Test (Python 3.13, ubuntu-latest)`.

## 1. A step with no model was constructing a provider

`_execute_loop` built every `agent_started` payload with a `context_window_max` resolved through `_get_context_window_for_agent`, which resolves a provider — and `ProviderRegistry` builds providers lazily. A `wait` / `set` / `script` / `terminate` / `human_gate` step has no model, so that construction bought a guaranteed `None`.

It is also charged to `limits.timeout_seconds`, because it runs *inside* the engine's timed loop. Profiling a provider-free wait workflow, the first step spent **0.434s** of the budget building a Copilot SDK client:

```
gap workflow_started -> first agent_started: 0.451s   # before
gap workflow_started -> first agent_started: 0.000s   # after
```

On a cold Windows CI runner that (plus general per-step overhead) consumed enough of `examples/wait-smoke.yaml`'s 3s cap to time the workflow out. The child then exits non-zero, and the launch gate reports it as `Background process exited before the workflow started (code 1)` — failing the smoke job for something it does not test. In-engine time for that workflow drops from 1.46s to 1.01s, of which 1.00s is the sleeps it is meant to perform.

`is_llm_agent` was already computed two lines above, so the fix gates the lookup on it. Provider-backed agents are unaffected; the two completion-side call sites already run only in the LLM branches.

`TestNonLlmStepsSkipTheProviderLookup` pins it with a spy on `ProviderRegistry.get_provider` — verified to fail on the unfixed engine, so it is not vacuous.

## 2. `test_a_scan_failure_does_not_wedge_the_screen` was racing its own poll timer

The two `TestRunsScreenGuardRecovery` tests asserted `_refreshing is False` a single instant after `settle()`, while shrinking `POLL_INTERVAL_SECONDS` to 0.05s — so a tick landing during `settle()`'s trailing `pilot.pause()` legitimately set the flag back to `True` before the assertion read it (`assert True is False`). Reproduced locally at ~20%.

They now wait for the flag to *clear*, which is what the `finally` actually guarantees: without it the flag latches `True` for the session and the wait times out, so the regression is still caught. **20/20 clean, from 2/10 failing.**

## 3. Headroom for the smoke fixture

`examples/wait-smoke.yaml`'s 3s cap left no margin on a cold Windows runner even after fix 1, so it is now 15s, with `examples/README.md` and the `ci.yml` job comment updated. The timeout path the example demonstrates is unchanged — drive it with a larger `--input middle_duration_ms`.

## Validation

- `make check` (ruff, ruff format, ty) — clean
- `tests/test_engine` + `tests/test_fleet` — 1602 passed, 1 skipped
- `make validate-examples` — exit 0
- Real `conductor run examples/wait-smoke.yaml --web-bg` — launches, reaches `workflow_completed` in 1.013s in-engine, `conductor stop` cleans up