### PR TITLE
fix(providers): classify pydantic-ai translated errors as retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged, so that combination still warns. Workflows that set `max_bytes`
   explicitly are unaffected.
 
+### Fixed
+
+- **The Pydantic AI provider (`claude`) never retried on HTTP 429/5xx or
+  transport errors** (#454). `pydantic_ai.models.anthropic._map_api_errors`
+  translates the Anthropic SDK's exceptions into `ModelHTTPError` (for an
+  HTTP error response) and `ModelAPIError` (for a connection/timeout
+  failure) before Conductor ever sees them, so neither the SDK class names
+  nor the `anthropic.APIStatusError` check that `_is_retryable_error`
+  relied on ever matched — every attempt failed fast as a non-retryable
+  error regardless of `retry:` configuration. Both translated types are now
+  classified directly, matching the existing 429/5xx retryable set, and a
+  server's `retry-after` value is recovered from `__cause__` (the
+  translation drops response headers, but preserves the original SDK
+  exception there) or from the response body.
+- **A per-agent `retry.delay_seconds` larger than the 30s provider default
+  was silently clamped back down to 30s** on both the Pydantic AI (`claude`)
+  and Copilot providers, so `delay_seconds: 60` produced 30s waits instead
+  of the stated 60s. The internal backoff cap is now `max(default_max_delay,
+  delay_seconds)`, so a larger stated delay raises the cap instead of being
+  clamped by it; existing configurations with `delay_seconds` below the
+  default are unaffected.
+
 ## [0.1.32](https://github.com/microsoft/conductor/compare/v0.1.31...v0.1.32) - 2026-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **The Pydantic AI provider (`claude`) never retried on HTTP 429/5xx or
-  transport errors** (#454). `pydantic_ai.models.anthropic._map_api_errors`
-  translates the Anthropic SDK's exceptions into `ModelHTTPError` (for an
-  HTTP error response) and `ModelAPIError` (for a connection/timeout
-  failure) before Conductor ever sees them, so neither the SDK class names
+  transport errors** (#454). pydantic-ai's Anthropic model translates the
+  SDK's exceptions before Conductor ever sees them (a private helper,
+  `_map_api_errors` in pydantic-ai 2.x, written inline at the 1.44.0 floor)
+  into `ModelHTTPError` (for an HTTP error response) and `ModelAPIError`
+  (for a connection/timeout failure), so neither the SDK class names
   nor the `anthropic.APIStatusError` check that `_is_retryable_error`
   relied on ever matched — every attempt failed fast as a non-retryable
   error regardless of `retry:` configuration. Both translated types are now

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -190,7 +190,7 @@ agents:
 |-------|------|---------|-------------|
 | `max_attempts` | `1-10` | `1` | Total attempts including the first. `1` = no retry. |
 | `backoff` | `exponential \| fixed` | `exponential` | Backoff strategy between retries. |
-| `delay_seconds` | `0.0-300.0` | `2.0` | Base delay in seconds before the first retry. |
+| `delay_seconds` | `0.0-300.0` | `2.0` | Base delay in seconds before the first retry. This value also raises the internal backoff cap, so exponential growth never exceeds it — `delay_seconds: 60` produces 60s waits rather than being clamped to the 30s provider default. |
 | `retry_on` | list | `[provider_error, timeout]` | Error categories that trigger a retry. |
 | `max_parse_recovery_attempts` | `0-10` | Provider default | In-session recovery attempts before giving up. See below. |
 

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -190,9 +190,11 @@ agents:
 |-------|------|---------|-------------|
 | `max_attempts` | `1-10` | `1` | Total attempts including the first. `1` = no retry. |
 | `backoff` | `exponential \| fixed` | `exponential` | Backoff strategy between retries. |
-| `delay_seconds` | `0.0-300.0` | `2.0` | Base delay in seconds before the first retry. This value also raises the internal backoff cap, so exponential growth never exceeds it — `delay_seconds: 60` produces 60s waits rather than being clamped to the 30s provider default. |
+| `delay_seconds` | `0.0-300.0` | `2.0` | Base delay in seconds before the first retry. See below for how it interacts with the internal backoff cap. |
 | `retry_on` | list | `[provider_error, timeout]` | Error categories that trigger a retry. |
 | `max_parse_recovery_attempts` | `0-10` | Provider default | In-session recovery attempts before giving up. See below. |
+
+`delay_seconds` also raises the provider's internal 30s backoff cap when set above 30, rather than being clamped down to it: the effective cap is `max(30, delay_seconds)`. It does **not** change the cap when set below 30 — with the default `delay_seconds: 2.0` and `backoff: exponential`, the wait sequence is `2, 4, 8, 16, 30, 30` seconds, well beyond `delay_seconds` itself. Setting `delay_seconds: 60` raises the cap to 60s, so waits grow up to ~60s before the default `jitter` of `0.25` (applied after the cap) adds up to another 25%. Note that once `delay_seconds` reaches or exceeds 30s, the base delay and the cap become equal, so `backoff: exponential` degenerates into a fixed wait on every attempt.
 
 #### `max_parse_recovery_attempts`
 

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -631,7 +631,13 @@ class RetryPolicy(BaseModel):
     """Backoff strategy between retries."""
 
     delay_seconds: float = Field(default=2.0, ge=0.0, le=300.0)
