### PR TITLE
chore(release): cut 0.1.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.32...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.33...HEAD)
+
+## [0.1.33](https://github.com/microsoft/conductor/compare/v0.1.32...v0.1.33) - 2026-08-18
 
 ### Added
 
@@ -115,9 +117,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow out and fail the `--web-bg` launcher smoke job. Provider-backed
   agents are unaffected — they still report the window on both
   `agent_started` and `agent_completed`.
-
-### Fixed
-
+- **Fleet Manager TUI: the footer now says what `enter` does on each
+  screen** (issue #459). Every drill-down screen bound `enter` but left it
+  unlabeled, so the one key that navigates the TUI was the one key the
+  footer never advertised — Runs opens the run detail, Run detail opens the
+  step detail, History surfaces the `conductor replay` command, Providers
+  expands or collapses a provider, and Registries opens that registry's
+  workflows. The binding is also hidden whenever it would do nothing: an
+  empty, failed, or still-loading table, or a Providers sub-row that is not
+  a provider. Expanding a provider a second time now collapses the provider
+  you were actually on rather than whichever row the rebuild left under the
+  cursor. See [`docs/fleet.md`](docs/fleet.md).
 - **The Pydantic AI provider (`claude`) never retried on HTTP 429/5xx or
   transport errors** (#454). pydantic-ai's Anthropic model translates the
   SDK's exceptions before Conductor ever sees them (a private helper,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.32"
+version = "0.1.33"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.32"
+version = "0.1.33"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 0.1.33

Cuts release **0.1.33** (previous tag: `v0.1.32`).

## Commit audit

All **7** commits in `v0.1.32..main` were audited; every one has an explicit
disposition:

| Short SHA | Subject | PR | Classification | Changelog |
|-----------|---------|-----|----------------|-----------|
| `3905db6` | `feat(claude-agent-sdk)`: continue one Claude session via `session_key` | #409 | Added + Changed | already present (3 entries) |
| `f0849c5` | `fix(engine)`: stop non-LLM steps constructing a provider | #456 | Fixed + Changed | already present (2 entries) |
| `02b9dff` | `fix(providers)`: Claude `models.list()` failures inconclusive | #457 | Fixed | already present |
| `6ce7ee8` | `fix(providers)`: classify pydantic-ai translated errors as retryable | #458 | Fixed | already present (2 entries) |
| `9860a71` | `feat(fleet)`: resume from the TUI History screen | #463 | Added | already present |
| `107f425` | `fix(fleet)`: advertise per-screen `enter` binding in TUI footer | #461 | Fixed | **added in this PR** |
| `d39efca` | `fix(fleet)`: tick no longer repaints preview/footer; RDP anim off | #464 | Added + Fixed | already present (2 entries) |

## Changelog reconciliation

Two defects in the `[Unreleased]` section were corrected while finalizing it:

- **Added the missing entry for #461** (issue #459) — the per-screen `enter`
  binding is now advertised in the Fleet Manager TUI footer. This was the only
  user-visible change in the range with no changelog coverage.
- **Merged two duplicate `### Fixed` headings.** #456 opened a `Fixed` section
  and #458 opened a second one below it, so the release section carried the
  heading twice. All entries are now under a single `Added` / `Changed` /
  `Fixed` set, in Keep a Changelog order.

No existing entries were removed, and no changes were classified as internal —
every commit in this range is user-visible.

## Release summary

- **Added** — `session_key` session continuity for `claude-agent-sdk`;
  checkpoints persist every provider's session map; Fleet Manager TUI History
  Resume; automatic animation-off on RDP sessions with a new
  `CONDUCTOR_FLEET_ANIM` force-on switch.
- **Changed** — `runtime.skill_injection.max_bytes` default 128KB → 160KB;
  `examples/wait-smoke.yaml` timeout raised 3s → 15s.
- **Fixed** — non-LLM steps no longer build a provider inside the timed loop;
  `claude` startup no longer fails on endpoints without `models.list()`;
  pydantic-ai's translated `ModelHTTPError`/`ModelAPIError` are now retryable
  and `retry.delay_seconds` above 30s is no longer clamped; the TUI footer
  advertises `enter` per screen; the ~10fps tick no longer repaints the
  preview pane and footer.

## Validation

All run from the release worktree at the commit in this PR:

- `make check` — ruff check, ruff format --check, `ty check` all passed
- `make test` — **7457 passed**, 56 skipped, 14 deselected
- `make validate-examples` — exit 0 (schema and examples both changed in this range)
- `git diff --check` clean; diff limited to `CHANGELOG.md`, `pyproject.toml`, `uv.lock`
- `uv.lock` regenerated with `uv lock`; the only change is `conductor-cli` 0.1.32 → 0.1.33

## After merge

Merging this PR will be followed by pushing the `v0.1.33` tag at the merge
commit, which triggers
[`.github/workflows/release.yml`](.github/workflows/release.yml) to build and
publish the GitHub Release with its artifacts. The release is **not** created
manually.
