### PR TITLE
fix(providers): treat non-credential HTTP failures from Claude models.list() as inconclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged, so that combination still warns. Workflows that set `max_bytes`
   explicitly are unaffected.
 
+### Fixed
+
+- **`claude` provider: `validate_connection()` no longer fails startup when an
+  Anthropic-compatible endpoint doesn't implement `models.list()`** (issue
+  #455). Azure AI Foundry's Anthropic endpoint, and some LiteLLM/Databricks AI
+  Gateway configurations, answer `/v1/models` with a 404 while `/v1/messages`
+  (what agents actually call) works fine — previously this made every workflow
+  using such an endpoint fail before running a single agent. The startup probe
+  now only fails on positive evidence of a broken setup: an unreachable host,
+  rejected credentials (401/403), or a non-HTTP error. Any other HTTP status
+  logs a warning naming the status code and continues, deferring credential
+  verification to the first agent execution — the same posture the `hermes`
+  provider already documents. See
+  [`docs/providers/claude.md`](docs/providers/claude.md#startup-connection-validation).
+
 ## [0.1.32](https://github.com/microsoft/conductor/compare/v0.1.31...v0.1.32) - 2026-08-16
 
 ### Fixed

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -158,8 +158,11 @@ workflow:
 
 ### Startup Connection Validation
 
-`conductor validate` and `conductor run` probe the endpoint with `client.models.list()` before
-running any agent. Not every Anthropic-compatible endpoint implements model listing — Azure AI
+`conductor run` probes the endpoint with `client.models.list()` when it lazily constructs the
+Claude provider — before the first agent on that provider runs. `conductor doctor --check` /
+`--models` run the same probe. `conductor validate` does **not** — it is a static YAML/schema
+check that never constructs a provider or contacts the endpoint. Not every Anthropic-compatible
+endpoint implements model listing — Azure AI
 Foundry's Anthropic endpoint (`https://<resource>.services.ai.azure.com/anthropic`) and some
 LiteLLM/Databricks AI Gateway configurations answer it with a 404 while `/v1/messages` (the
 endpoint agents actually use) works fine. To avoid failing startup on those endpoints, the probe
@@ -628,15 +631,17 @@ This will log:
 #### Test Provider Connection
 
 ```bash
-conductor validate workflow.yaml --provider claude
+conductor doctor --check -p claude
 ```
 
 This validates:
 - API key is set and (on endpoints that implement `/v1/models`) verified against the API — on
   endpoints that don't (e.g. Azure AI Foundry), credentials are instead verified at first agent
-  execution; see [Startup Connection Validation](#startup-connection-validation)
+  execution; see [Startup Connection Validation](#startup-connection-validation) above
 - Provider can connect to Claude API
-- Workflow YAML is syntactically correct
+
+Separately, `conductor validate workflow.yaml` checks that the workflow YAML is syntactically
+correct — it never contacts the Claude endpoint.
 
 #### Check SDK Installation
 

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -156,6 +156,23 @@ workflow:
 - **Credential precedence**: `api_key` and `auth_token` are resolved together, not independently. Setting **either** in YAML makes the Anthropic SDK skip environment-variable credential resolution entirely, so a YAML `auth_token` also suppresses `ANTHROPIC_API_KEY`, and vice versa. If you set one credential in YAML and expect the other from the environment, it resolves to `None` with no warning.
 - **Authentication header selection**: Use `api_key` for standard Anthropic keys (`x-api-key` header). Use `auth_token` for gateways expecting bearer authentication (`Authorization: Bearer` header). **Set exactly one.** If both are configured, the Anthropic SDK does not choose between them: it sends `X-Api-Key` and `Authorization: Bearer` on every request, so your Anthropic key reaches whatever `base_url` points at. Conductor forwards both without arbitrating and logs a warning.
 
+### Startup Connection Validation
+
+`conductor validate` and `conductor run` probe the endpoint with `client.models.list()` before
+running any agent. Not every Anthropic-compatible endpoint implements model listing — Azure AI
+Foundry's Anthropic endpoint (`https://<resource>.services.ai.azure.com/anthropic`) and some
+LiteLLM/Databricks AI Gateway configurations answer it with a 404 while `/v1/messages` (the
+endpoint agents actually use) works fine. To avoid failing startup on those endpoints, the probe
+only fails when there is positive evidence of a broken setup:
+
+- An unreachable host (connection error) — fails startup.
+- Rejected credentials (HTTP 401/403) — fails startup.
+- A non-HTTP error (no status code and not a connection error) — fails startup.
+- Any other HTTP status (e.g. 404, 400, 405, 429, 5xx) — logs a warning naming the status code
+  and **continues**. On these endpoints your credentials are first verified when the first agent
+  actually calls `/v1/messages`, and model-discovery-derived features (context-window reporting,
+  `conductor doctor --models`) are unavailable since the model list could never be fetched.
+
 ### Security Warning
 
 Secrets must always use environment variable interpolation (such as `${ANTHROPIC_API_KEY}` or `${GATEWAY_TOKEN}`), never literal string values. Conductor embeds raw workflow source code inside the `yaml_source` attribute of `workflow_started` events. Hardcoding a literal secret key in YAML exposes it in JSONL event logs and the web dashboard.
@@ -577,6 +594,22 @@ pip install --upgrade 'anthropic>=0.77.0,<1.0.0'
 uv add 'anthropic>=0.77.0,<1.0.0'
 ```
 
+#### 8. `models.list()` Not Supported (Azure AI Foundry, some gateways)
+
+**Warning**: `Could not verify connection via models.list() (HTTP 404): ...`
+
+**Cause**: The endpoint (e.g. Azure AI Foundry's Anthropic endpoint, or a LiteLLM/Databricks-style
+gateway) does not implement `/v1/models`, even though `/v1/messages` works fine. This is not
+treated as a startup failure — see [Startup Connection
+Validation](#startup-connection-validation) above.
+
+**Solutions**:
+- No action needed if agents run successfully afterward; the warning is informational.
+- If agent execution then fails with an authentication error, your credentials really are wrong —
+  check `api_key`/`auth_token` as in [Authentication Errors](#1-authentication-errors) above.
+- Context-window reporting and `conductor doctor --models` will be unavailable on this endpoint,
+  since they depend on the same model-listing call.
+
 ### Debugging Tips
 
 #### Enable Debug Logging
@@ -599,7 +632,9 @@ conductor validate workflow.yaml --provider claude
 ```
 
 This validates:
-- API key is set and valid
+- API key is set and (on endpoints that implement `/v1/models`) verified against the API — on
+  endpoints that don't (e.g. Azure AI Foundry), credentials are instead verified at first agent
+  execution; see [Startup Connection Validation](#startup-connection-validation)
 - Provider can connect to Claude API
 - Workflow YAML is syntactically correct
 

--- a/src/conductor/cli/doctor.py
+++ b/src/conductor/cli/doctor.py
@@ -273,6 +273,8 @@ def _connection_cell(diag: ProviderDiagnostic) -> Text:
     """Format the connection-check result cell."""
     if not diag.checked or diag.connection_ok is None:
         return _DASH
+    if diag.connection_ok and diag.connection_note:
+        return styled("[yellow]⚠[/yellow] {}", diag.connection_note)
     if diag.connection_ok:
         return styled("{} connected", _CHECK)
     if diag.connection_error:

--- a/src/conductor/fleet/tui/screens/providers.py
+++ b/src/conductor/fleet/tui/screens/providers.py
@@ -125,6 +125,8 @@ def _models_summary_cell(diag: ProviderDiagnostic, *, loading: bool) -> Text:
         return Text.from_markup("[dim]enter to check[/dim]")
     if diag.connection_ok is False:
         return Text.from_markup("[red]✗[/red] connection failed")
+    if diag.connection_ok and diag.connection_note:
+        return styled("[yellow]⚠[/yellow] {}", diag.connection_note)
     if diag.models is None:
         return Text.from_markup("[dim]n/a[/dim]")
     count = len(diag.models)
@@ -305,6 +307,16 @@ class ProvidersScreen(Screen):
                 "",
                 "",
                 key=f"{name}{_SUB_ROW_DELIMITER}connection-failed",
+            )
+            return
+        if diag.connection_ok and diag.connection_note:
+            table.add_row(
+                styled("    [yellow]⚠[/yellow] {}", diag.connection_note),
+                "",
+                "",
+                "",
+                "",
+                key=f"{name}{_SUB_ROW_DELIMITER}connection-note",
             )
             return
         if diag.models is None:

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -264,6 +264,17 @@ class ClaudeProvider(AgentProvider):
         self._max_input_cache: dict[str, int | None] | None = None
         self._max_input_cache_lock = asyncio.Lock()
 
+        # Set when validate_connection()'s models.list() probe is inconclusive
+        # (see _connection_probe_verdict) rather than a confirmed success.
+        # connection_note carries a human-readable reason for diagnostics
+        # (cli/doctor.py, providers/diagnostics.py) to surface instead of
+        # silently claiming "connected". model_listing_unavailable short-
+        # circuits get_max_prompt_tokens()/list_models() so an endpoint that
+        # doesn't implement /v1/models isn't re-probed on every call.
+        self._connection_probe_note: str | None = None
+        self._model_listing_unavailable = False
+        self._model_listing_unavailable_warned = False
+
         # Initialize the client (sync initialization)
         self._initialize_client()
 
@@ -390,6 +401,9 @@ class ClaudeProvider(AgentProvider):
             models_page = await self._client.models.list()
             # Log available models for debugging
             self._report_available_models(models_page)
+            self._connection_probe_note = None
+            self._model_listing_unavailable = False
+            self._model_listing_unavailable_warned = False
             return True
         except Exception as e:
             return self._connection_probe_verdict(e)
@@ -418,6 +432,13 @@ class ClaudeProvider(AgentProvider):
             status_code = getattr(exc, "status_code", None)
             if status_code is None:
                 status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            # A duck-typed status_code may be a non-int (e.g. a stringified "401"
+            # from a proxy wrapper) or an auto-created Mock attribute; neither is
+            # usable for the 401/403 check below, so route it into the fail-CLOSED
+            # arm rather than let it silently pass through as inconclusive. `bool`
+            # is excluded explicitly since `isinstance(True, int)` is `True`.
+            if not isinstance(status_code, int) or isinstance(status_code, bool):
+                status_code = None
 
         if status_code is None:
             logger.error(f"Connection validation failed: {exc}")
@@ -432,6 +453,9 @@ class ClaudeProvider(AgentProvider):
             "This endpoint may not implement /v1/models. Continuing startup; credentials "
             "will be verified on the first agent call."
         )
+        self._connection_probe_note = f"unverified (HTTP {status_code})"
+        self._model_listing_unavailable = True
+        self._model_listing_unavailable_warned = False
         return True
 
     def _report_available_models(self, models_page: Any) -> None:
@@ -464,6 +488,23 @@ class ClaudeProvider(AgentProvider):
             info.id: getattr(info, "max_input_tokens", None) for info in models_data
         }
 
+    def _log_model_listing_unavailable(self) -> None:
+        """Log that model listing is unavailable, once at warning then at debug.
+
+        Called by ``get_max_prompt_tokens``/``list_models`` when
+        ``_model_listing_unavailable`` is set (an inconclusive
+        ``validate_connection()`` probe) so repeated calls don't each re-attempt
+        a guaranteed-failing ``models.list()`` round-trip.
+        """
+        if not self._model_listing_unavailable_warned:
+            logger.warning(
+                "Model listing is unavailable for this endpoint; context-window "
+                "reporting disabled for this endpoint."
+            )
+            self._model_listing_unavailable_warned = True
+        else:
+            logger.debug("Model listing remains unavailable for this endpoint.")
+
     async def get_max_prompt_tokens(self, model: str) -> int | None:
         """Return the Anthropic SDK's ``max_input_tokens`` for ``model``.
 
@@ -471,7 +512,9 @@ class ClaudeProvider(AgentProvider):
         ``client.models.list()``; subsequent calls are dictionary lookups.
         ``validate_connection()`` already populates the cache, so callers
         that go through normal connection setup never pay for an extra
-        round-trip.
+        round-trip — unless the probe was inconclusive (see
+        ``_connection_probe_verdict``), in which case the cache is never seeded
+        and this method short-circuits instead of re-attempting the call.
 
         Resolves aliases (``-latest``, dated suffixes, base/versioned name
         mismatches) via :func:`match_model_id`. Returns ``None`` when the
@@ -485,6 +528,10 @@ class ClaudeProvider(AgentProvider):
         reports the default window.
         """
         if not ANTHROPIC_SDK_AVAILABLE or self._client is None:
+            return None
+
+        if self._model_listing_unavailable:
+            self._log_model_listing_unavailable()
             return None
 
         if self._max_input_cache is None:
@@ -517,6 +564,9 @@ class ClaudeProvider(AgentProvider):
         constructed, or the listing call fails — diagnostics must never raise.
         """
         if not ANTHROPIC_SDK_AVAILABLE or self._client is None:
+            return None
+        if self._model_listing_unavailable:
+            self._log_model_listing_unavailable()
             return None
         try:
             page = await self._client.models.list()

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -14,6 +14,9 @@ Error Handling Strategy:
   Examples: HTTP 500 errors, rate limits, authentication failures.
 
 This distinction ensures clear error classification and appropriate retry behavior.
+Startup connection validation is deliberately advisory for non-credential HTTP failures from
+``models.list()`` (e.g. a 404 on a gateway that doesn't implement model listing) — see
+``validate_connection()``.
 """
 
 from __future__ import annotations
@@ -47,7 +50,7 @@ from conductor.providers.reasoning import (
 # Try to import the Anthropic SDK
 try:
     import anthropic
-    from anthropic import AnthropicError, AsyncAnthropic
+    from anthropic import AnthropicError, APIConnectionError, APIStatusError, AsyncAnthropic
 
     ANTHROPIC_SDK_AVAILABLE = True
 except ImportError:
@@ -55,6 +58,12 @@ except ImportError:
     AsyncAnthropic = None  # type: ignore[misc, assignment]
     anthropic = None  # type: ignore[assignment]
     AnthropicError = Exception  # type: ignore[misc, assignment]
+
+    class _SDKUnavailableError(Exception):
+        """Sentinel that never matches a real exception when the SDK is absent."""
+
+    APIConnectionError = _SDKUnavailableError  # type: ignore[misc, assignment]
+    APIStatusError = _SDKUnavailableError  # type: ignore[misc, assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -363,39 +372,77 @@ class ClaudeProvider(AgentProvider):
         1. Validates API connectivity and credentials
         2. Performs async model verification (deferred from __init__)
 
+        ``models.list()`` is not implemented by every Anthropic-compatible endpoint
+        (Azure AI Foundry, some LiteLLM/Databricks gateways answer it with a 404 while
+        ``/v1/messages`` works fine), so a non-connection, non-credential HTTP failure from
+        this probe is treated as inconclusive rather than fatal: the workflow proceeds and
+        credentials are verified at the first agent execution instead. Only an unreachable
+        host, rejected credentials (401/403), or a non-HTTP error still fail startup.
+
         Returns:
-            True if connection successful, False otherwise.
+            True if connection successful (or the probe was inconclusive), False otherwise.
         """
         if self._client is None:
             return False
 
         try:
             # Test: list models to verify API key works and perform model verification
-            await self._client.models.list()
+            models_page = await self._client.models.list()
             # Log available models for debugging
-            await self._log_available_models()
+            self._report_available_models(models_page)
             return True
         except Exception as e:
-            logger.error(f"Connection validation failed: {e}")
+            return self._connection_probe_verdict(e)
+
+    def _connection_probe_verdict(self, exc: Exception) -> bool:
+        """Classify a ``models.list()`` failure as fatal or merely inconclusive.
+
+        Args:
+            exc: The exception raised by ``client.models.list()``.
+
+        Returns:
+            False when the failure indicates an unreachable host, rejected credentials, or
+            a non-HTTP error. True when the endpoint returned some other HTTP status (the
+            endpoint likely doesn't implement model listing) — startup proceeds and
+            credentials are verified at the first agent execution instead.
+        """
+        if isinstance(exc, APIConnectionError):
+            logger.error(f"Connection validation failed: {exc}")
             return False
 
-    async def _log_available_models(self) -> None:
-        """List and log available models, warn if default model is unavailable.
+        if isinstance(exc, APIStatusError):
+            status_code = exc.status_code
+        else:
+            # Fall back for a duck-typed error (e.g. a gateway-layer httpx.HTTPStatusError)
+            # that carries a status code without being an APIStatusError itself.
+            status_code = getattr(exc, "status_code", None)
+            if status_code is None:
+                status_code = getattr(getattr(exc, "response", None), "status_code", None)
+
+        if status_code is None:
+            logger.error(f"Connection validation failed: {exc}")
+            return False
+
+        if status_code in (401, 403):
+            logger.error(f"Connection validation failed: {exc}")
+            return False
+
+        logger.warning(
+            f"Could not verify connection via models.list() (HTTP {status_code}): {exc}. "
+            "This endpoint may not implement /v1/models. Continuing startup; credentials "
+            "will be verified on the first agent call."
+        )
+        return True
+
+    def _report_available_models(self, models_page: Any) -> None:
+        """Log available models, warn if default model is unavailable.
 
         Also seeds ``_max_input_cache`` so the first call to
         :meth:`get_max_prompt_tokens` doesn't pay for an extra round-trip.
+
+        Args:
+            models_page: The result of ``client.models.list()``.
         """
-        if self._client is None:
-            return
-
-        try:
-            # Call client.models.list() to get available models (async)
-            logger.debug("Discovering available Claude models via client.models.list()...")
-            models_page = await self._client.models.list()
-        except (TimeoutError, AnthropicError, OSError) as e:
-            logger.warning(f"Could not list available models (discovery failed): {e}")
-            return
-
         available_models = [model.id for model in models_page.data]
         logger.info(f"Available Claude models: {', '.join(available_models)}")
 

--- a/src/conductor/providers/diagnostics.py
+++ b/src/conductor/providers/diagnostics.py
@@ -194,6 +194,7 @@ class ProviderDiagnostic:
     checked: bool = False
     connection_ok: bool | None = None
     connection_error: str | None = None
+    connection_note: str | None = None
     models: list[ModelDiagnostic] | None = None
     models_error: str | None = None
     note: str | None = None
@@ -210,6 +211,7 @@ class ProviderDiagnostic:
             "checked": self.checked,
             "connection_ok": self.connection_ok,
             "connection_error": self.connection_error,
+            "connection_note": self.connection_note,
             "models": [m.to_dict() for m in self.models] if self.models is not None else None,
             "models_error": self.models_error,
             "note": self.note,
@@ -605,11 +607,24 @@ async def gather_provider(
     try:
         try:
             diag.connection_ok = bool(await provider.validate_connection())
+            # Some providers (e.g. claude, issue #455) return True for a
+            # merely inconclusive probe (an endpoint that doesn't implement
+            # model listing). connection_note carries that caveat so a
+            # renderer doesn't claim "connected" when nothing was verified.
+            # Restricted to str: an AsyncMock/Mock-based test double without
+            # this attribute set auto-creates a truthy Mock via getattr(),
+            # which is not a real note.
+            note = getattr(provider, "_connection_probe_note", None)
+            diag.connection_note = note if isinstance(note, str) else None
         except Exception as e:  # noqa: BLE001 - diagnostics must never raise
             diag.connection_ok = False
             diag.connection_error = _format_error(e)
 
-        if list_models and diag.connection_ok:
+        # Gate on a verified (not merely truthy) connection: an inconclusive
+        # probe means models.list() already failed once, so calling
+        # list_models() here would just be a second guaranteed-failing
+        # round-trip.
+        if list_models and diag.connection_ok and diag.connection_note is None:
             try:
                 model_ids = await provider.list_models()
                 diag.models = (

--- a/tests/test_providers/test_claude.py
+++ b/tests/test_providers/test_claude.py
@@ -453,6 +453,55 @@ class TestConnectionValidation:
         provider = ClaudeProvider()
         assert await provider.validate_connection() is True
 
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_validate_connection_duck_typed_string_status_fails_closed(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        """A stringified status_code (e.g. "401" from a proxy wrapper) must not fail open.
+
+        `"401" in (401, 403)` is `False`, so without narrowing to `int` this would
+        be misclassified as inconclusive and return `True` for a rejected credential.
+        """
+        mock_anthropic_module.__version__ = "0.77.0"
+
+        class _StringStatusError(Exception):
+            def __init__(self) -> None:
+                super().__init__("unauthorized")
+                self.response = Mock(status_code="401")
+
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(side_effect=_StringStatusError())
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        assert await provider.validate_connection() is False
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_validate_connection_duck_typed_status_code_attribute_401_fails_closed(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        """A duck-typed integer status_code set directly on the exception (no
+        `.response`) must still be checked against the 401/403 rule."""
+        mock_anthropic_module.__version__ = "0.77.0"
+
+        class _DirectStatusError(Exception):
+            def __init__(self) -> None:
+                super().__init__("unauthorized")
+                self.status_code = 401
+
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(side_effect=_DirectStatusError())
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        assert await provider.validate_connection() is False
+
 
 class TestCloseMethod:
     """Tests for resource cleanup."""

--- a/tests/test_providers/test_claude.py
+++ b/tests/test_providers/test_claude.py
@@ -26,6 +26,8 @@ import os
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
+import anthropic
+import httpx
 import pytest
 from pydantic import BaseModel
 from pydantic_ai import Agent
@@ -54,6 +56,13 @@ def _build_structured_agent(model_cls: type[BaseModel], data: dict[str, Any]) ->
         model=TestModel(custom_output_args=data),
         output_type=model_cls,
     )
+
+
+def _make_status_error(error_cls: type[Exception], status_code: int) -> Exception:
+    """Build a real ``anthropic.APIStatusError`` (or subclass) for a given HTTP status."""
+    request = httpx.Request("GET", "https://example.com/v1/models")
+    response = httpx.Response(status_code, request=request)
+    return error_cls(f"error {status_code}", response=response, body=None)  # type: ignore[call-arg]
 
 
 class TestClaudeProviderInitialization:
@@ -233,7 +242,7 @@ class TestModelVerification:
         provider = ClaudeProvider()
         await provider.validate_connection()
 
-        assert mock_client.models.list.call_count == 2
+        assert mock_client.models.list.call_count == 1
 
         info_calls = [call[0][0] for call in mock_logger.info.call_args_list]
         assert any("Available Claude models" in call for call in info_calls)
@@ -294,7 +303,8 @@ class TestConnectionValidation:
     async def test_validate_connection_failure(
         self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
     ) -> None:
-        """Test connection validation failure."""
+        """A bare non-HTTP exception (no status_code, not a connection error) still fails
+        startup — there is no positive evidence the endpoint merely lacks /v1/models."""
         mock_anthropic_module.__version__ = "0.77.0"
         mock_client = Mock()
         mock_client.models.list = AsyncMock(side_effect=Exception("API key invalid"))
@@ -304,6 +314,144 @@ class TestConnectionValidation:
         result = await provider.validate_connection()
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_validate_connection_no_client_returns_false(self) -> None:
+        """No client at all (e.g. SDK unavailable at construction) fails immediately."""
+        with (
+            patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True),
+            patch("conductor.providers.claude.AsyncAnthropic"),
+            patch("conductor.providers.claude.anthropic") as mock_anthropic_module,
+        ):
+            mock_anthropic_module.__version__ = "0.77.0"
+            provider = ClaudeProvider()
+        provider._client = None
+
+        assert await provider.validate_connection() is False
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @patch("conductor.providers.claude.logger")
+    @pytest.mark.asyncio
+    async def test_validate_connection_404_is_inconclusive_not_fatal(
+        self, mock_logger: Mock, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        """404 from models.list() (Azure AI Foundry, issue #455) doesn't fail startup."""
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(
+            side_effect=_make_status_error(anthropic.NotFoundError, 404)
+        )
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        result = await provider.validate_connection()
+
+        assert result is True
+        assert mock_logger.warning.called
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        assert any("404" in call and "/v1/models" in call for call in warning_calls)
+
+    @pytest.mark.parametrize(
+        ("error_cls", "status_code"),
+        [
+            (anthropic.BadRequestError, 400),
+            (anthropic.RateLimitError, 429),
+            (anthropic.APIStatusError, 500),
+            (anthropic.APIStatusError, 501),
+            (anthropic.APIStatusError, 405),
+        ],
+    )
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_validate_connection_other_http_status_is_inconclusive(
+        self,
+        mock_anthropic_module: Mock,
+        mock_anthropic_class: Mock,
+        error_cls: type[Exception],
+        status_code: int,
+    ) -> None:
+        """Any HTTP status other than 401/403 from models.list() is inconclusive, not fatal."""
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(side_effect=_make_status_error(error_cls, status_code))
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        assert await provider.validate_connection() is True
+
+    @pytest.mark.parametrize(
+        ("error_cls", "status_code"),
+        [
+            (anthropic.AuthenticationError, 401),
+            (anthropic.PermissionDeniedError, 403),
+        ],
+    )
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_validate_connection_rejected_credentials_fails(
+        self,
+        mock_anthropic_module: Mock,
+        mock_anthropic_class: Mock,
+        error_cls: type[Exception],
+        status_code: int,
+    ) -> None:
+        """Rejected credentials (401/403) from models.list() still fail startup."""
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(side_effect=_make_status_error(error_cls, status_code))
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        assert await provider.validate_connection() is False
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_validate_connection_unreachable_host_fails(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        """An unreachable host (APIConnectionError, no status code) still fails startup."""
+        mock_anthropic_module.__version__ = "0.77.0"
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(
+            side_effect=anthropic.APIConnectionError(
+                request=httpx.Request("GET", "https://example.invalid/v1/models")
+            )
+        )
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        assert await provider.validate_connection() is False
+
+    @patch("conductor.providers.claude.ANTHROPIC_SDK_AVAILABLE", True)
+    @patch("conductor.providers.claude.AsyncAnthropic")
+    @patch("conductor.providers.claude.anthropic")
+    @pytest.mark.asyncio
+    async def test_validate_connection_duck_typed_gateway_status_is_inconclusive(
+        self, mock_anthropic_module: Mock, mock_anthropic_class: Mock
+    ) -> None:
+        """A gateway wrapper exposing only `.response.status_code` is still classified
+        (e.g. an httpx.HTTPStatusError raised by a proxy layer in front of the SDK)."""
+        mock_anthropic_module.__version__ = "0.77.0"
+
+        class _GatewayError(Exception):
+            def __init__(self) -> None:
+                super().__init__("upstream returned 404")
+                self.response = Mock(status_code=404)
+
+        mock_client = Mock()
+        mock_client.models.list = AsyncMock(side_effect=_GatewayError())
+        mock_anthropic_class.return_value = mock_client
+
+        provider = ClaudeProvider()
+        assert await provider.validate_connection() is True
 
 
 class TestCloseMethod:

--- a/tests/test_providers/test_factory.py
+++ b/tests/test_providers/test_factory.py
@@ -268,8 +268,8 @@ class TestCreateProvider:
         assert provider is not None
         assert provider.__class__.__name__ == "ClaudeProvider"
         # Verify models.list was called for validation
-        # Called twice: once in __init__ and once in validate_connection
-        assert mock_client.models.list.call_count == 2
+        # validate_connection() shares one round-trip between validation and model discovery
+        assert mock_client.models.list.call_count == 1
 
     @pytest.mark.asyncio
     async def test_create_unknown_provider_raises(self) -> None:


### PR DESCRIPTION
## Summary
Azure AI Foundry and some LiteLLM/Databricks gateways answer `models.list()` with a 404 while `/v1/messages` works fine, causing `validate_connection()` to fail startup even though the endpoint is usable. This treats a non-credential, non-connection HTTP failure from that probe as inconclusive instead of fatal: the workflow proceeds and credentials are verified at the first agent execution.

- Unreachable host, rejected credentials (401/403), or a non-HTTP error still fail startup.
- Any other HTTP status now warns and continues.

Closes #455