-    """Base delay in seconds before the first retry."""
+    """Base delay in seconds before the first retry.
+
+    Also raises the provider's internal 30s backoff cap when set above 30
+    (the effective cap is ``max(30, delay_seconds)``); a value below 30
+    leaves the cap unchanged. See the Retry section of
+    docs/workflow-syntax.md for the resulting wait sequence.
+    """
 
     retry_on: list[Literal["provider_error", "timeout"]] = Field(
         default_factory=lambda: ["provider_error", "timeout"]

--- a/src/conductor/providers/_pydantic_ai/retry.py
+++ b/src/conductor/providers/_pydantic_ai/retry.py
@@ -7,6 +7,18 @@ Structured-output recovery retries are left enabled in ``build_agent`` because
 plain-text answers to a tool-output schema must be recovered in-session before
 ``execute_with_retry`` can see a result. If that internal budget is exhausted,
 Conductor retries the whole call.
+
+pydantic-ai translates the Anthropic SDK's own exceptions before Conductor
+ever sees them (``pydantic_ai.models.anthropic._map_api_errors``): an HTTP
+error response (``APIStatusError``, including ``RateLimitError``) becomes
+``ModelHTTPError``, and a transport failure (``APIConnectionError``,
+including ``APITimeoutError``) becomes a bare ``ModelAPIError``. Those are
+the exception types actually observed on this path, not the SDK's own
+classes, so ``_is_retryable_error`` and ``_get_retry_after`` classify those
+translated types directly (issue #454). The translation also drops the
+original response headers, so a server's ``retry-after`` value is only
+recoverable through ``__cause__``, which ``_map_api_errors`` sets to the
+untranslated SDK exception.
 """
 
 from __future__ import annotations
@@ -16,12 +28,14 @@ import contextlib
 import logging
 import random
 from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, cast
 
 try:
     import anthropic
 except ImportError:
     anthropic = None  # type: ignore[assignment]
+
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 
 from conductor.config.schema import RetryPolicy
 from conductor.exceptions import ProviderError, ValidationError
@@ -81,7 +95,10 @@ def _resolve_retry_config(
     return RetryConfig(
         max_attempts=retry.max_attempts,
         base_delay=retry.delay_seconds,
-        max_delay=default.max_delay,
+        # A user who writes delay_seconds: 60 must not have it silently clamped
+        # to the 30s provider default. The cap becomes their stated value, so
+        # exponential growth is clamped to it rather than below it. Issue #454.
+        max_delay=max(default.max_delay, retry.delay_seconds),
         jitter=default.jitter,
         backoff=retry.backoff,
         retry_on=list(retry.retry_on),
@@ -113,10 +130,24 @@ def _classify_error(error: Exception) -> str:
 def _is_retryable_error(exception: Exception) -> bool:
     """Determine if an error should trigger a retry.
 
-    Mirrors ``ClaudeProvider._is_retryable_error``.
+    Mirrors ``ClaudeProvider._is_retryable_error``, extended to classify the
+    ``ModelHTTPError``/``ModelAPIError`` types pydantic-ai actually raises on
+    this path (see the module docstring; issue #454).
     """
     if isinstance(exception, ProviderError):
         return exception.is_retryable
+
+    # pydantic-ai translates the Anthropic SDK's exceptions before Conductor
+    # sees them (pydantic_ai.models.anthropic._map_api_errors), so neither the
+    # SDK class names nor the anthropic.APIStatusError isinstance check below
+    # ever match. Issue #454.
+    if isinstance(exception, ModelHTTPError):
+        code = exception.status_code
+        return code == 429 or 500 <= code < 600
+    # A bare ModelAPIError is what APIConnectionError/APITimeoutError become —
+    # a transport failure, retryable for the same reason the SDK names below are.
+    if isinstance(exception, ModelAPIError):
+        return True
 
     error_type_name = type(exception).__name__
 
@@ -151,10 +182,12 @@ def _is_retryable_error(exception: Exception) -> bool:
     return False
 
 
-def _get_retry_after(exception: Exception) -> float | None:
-    """Extract retry-after value from a rate limit exception.
+def _retry_after_from_headers(exception: BaseException) -> float | None:
+    """Extract a retry-after value from a rate-limit exception's response headers.
 
-    Mirrors ``ClaudeProvider._get_retry_after``.
+    Mirrors ``ClaudeProvider._get_retry_after``'s original header-reading
+    behavior, unchanged, so it can be reused both on the exception itself and
+    when walking ``__cause__`` for a translated pydantic-ai exception.
     """
     error_type_name = type(exception).__name__
     is_rate_limit = False
@@ -174,6 +207,68 @@ def _get_retry_after(exception: Exception) -> float | None:
                 return float(retry_after)
             except ValueError:
                 pass
+    return None
+
+
+def _retry_after_from_body(exception: ModelHTTPError) -> float | None:
+    """Extract a retry-after value from a ``ModelHTTPError``'s response body.
+
+    ``ModelHTTPError`` carries the Anthropic API's parsed JSON ``body`` but
+    not the response headers, so a server that reports retry timing in the
+    body (rather than, or in addition to, a ``retry-after`` header) is only
+    recoverable here. No prose parsing of message strings — that is
+    unreliable and would misfire.
+    """
+    body = exception.body
+    if not isinstance(body, dict):
+        return None
+    body_dict = cast("dict[str, Any]", body)
+
+    candidates: list[Any] = [body_dict.get("retry_after"), body_dict.get("retry-after")]
+    error = body_dict.get("error")
+    if isinstance(error, dict):
+        error_dict = cast("dict[str, Any]", error)
+        candidates.extend([error_dict.get("retry_after"), error_dict.get("retry-after")])
+
+    for value in candidates:
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _get_retry_after(exception: Exception) -> float | None:
+    """Extract retry-after value from a rate limit exception.
+
+    Mirrors ``ClaudeProvider._get_retry_after``, extended for pydantic-ai's
+    translated exceptions (issue #454): ``ModelHTTPError``/``ModelAPIError``
+    carry no response headers, since ``_map_api_errors`` drops them, but
+    ``__cause__`` is the original, untranslated Anthropic SDK exception with
+    ``.response.headers`` intact, so it is walked as a fallback.
+    """
+    retry_after = _retry_after_from_headers(exception)
+    if retry_after is not None:
+        return retry_after
+
+    if isinstance(exception, ModelHTTPError):
+        retry_after = _retry_after_from_body(exception)
+        if retry_after is not None:
+            return retry_after
+
+    seen: set[int] = {id(exception)}
+    cause = exception.__cause__
+    depth = 0
+    while cause is not None and depth < 5 and id(cause) not in seen:
+        retry_after = _retry_after_from_headers(cause)
+        if retry_after is not None:
+            return retry_after
+        seen.add(id(cause))
+        cause = cause.__cause__
+        depth += 1
+
     return None
 
 

--- a/src/conductor/providers/_pydantic_ai/retry.py
+++ b/src/conductor/providers/_pydantic_ai/retry.py
@@ -9,16 +9,20 @@ plain-text answers to a tool-output schema must be recovered in-session before
 Conductor retries the whole call.
 
 pydantic-ai translates the Anthropic SDK's own exceptions before Conductor
-ever sees them (``pydantic_ai.models.anthropic._map_api_errors``): an HTTP
-error response (``APIStatusError``, including ``RateLimitError``) becomes
-``ModelHTTPError``, and a transport failure (``APIConnectionError``,
+ever sees them — a private helper (``_map_api_errors`` in pydantic-ai 2.x;
+written inline in ``AnthropicModel`` at the 1.44.0 floor pinned in
+pyproject.toml, with identical resulting behavior) wraps the SDK call: an
+HTTP error response (``APIStatusError``, including ``RateLimitError``)
+becomes ``ModelHTTPError``, and a transport failure (``APIConnectionError``,
 including ``APITimeoutError``) becomes a bare ``ModelAPIError``. Those are
 the exception types actually observed on this path, not the SDK's own
 classes, so ``_is_retryable_error`` and ``_get_retry_after`` classify those
-translated types directly (issue #454). The translation also drops the
-original response headers, so a server's ``retry-after`` value is only
-recoverable through ``__cause__``, which ``_map_api_errors`` sets to the
-untranslated SDK exception.
+translated types directly (issue #454). Only the public ``ModelHTTPError``/
+``ModelAPIError`` types are relied on at runtime, so a change to the private
+translator degrades this comment, not the code. The translation also drops
+the original response headers, so a server's ``retry-after`` value is only
+recoverable through ``__cause__``, which the translator sets to the
+untranslated SDK exception via ``from e``.
 """
 
 from __future__ import annotations
@@ -26,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 import random
 from collections.abc import Callable, Coroutine
 from typing import Any, cast
@@ -130,23 +135,33 @@ def _classify_error(error: Exception) -> str:
 def _is_retryable_error(exception: Exception) -> bool:
     """Determine if an error should trigger a retry.
 
-    Mirrors ``ClaudeProvider._is_retryable_error``, extended to classify the
-    ``ModelHTTPError``/``ModelAPIError`` types pydantic-ai actually raises on
-    this path (see the module docstring; issue #454).
+    Extended to classify the ``ModelHTTPError``/``ModelAPIError`` types
+    pydantic-ai actually raises on this path (see the module docstring;
+    issue #454). The SDK-class-name and ``anthropic.APIStatusError``
+    fallback below is unreachable in production but kept intentionally —
+    see the comment at its definition.
     """
     if isinstance(exception, ProviderError):
         return exception.is_retryable
 
     # pydantic-ai translates the Anthropic SDK's exceptions before Conductor
-    # sees them (pydantic_ai.models.anthropic._map_api_errors), so neither the
-    # SDK class names nor the anthropic.APIStatusError isinstance check below
-    # ever match. Issue #454.
+    # sees them (see the module docstring), so on this path neither the SDK
+    # class names nor the anthropic.APIStatusError isinstance check below ever
+    # match in production; that tail is kept as a fallback for non-pydantic-ai
+    # callers, for the tests that exercise it directly via the Mock* classes
+    # below, and as cheap insurance if pydantic-ai ever narrows its
+    # translation. Issue #454.
     if isinstance(exception, ModelHTTPError):
         code = exception.status_code
         return code == 429 or 500 <= code < 600
     # A bare ModelAPIError is what APIConnectionError/APITimeoutError become —
-    # a transport failure, retryable for the same reason the SDK names below are.
-    if isinstance(exception, ModelAPIError):
+    # a transport failure, retryable for the same reason the SDK names below
+    # are. Checked with `type(...) is ...` rather than isinstance: ModelHTTPError
+    # is ModelAPIError's only subclass today (see the canary test asserting
+    # that), and it is already handled above, so this stays scoped to the
+    # bare base class rather than silently absorbing a future subclass that
+    # may not be a transient condition.
+    if type(exception) is ModelAPIError:
         return True
 
     error_type_name = type(exception).__name__
@@ -185,9 +200,10 @@ def _is_retryable_error(exception: Exception) -> bool:
 def _retry_after_from_headers(exception: BaseException) -> float | None:
     """Extract a retry-after value from a rate-limit exception's response headers.
 
-    Mirrors ``ClaudeProvider._get_retry_after``'s original header-reading
-    behavior, unchanged, so it can be reused both on the exception itself and
-    when walking ``__cause__`` for a translated pydantic-ai exception.
+    Split out of ``_get_retry_after`` so it can run against both the raised
+    exception and each ``__cause__`` in the chain, since pydantic-ai's
+    translated ``ModelHTTPError``/``ModelAPIError`` carry no response headers
+    of their own (issue #454).
     """
     error_type_name = type(exception).__name__
     is_rate_limit = False
@@ -202,11 +218,13 @@ def _retry_after_from_headers(exception: BaseException) -> float | None:
     if is_rate_limit and hasattr(exception, "response") and exception.response:
         headers = getattr(exception.response, "headers", {})
         retry_after = headers.get("retry-after") or headers.get("Retry-After")
-        if retry_after:
+        if retry_after is not None:
             try:
-                return float(retry_after)
-            except ValueError:
-                pass
+                parsed = float(retry_after)
+            except (TypeError, ValueError):
+                return None
+            if math.isfinite(parsed) and parsed > 0:
+                return parsed
     return None
 
 
@@ -234,29 +252,37 @@ def _retry_after_from_body(exception: ModelHTTPError) -> float | None:
         if value is None:
             continue
         try:
-            return float(value)
+            parsed = float(value)
         except (TypeError, ValueError):
             continue
+        if not math.isfinite(parsed) or parsed <= 0:
+            logger.debug(
+                "Ignoring unparseable retry_after %r in %s response body (status %s)",
+                value,
+                type(exception).__name__,
+                getattr(exception, "status_code", None),
+            )
+            continue
+        return parsed
     return None
 
 
 def _get_retry_after(exception: Exception) -> float | None:
     """Extract retry-after value from a rate limit exception.
 
-    Mirrors ``ClaudeProvider._get_retry_after``, extended for pydantic-ai's
-    translated exceptions (issue #454): ``ModelHTTPError``/``ModelAPIError``
-    carry no response headers, since ``_map_api_errors`` drops them, but
-    ``__cause__`` is the original, untranslated Anthropic SDK exception with
-    ``.response.headers`` intact, so it is walked as a fallback.
+    Extended for pydantic-ai's translated exceptions (issue #454):
+    ``ModelHTTPError``/``ModelAPIError`` carry no response headers, since the
+    translator drops them. For an HTTP error the ``__cause__`` is the
+    original, untranslated ``APIStatusError`` with ``.response.headers``
+    intact, so it is walked and preferred over the body (the header is the
+    value the server actually sent over HTTP; the body key is an unconfirmed
+    convention Anthropic does not document). A transport-failure cause
+    (``APIConnectionError``) has no ``.response`` at all and yields nothing
+    here.
     """
     retry_after = _retry_after_from_headers(exception)
     if retry_after is not None:
         return retry_after
-
-    if isinstance(exception, ModelHTTPError):
-        retry_after = _retry_after_from_body(exception)
-        if retry_after is not None:
-            return retry_after
 
     seen: set[int] = {id(exception)}
     cause = exception.__cause__
@@ -268,6 +294,11 @@ def _get_retry_after(exception: Exception) -> float | None:
         seen.add(id(cause))
         cause = cause.__cause__
         depth += 1
+
+    if isinstance(exception, ModelHTTPError):
+        retry_after = _retry_after_from_body(exception)
+        if retry_after is not None:
+            return retry_after
 
     return None
 
@@ -289,6 +320,29 @@ def _extract_status_code(exception: Exception) -> int | None:
         if status_code is not None:
             return int(status_code)
     return None
+
+
+def _describe_root_cause(error: BaseException, *, max_depth: int = 5) -> str | None:
+    """Describe the deepest exception in a ``__cause__`` chain, if any.
+
+    Mirrors the bounded, cycle-guarded walk in ``_get_retry_after`` so a
+    translated ``ModelAPIError`` (issue #454) — whose own message is the
+    Anthropic SDK's hardcoded "Connection error." — can surface the real
+    transport failure (DNS, TLS, proxy, ...) that pydantic-ai chained onto it
+    via ``from e``.
+    """
+    seen: set[int] = {id(error)}
+    cause = error.__cause__
+    depth = 0
+    deepest: BaseException | None = None
+    while cause is not None and depth < max_depth and id(cause) not in seen:
+        deepest = cause
+        seen.add(id(cause))
+        cause = cause.__cause__
+        depth += 1
+    if deepest is None:
+        return None
+    return f"{type(deepest).__name__}: {deepest}"
 
 
 def _calculate_delay(attempt: int, config: RetryConfig) -> float:
@@ -402,9 +456,12 @@ async def execute_with_retry[T](
 
             retry_after = _get_retry_after(e)
             if retry_after is not None:
-                delay = retry_after
+                delay = min(retry_after, retry_config.max_delay)
                 logger.warning(
-                    "Rate limit hit (HTTP 429), respecting retry-after header: %ss",
+                    "Retry-after value reported for %s (HTTP %s): %ss (clamped to %ss)",
+                    type(e).__name__,
+                    _extract_status_code(e),
+                    retry_after,
                     delay,
                 )
             else:
@@ -455,6 +512,21 @@ async def execute_with_retry[T](
             "Model repeatedly failed to produce valid structured output (output tool not called); "
             "retry later or simplify the output schema"
         )
+    elif last_error is not None and isinstance(last_error, ModelAPIError):
+        # A bare ModelAPIError (issue #454) is what a transport failure
+        # (APIConnectionError/APITimeoutError) becomes; its own message is
+        # the Anthropic SDK's hardcoded "Connection error." with no detail.
+        # Walk __cause__ (same bounded, cycle-guarded pattern as
+        # _get_retry_after) to surface what actually failed (DNS, TLS,
+        # proxy, ...) instead of leaving a misconfiguration undiagnosable.
+        root_cause = _describe_root_cause(last_error)
+        if root_cause is not None:
+            suggestion = (
+                "Check API connectivity, base_url, and proxy/TLS settings. "
+                f"Underlying cause: {root_cause}"
+            )
+        else:
+            suggestion = f"Check API connectivity and rate limits. Last error: {last_error}"
     else:
         suggestion = f"Check API connectivity and rate limits. Last error: {last_error}"
 
@@ -462,4 +534,4 @@ async def execute_with_retry[T](
         f"Pydantic AI call failed after {retry_config.max_attempts} attempts: {last_error}",
         suggestion=suggestion,
         is_retryable=False,
-    )
+    ) from last_error

--- a/src/conductor/providers/copilot.py
+++ b/src/conductor/providers/copilot.py
@@ -828,7 +828,11 @@ class CopilotProvider(AgentProvider):
         return RetryConfig(
             max_attempts=retry.max_attempts,
             base_delay=retry.delay_seconds,
-            max_delay=self._retry_config.max_delay,
+            # A user who writes delay_seconds: 60 must not have it silently
+            # clamped to the 30s provider default. The cap becomes their
+            # stated value, so exponential growth is clamped to it rather
+            # than below it. Issue #454.
+            max_delay=max(self._retry_config.max_delay, retry.delay_seconds),
             jitter=self._retry_config.jitter,
             backoff=retry.backoff,
             retry_on=list(retry.retry_on),

--- a/tests/test_per_agent_retry.py
+++ b/tests/test_per_agent_retry.py
@@ -198,7 +198,10 @@ class TestResolveRetryConfig:
         assert config is not provider._retry_config
 
     def test_agent_retry_preserves_provider_jitter_and_max_delay(self) -> None:
-        """Test that resolved config preserves provider's jitter and max_delay."""
+        """Test that resolved config preserves provider's jitter, and that
+        the provider's max_delay acts as a floor for max_delay (not a fixed
+        value) — see test_agent_retry_raises_max_delay_when_delay_seconds_larger
+        below for the case where the agent's delay_seconds exceeds it."""
         custom_retry_config = RetryConfig(
             max_attempts=3, base_delay=1.0, max_delay=60.0, jitter=0.5
         )
@@ -211,10 +214,24 @@ class TestResolveRetryConfig:
 
         config = provider._resolve_retry_config(agent)
 
-        assert config.max_delay == 60.0  # From provider
+        assert config.max_delay == 60.0  # From provider (floor, unaffected here)
         assert config.jitter == 0.5  # From provider
         assert config.max_attempts == 2  # From agent
         assert config.base_delay == 5.0  # From agent
+
+    def test_agent_retry_raises_max_delay_when_delay_seconds_larger(self) -> None:
+        """A user-stated delay_seconds larger than the provider default must
+        raise the cap rather than be silently clamped below it (issue #454)."""
+        provider = CopilotProvider(retry_config=RetryConfig(max_delay=30.0))
+        agent = AgentDef(
+            name="test",
+            prompt="Test",
+            retry=RetryPolicy(delay_seconds=60.0),
+        )
+
+        config = provider._resolve_retry_config(agent)
+
+        assert config.max_delay == 60.0
 
     def test_agent_retry_on_is_forwarded(self) -> None:
         """Test that retry_on from agent policy is forwarded to config."""

--- a/tests/test_providers/test_pydantic_ai_retry.py
+++ b/tests/test_providers/test_pydantic_ai_retry.py
@@ -7,6 +7,7 @@ semantics, that Pydantic AI's own retry budget is disabled, and that the
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Coroutine
 from typing import Any
 from unittest.mock import Mock, patch
@@ -153,6 +154,14 @@ class TestRetryClassification:
         err = ModelAPIError(model_name="claude-x", message="Connection error.")
         assert _is_retryable_error(err) is True
 
+    def test_model_api_error_has_no_other_subclasses(self) -> None:
+        """Canary: the blanket ``type(exception) is ModelAPIError`` retryable
+        arm is only safe while ``ModelHTTPError`` (already handled above and
+        returned first) is the *only* subclass of ``ModelAPIError``. If
+        pydantic-ai adds e.g. an auth or quota error as a new subclass, this
+        must fail loudly rather than let it silently become retryable."""
+        assert ModelAPIError.__subclasses__() == [ModelHTTPError]
+
 
 class TestRetryConfig:
     """Tests for retry configuration resolution."""
@@ -262,19 +271,72 @@ class TestRetryDelay:
         err = ModelHTTPError(status_code=429, model_name="claude-x", body={"message": "oops"})
         assert _get_retry_after(err) is None
 
+    @pytest.mark.parametrize("bad_value", ["Infinity", "nan", "-5", "0"])
+    def test_retry_after_from_body_rejects_non_finite_and_non_positive(
+        self, bad_value: str
+    ) -> None:
+        """A body-supplied retry_after must be finite and positive, or it is
+        discarded rather than used verbatim (issue #454 blocking finding:
+        Infinity hangs the workflow forever, NaN crashes asyncio.sleep, and a
+        negative/zero value burns the retry budget in a hot loop)."""
+        err = ModelHTTPError(
+            status_code=429,
+            model_name="claude-x",
+            body={"retry_after": bad_value},
+        )
+        assert _get_retry_after(err) is None
+
+    def test_retry_after_from_headers_rejects_non_finite_and_non_positive(self) -> None:
+        """Same validation must apply to the header path, not just the body."""
+        for bad_value in ("Infinity", "nan", "-5", "0"):
+            err = MockRateLimitError("rate limited")
+            err.response = Mock(headers={"retry-after": bad_value})
+            assert _get_retry_after(err) is None
+
     def test_extract_status_code_from_api_status_error(self) -> None:
         """HTTP status code must be extracted from APIStatusError-like errors."""
         assert _extract_status_code(MockAPIStatusError("503", 503)) == 503
         assert _extract_status_code(MockBadRequestError("bad")) == 400
 
+    def test_execute_with_retry_clamps_retry_after_to_max_delay(self) -> None:
+        """A body-supplied retry-after (issue #454's new trusted-input path)
+        must still be validated even though it never reaches asyncio.sleep
+        directly here — covered end-to-end in TestExecuteWithRetry."""
+        err = ModelHTTPError(
+            status_code=429,
+            model_name="claude-x",
+            body={"retry_after": 86400},
+        )
+        assert _get_retry_after(err) == 86400.0
+
     def test_clamped_delay_sequence_is_60_60_60(self) -> None:
-        """The answered-question contract: base_delay == max_delay == 60
-        must produce 60s at every attempt (exponential growth clamped to the
-        user-stated cap, not the 30s provider default). Issue #454."""
-        config = RetryConfig(base_delay=60.0, max_delay=60.0, jitter=0.0)
-        assert _calculate_delay(1, config) == 60.0
-        assert _calculate_delay(2, config) == 60.0
-        assert _calculate_delay(3, config) == 60.0
+        """A user-stated delay_seconds of 60 must produce 60s waits at every
+        attempt, routed through the real _resolve_retry_config path (issue
+        #454). Uses a 5xx rather than a 429 so the delay is calculated
+        backoff, not a retry-after override."""
+        agent = AgentDef(name="retryer", retry=RetryPolicy(max_attempts=3, delay_seconds=60.0))
+        config = _resolve_retry_config(agent, RetryConfig(max_delay=30.0, jitter=0.0))
+        factory = _make_factory(
+            [
+                MockAPIStatusError("server error", 500),
+                MockAPIStatusError("server error", 500),
+                "ok",
+            ]
+        )
+
+        async def run() -> str:
+            return await execute_with_retry(
+                factory,
+                retry_config=config,
+                event_callback=None,
+                agent_name="retryer",
+            )
+
+        with patch("conductor.providers._pydantic_ai.retry.asyncio.sleep") as mock_sleep:
+            result = asyncio.run(run())
+
+        assert result == "ok"
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [60.0, 60.0]
 
 
 class TestExecuteWithRetry:
@@ -390,6 +452,36 @@ class TestExecuteWithRetry:
         assert exc_info.value.is_retryable is False
         assert "after 3 attempts" in str(exc_info.value)
         assert len(events) == 2
+        # Issue #454 blocking finding: exhaustion must preserve the original
+        # error as __cause__ rather than raising bare.
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, MockAPIConnectionError)
+
+    @pytest.mark.asyncio
+    async def test_retries_exhausted_on_model_api_error_names_root_cause(self) -> None:
+        """Exhaustion on a translated ModelAPIError must name the real
+        transport failure rather than only the SDK's hardcoded "Connection
+        error." message (issue #454 blocking finding), and must chain the
+        original error via __cause__."""
+        transport_error = ConnectionError("Name or service not known")
+        api_error = ModelAPIError(model_name="claude-x", message="Connection error.")
+        api_error.__cause__ = transport_error
+        config = RetryConfig(max_attempts=2, base_delay=0.0, jitter=0.0)
+        factory = _make_factory([api_error, api_error])
+
+        with (
+            patch("conductor.providers._pydantic_ai.retry.asyncio.sleep"),
+            pytest.raises(ProviderError) as exc_info,
+        ):
+            await execute_with_retry(
+                factory,
+                retry_config=config,
+                event_callback=None,
+                agent_name="retryer",
+            )
+
+        assert exc_info.value.__cause__ is api_error
+        assert "Name or service not known" in exc_info.value.suggestion
 
     @pytest.mark.asyncio
     async def test_validation_error_not_retried(self) -> None:
@@ -448,7 +540,9 @@ class TestExecuteWithRetry:
         def callback(event_type: str, payload: dict[str, Any]) -> None:
             events.append((event_type, payload))
 
-        config = RetryConfig(max_attempts=2, base_delay=1.0, jitter=0.0)
+        # max_delay must accommodate the 60s server hint, or it is clamped
+        # (issue #454: an unvalidated retry-after can bypass max_delay).
+        config = RetryConfig(max_attempts=2, base_delay=1.0, max_delay=60.0, jitter=0.0)
         factory = _make_factory([MockRateLimitError("rate limited"), "ok"])
 
         with patch("conductor.providers._pydantic_ai.retry.asyncio.sleep") as mock_sleep:
@@ -463,6 +557,31 @@ class TestExecuteWithRetry:
         assert len(events) == 1
         assert events[0][1]["delay"] == 60.0
         mock_sleep.assert_called_once_with(60.0)
+
+    @pytest.mark.asyncio
+    async def test_retry_after_header_clamped_to_max_delay(self) -> None:
+        """A server retry-after above max_delay must be clamped, not honored
+        verbatim (issue #454 blocking finding: unvalidated retry-after can
+        bypass max_delay and stall a run for hours)."""
+        events: list[tuple[str, dict[str, Any]]] = []
+
+        def callback(event_type: str, payload: dict[str, Any]) -> None:
+            events.append((event_type, payload))
+
+        config = RetryConfig(max_attempts=2, base_delay=1.0, max_delay=30.0, jitter=0.0)
+        factory = _make_factory([MockRateLimitError("rate limited"), "ok"])
+
+        with patch("conductor.providers._pydantic_ai.retry.asyncio.sleep") as mock_sleep:
+            result = await execute_with_retry(
+                factory,
+                retry_config=config,
+                event_callback=callback,
+                agent_name="retryer",
+            )
+
+        assert result == "ok"
+        assert events[0][1]["delay"] == 30.0
+        mock_sleep.assert_called_once_with(30.0)
 
     @pytest.mark.asyncio
     async def test_retry_event_callback_errors_swallowed(self) -> None:

--- a/tests/test_providers/test_pydantic_ai_retry.py
+++ b/tests/test_providers/test_pydantic_ai_retry.py
@@ -12,7 +12,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UnexpectedModelBehavior
 
 from conductor.config.schema import AgentDef, RetryPolicy
 from conductor.exceptions import ProviderError, ValidationError
@@ -128,6 +128,31 @@ class TestRetryClassification:
         err = UnexpectedModelBehavior("Exceeded maximum output retries (2)")
         assert _is_retryable_error(err) is True
 
+    def test_model_http_error_429_and_5xx_are_retryable(self) -> None:
+        """pydantic-ai's translated ModelHTTPError must be retryable at 429/5xx.
+
+        Regression test for issue #454: pydantic_ai.models.anthropic
+        translates the Anthropic SDK's APIStatusError/RateLimitError into
+        ModelHTTPError before Conductor ever sees them.
+        """
+        assert _is_retryable_error(ModelHTTPError(status_code=429, model_name="claude-x")) is True
+        assert _is_retryable_error(ModelHTTPError(status_code=500, model_name="claude-x")) is True
+        assert _is_retryable_error(ModelHTTPError(status_code=503, model_name="claude-x")) is True
+
+    def test_model_http_error_4xx_are_not_retryable(self) -> None:
+        """A ModelHTTPError for a client error must stay fatal.
+
+        Guards against the broader ModelAPIError arm (ModelHTTPError is a
+        subclass of ModelAPIError) swallowing 4xx errors.
+        """
+        assert _is_retryable_error(ModelHTTPError(status_code=400, model_name="claude-x")) is False
+        assert _is_retryable_error(ModelHTTPError(status_code=401, model_name="claude-x")) is False
+
+    def test_bare_model_api_error_is_retryable(self) -> None:
+        """A bare ModelAPIError (connection/timeout translation) must be retryable."""
+        err = ModelAPIError(model_name="claude-x", message="Connection error.")
+        assert _is_retryable_error(err) is True
+
 
 class TestRetryConfig:
     """Tests for retry configuration resolution."""
@@ -166,6 +191,26 @@ class TestRetryConfig:
         assert config.max_attempts == 7
         assert config.base_delay == 0.5
 
+    def test_max_delay_raised_to_delay_seconds_when_larger(self) -> None:
+        """A user-stated delay_seconds larger than the provider default must
+        raise the cap rather than be silently clamped below it. Issue #454."""
+        agent = AgentDef(name="retryer", retry=RetryPolicy(delay_seconds=60.0))
+        default = RetryConfig(max_delay=30.0)
+
+        config = _resolve_retry_config(agent, default)
+
+        assert config.max_delay == 60.0
+
+    def test_max_delay_unaffected_when_delay_seconds_smaller(self) -> None:
+        """A delay_seconds smaller than the provider default must leave the
+        existing cap in place (no regression for existing users)."""
+        agent = AgentDef(name="retryer", retry=RetryPolicy(delay_seconds=2.0))
+        default = RetryConfig(max_delay=30.0)
+
+        config = _resolve_retry_config(agent, default)
+
+        assert config.max_delay == 30.0
+
 
 class TestRetryDelay:
     """Tests for backoff and retry-after behavior."""
@@ -193,10 +238,43 @@ class TestRetryDelay:
         err = MockRateLimitError("rate limited")
         assert _get_retry_after(err) == 60.0
 
+    def test_retry_after_recovered_from_model_http_error_cause(self) -> None:
+        """A ModelHTTPError's response headers live on its __cause__, since
+        pydantic-ai's translation (_map_api_errors) drops them. Issue #454."""
+        cause = MockRateLimitError("rate limited")
+        err = ModelHTTPError(status_code=429, model_name="claude-x")
+        err.__cause__ = cause
+        assert _get_retry_after(err) == 60.0
+
+    def test_retry_after_recovered_from_model_http_error_body(self) -> None:
+        """A ModelHTTPError with no cause but a body carrying retry_after must
+        still surface a delay."""
+        err = ModelHTTPError(
+            status_code=429,
+            model_name="claude-x",
+            body={"error": {"retry_after": 45}},
+        )
+        assert _get_retry_after(err) == 45.0
+
+    def test_retry_after_none_when_no_cause_and_opaque_body(self) -> None:
+        """A ModelHTTPError with neither a usable cause nor a recognizable body
+        must fall through to None so the caller uses calculated backoff."""
+        err = ModelHTTPError(status_code=429, model_name="claude-x", body={"message": "oops"})
+        assert _get_retry_after(err) is None
+
     def test_extract_status_code_from_api_status_error(self) -> None:
         """HTTP status code must be extracted from APIStatusError-like errors."""
         assert _extract_status_code(MockAPIStatusError("503", 503)) == 503
         assert _extract_status_code(MockBadRequestError("bad")) == 400
+
+    def test_clamped_delay_sequence_is_60_60_60(self) -> None:
+        """The answered-question contract: base_delay == max_delay == 60
+        must produce 60s at every attempt (exponential growth clamped to the
+        user-stated cap, not the 30s provider default). Issue #454."""
+        config = RetryConfig(base_delay=60.0, max_delay=60.0, jitter=0.0)
+        assert _calculate_delay(1, config) == 60.0
+        assert _calculate_delay(2, config) == 60.0
+        assert _calculate_delay(3, config) == 60.0
 
 
 class TestExecuteWithRetry:
@@ -540,6 +618,71 @@ class TestExecuteWithRetry:
         # The original pydantic ValidationError must be preserved as the cause
         # so callers can introspect field-level errors (issue #343 contract).
         assert exc_info.value.__cause__ is schema_error
+
+    @pytest.mark.asyncio
+    async def test_model_http_error_429_retried_and_succeeds(self) -> None:
+        """Regression test for issue #454, reproduced end to end: a
+        ModelHTTPError(429) — pydantic-ai's translated form of an Anthropic
+        RateLimitError — must be retried rather than raised immediately.
+
+        ``retry_on=["provider_error"]`` mirrors the issue's YAML and exercises
+        ``_classify_error``'s fall-through for a non-ProviderError exception.
+        """
+        events: list[tuple[str, dict[str, Any]]] = []
+
+        def callback(event_type: str, payload: dict[str, Any]) -> None:
+            events.append((event_type, payload))
+
+        config = RetryConfig(
+            max_attempts=3,
+            base_delay=0.0,
+            jitter=0.0,
+            retry_on=["provider_error"],
+        )
+        factory = _make_factory([ModelHTTPError(status_code=429, model_name="claude-x"), "ok"])
+
+        with patch("conductor.providers._pydantic_ai.retry.asyncio.sleep") as mock_sleep:
+            result = await execute_with_retry(
+                factory,
+                retry_config=config,
+                event_callback=callback,
+                agent_name="retryer",
+            )
+
+        assert result == "ok"
+        assert len(events) == 1
+        assert events[0][0] == "agent_retry"
+        assert events[0][1]["error_type"] == "ModelHTTPError"
+        mock_sleep.assert_called_once_with(0.0)
+
+    @pytest.mark.asyncio
+    async def test_model_http_error_400_raises_immediately(self) -> None:
+        """A ModelHTTPError(400) must raise a non-retryable ProviderError
+        after exactly one attempt (no retry loop entered)."""
+        config = RetryConfig(max_attempts=3, base_delay=0.0, jitter=0.0)
+        factory = _make_factory([ModelHTTPError(status_code=400, model_name="claude-x")])
+        call_count = 0
+
+        async def counting_factory() -> Any:
+            nonlocal call_count
+            call_count += 1
+            return await factory()
+
+        with (
+            patch("conductor.providers._pydantic_ai.retry.asyncio.sleep") as mock_sleep,
+            pytest.raises(ProviderError) as exc_info,
+        ):
+            await execute_with_retry(
+                counting_factory,
+                retry_config=config,
+                event_callback=None,
+                agent_name="retryer",
+            )
+
+        assert exc_info.value.is_retryable is False
+        assert exc_info.value.status_code == 400
+        assert call_count == 1
+        mock_sleep.assert_not_called()
 
 
 class TestPydanticAIRetriesSplit:


### PR DESCRIPTION
## Summary
pydantic-ai translates the Anthropic SDK's exceptions before Conductor's Claude provider ever sees them, so 429/5xx responses arrive as `ModelHTTPError` and transport failures as `ModelAPIError` -- neither of which the existing retry classifier recognized. Claude rate-limit (429) errors were never retried on this path.

- `_is_retryable_error` now classifies `ModelHTTPError` (429/5xx) and `ModelAPIError` (transport failures) directly.
- `_get_retry_after` reads retry timing from `ModelHTTPError.body` and, when headers are needed, walks `__cause__` to the untranslated SDK exception that `_map_api_errors` preserves.
- Stopped silently clamping a user-configured `delay_seconds` below the provider's default `max_delay` (both pydantic-ai and Copilot retry configs) -- an explicit `delay_seconds: 60` now raises the cap instead of being capped at 30s.

Closes #454

## Testing
- `uv run pytest tests/test_providers/test_pydantic_ai_retry.py tests/test_per_agent_retry.py`