### PR TITLE
feat(cli): add runtime.log_file YAML default for --log-file

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -65,7 +65,7 @@ conductor run <workflow.yaml> [OPTIONS]
 | `--provider PROVIDER` | `-p` | Override provider (copilot, claude, claude-agent-sdk, hermes) |
 | `--dry-run` | | Show execution plan without running |
 | `--skip-gates` | | Auto-select first option at human gates |
-| `--log-file <auto\|PATH>` | `-l` | Write full debug output to a file |
+| `--log-file <auto\|PATH>` | `-l` | Write full debug output to a file. Overrides `workflow.runtime.log_file` when supplied. |
 | `--web` | | Start a real-time web dashboard |
 | `--web-bg` | | Run in background, print dashboard URL, exit |
 | `--web-port PORT` | | Port for web dashboard (0 = auto-select) |
@@ -74,6 +74,19 @@ conductor run <workflow.yaml> [OPTIONS]
 > **Note:** Output verbosity (`--quiet`/`-q`, `--silent`/`-s`) is controlled by
 > [root-level options](#root-level-options), which must appear *before* the
 > `run` subcommand: `conductor --quiet run workflow.yaml`.
+
+### File Logging
+
+Debug file logging can be configured with `workflow.runtime.log_file` or the
+`--log-file` / `-l` option. Both forms accept `auto`, which creates a
+timestamped log in the OS temporary directory's `conductor/` subdirectory, or
+an explicit file path. Relative paths are resolved from the Conductor process's
+current working directory.
+
+The YAML setting applies to both `conductor run` and `conductor resume`. An
+explicit CLI option takes precedence over `workflow.runtime.log_file`. If
+neither is set, debug file logging is disabled. See
+[Runtime Configuration](configuration.md#debug-file-logging) for the YAML form.
 
 ### Examples
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ workflow:
     default_model: gpt-5.2
     temperature: 0.7
     max_tokens: 4096
+    log_file: auto  # Optional: "auto" or a file path; disabled when omitted
     default_reasoning_effort: medium  # low | medium | high | xhigh | max (optional)
     default_context_tier: default  # default | long_context (optional, Copilot only)
     # Provider-specific settings...
@@ -389,6 +390,24 @@ workflow:
 - `0.0 - 0.3`: Factual, deterministic (data extraction, classification)
 - `0.4 - 0.7`: Balanced (general Q&A, analysis)
 - `0.8 - 1.0`: Creative (brainstorming, content generation)
+
+### Debug File Logging
+
+Use `runtime.log_file` to enable debug file logging by default for both
+`conductor run` and `conductor resume`:
+
+```yaml
+workflow:
+  runtime:
+    log_file: auto  # Or ./logs/run.log
+```
+
+`auto` creates a timestamped `.log` file in the `conductor/` subdirectory of
+the OS temporary directory. Relative paths are resolved from the Conductor
+process's current working directory. An explicit CLI `--log-file` value takes
+precedence; if both settings are omitted, file logging remains disabled. See
+[Workflow Syntax](workflow-syntax.md) and the
+[CLI reference](cli-reference.md#file-logging).
 
 ## Claude-Specific Configuration
 

--- a/docs/workflow-syntax.md
+++ b/docs/workflow-syntax.md
@@ -56,6 +56,7 @@ workflow:
     default_model: gpt-5.2
     temperature: 0.7
     max_tokens: 4096
+    log_file: auto                   # Optional: "auto" or file path (default: no file logging)
     default_reasoning_effort: medium  # Optional: low | medium | high | xhigh | max
                                       # Workflow-wide default for reasoning /
                                       # extended-thinking effort. Inherited by
@@ -79,6 +80,16 @@ workflow:
                                       # and their MCP servers. Relative paths resolve against the
                                       # parent directory of the workflow YAML file.
 ```
+
+**Runtime file logging** enables debug file logging using the same destination
+forms as CLI `--log-file`.
+Set `log_file: auto` to generate a timestamped file in the OS temporary
+directory's `conductor/` subdirectory, or specify a path such as
+`./logs/run.log`. Relative paths are resolved from the Conductor process's
+current working directory. The setting applies to both `conductor run` and
+`conductor resume`. An explicitly supplied CLI `--log-file` takes precedence;
+if neither value is set, file logging remains disabled. See the
+[CLI reference](cli-reference.md#conductor-run) for the command-line option.
 
 **Workflow metadata** is included verbatim in the `workflow_started` event and lets downstream consumers (dashboards, queue runners, observability tools) adapt without parsing the YAML. CLI `--metadata key=value` flags merge on top of YAML metadata (CLI wins on conflicts).
 

--- a/plugins/conductor/skills/conductor/references/authoring.md
+++ b/plugins/conductor/skills/conductor/references/authoring.md
@@ -14,6 +14,7 @@ workflow:
   runtime:
     provider: copilot            # copilot (default), claude, claude-agent-sdk, hermes (experimental), or openai-agents
     default_model: gpt-5.2       # Default model for agents
+    log_file: auto               # Full debug log: "auto" or a file path (optional; CLI --log-file wins)
     temperature: 0.7             # 0.0-1.0 (optional)
     max_tokens: 4096             # Max output tokens per response (optional)
     timeout: 600                 # Per-request timeout in seconds (optional)

--- a/plugins/conductor/skills/conductor/references/execution.md
+++ b/plugins/conductor/skills/conductor/references/execution.md
@@ -24,7 +24,7 @@ conductor run <workflow.yaml> [OPTIONS]
 | `--web-bg` | Run in background, print dashboard URL, exit |
 | `--web-port PORT` | Port for web dashboard (0 = auto) |
 | `--no-interactive` | Disable Esc-to-interrupt capability |
-| `--log-file`, `-l PATH` | Write full debug output to file (`auto` for auto-generated) |
+| `--log-file`, `-l <auto\|PATH>` | Write full debug output to file; overrides `runtime.log_file` when supplied |
 | `--workspace-instructions` | Auto-discover `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, and `.github/instructions/**/*.instructions.md` (only files marked `applyTo: "**"`) and prepend them to every agent prompt |
 | `--instructions PATH` | Path to a specific instruction file to prepend (repeatable) |
 
@@ -198,7 +198,7 @@ conductor resume --from <checkpoint.json> [OPTIONS]
 | `--provider`, `-p PROVIDER` | Override provider for the resumed run |
 | `--metadata`, `-m KEY=VALUE` | Workflow metadata, merged on top of YAML metadata (repeatable) |
 | `--skip-gates` | Auto-select first option at human gates |
-| `--log-file`, `-l PATH` | Write debug output to file |
+| `--log-file`, `-l <auto\|PATH>` | Write debug output to file; overrides `runtime.log_file` when supplied |
 | `--no-interactive` | Disable Esc-to-interrupt |
 | `--web` | Start real-time web dashboard for the resumed run |
 | `--web-port PORT` | Port for the dashboard (0 = auto) |
@@ -414,7 +414,21 @@ conductor run workflow.yaml --log-file auto
 conductor -s run workflow.yaml --log-file debug.log
 ```
 
-Capture full debug output to a file. Combine with `--silent` for quiet terminal with full logging. Auto mode generates files in `$TMPDIR/conductor/`.
+Set a workflow default so the flag does not need to be repeated:
+
+```yaml
+workflow:
+  runtime:
+    log_file: auto  # Or ./logs/run.log
+```
+
+Both the YAML field and CLI option accept `auto`, which creates a timestamped
+file in the OS temporary directory's `conductor/` subdirectory, or an explicit
+file path. Relative paths are resolved from the Conductor process's current
+working directory. The YAML setting applies to both `run` and `resume`; an
+explicit CLI `--log-file` value takes precedence. If neither is set, debug file
+logging is disabled. Combine with `--silent` for a quiet terminal with file
+logging enabled.
 
 ### Dry Run
 

--- a/plugins/conductor/skills/conductor/references/yaml-schema.md
+++ b/plugins/conductor/skills/conductor/references/yaml-schema.md
@@ -30,6 +30,8 @@ workflow:
     provider: string | object       # "copilot" (default), "claude", "claude-agent-sdk", "hermes", or "openai-agents"
                                     # — or a ProviderSettings object (see below)
     default_model: string           # Default model for all agents
+    log_file: string                # Full debug log path, or "auto" for a generated temp file (optional)
+                                    # CLI --log-file overrides this value; omitted means no file logging
     temperature: float              # 0.0-1.0, controls randomness (optional, copilot/claude/hermes)
     max_tokens: integer             # Max OUTPUT tokens per response, 1-200000 (optional, copilot/claude/hermes)
     timeout: float                  # Per-request timeout in seconds (optional, default: 600, copilot/claude only)

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -139,6 +139,24 @@ def init_file_logging(log_path: Path) -> None:
     )
 
 
+def _try_init_file_logging(log_path: Path | None) -> bool:
+    """Initialize file logging, returning whether initialization succeeded."""
+    if log_path is None:
+        return False
+
+    try:
+        init_file_logging(log_path)
+    except OSError as e:
+        _verbose_console.print(
+            styled(
+                "[bold yellow]Warning:[/bold yellow] Cannot open log file {}: {}", log_path, e
+            )
+        )
+        return False
+
+    return True
+
+
 def close_file_logging() -> None:
     """Close file logging and clean up resources."""
     global _file_console, _file_handle
@@ -1959,15 +1977,7 @@ async def run_workflow_async(
     start_time = time.time()
 
     # Initialize file logging if requested
-    if log_file is not None:
-        try:
-            init_file_logging(log_file)
-        except OSError as e:
-            _verbose_console.print(
-                styled(
-                    "[bold yellow]Warning:[/bold yellow] Cannot open log file {}: {}", log_file, e
-                )
-            )
+    _try_init_file_logging(log_file)
 
     # Always create event emitter and JSONL log subscriber
     emitter = WorkflowEventEmitter()
@@ -1994,6 +2004,15 @@ async def run_workflow_async(
         load_start = time.time()
         config = load_config(workflow_path)
         verbose_log_timing("Configuration loaded", time.time() - load_start)
+
+        if log_file is None:
+            configured = config.workflow.runtime.log_file
+            if configured is not None:
+                if configured.lower() == "auto":
+                    log_file = generate_log_path(workflow_path.stem)
+                else:
+                    log_file = Path(configured)
+                _try_init_file_logging(log_file)
 
         # Merge CLI metadata on top of YAML-declared metadata
         if metadata:
@@ -2592,15 +2611,7 @@ async def resume_workflow_async(
     start_time = time.time()
 
     # Initialize file logging if requested
-    if log_file is not None:
-        try:
-            init_file_logging(log_file)
-        except OSError as e:
-            _verbose_console.print(
-                styled(
-                    "[bold yellow]Warning:[/bold yellow] Cannot open log file {}: {}", log_file, e
-                )
-            )
+    _try_init_file_logging(log_file)
 
     # Always create event emitter and JSONL log subscriber (parity with run)
     emitter = WorkflowEventEmitter()
@@ -2658,6 +2669,15 @@ async def resume_workflow_async(
         # Load workflow config first — needed both to construct the dashboard
         # (workflow_root) and to seed the synthetic replay fallback.
         config = load_config(resolved_workflow_path)
+
+        if log_file is None:
+            configured = config.workflow.runtime.log_file
+            if configured is not None:
+                if configured.lower() == "auto":
+                    log_file = generate_log_path(resolved_workflow_path.stem)
+                else:
+                    log_file = Path(configured)
+                _try_init_file_logging(log_file)
 
         # Merge CLI metadata on top of YAML-declared metadata (parity with run)
         if metadata:

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -148,9 +148,7 @@ def _try_init_file_logging(log_path: Path | None) -> bool:
         init_file_logging(log_path)
     except OSError as e:
         _verbose_console.print(
-            styled(
-                "[bold yellow]Warning:[/bold yellow] Cannot open log file {}: {}", log_path, e
-            )
+            styled("[bold yellow]Warning:[/bold yellow] Cannot open log file {}: {}", log_path, e)
         )
         return False
 

--- a/src/conductor/config/schema.py
+++ b/src/conductor/config/schema.py
@@ -3332,6 +3332,9 @@ class RuntimeConfig(BaseModel):
     default_model: str | None = None
     """Default model for agents that don't specify one."""
 
+    log_file: str | None = None
+    """Default log file path, or ``auto`` to generate one automatically."""
+
     mcp_servers: dict[str, MCPServerDef] = Field(default_factory=dict)
     """MCP server configurations keyed by server name."""
 

--- a/tests/test_cli/test_logging.py
+++ b/tests/test_cli/test_logging.py
@@ -395,6 +395,68 @@ class TestGenerateLogPath:
         assert str(path).startswith(tempfile.gettempdir())
 
 
+class TestTryInitFileLogging:
+    """Tests for _try_init_file_logging helper."""
+
+    def test_try_init_with_valid_path(self, tmp_path: Path) -> None:
+        """Test successful initialization with a valid path."""
+        from conductor.cli.run import (
+            _try_init_file_logging,
+            close_file_logging,
+            verbose_log,
+        )
+
+        log_path = tmp_path / "test.log"
+        token = verbose_mode.set(False)
+        try:
+            result = _try_init_file_logging(log_path)
+            assert result is True
+            assert log_path.exists()
+
+            verbose_log("hello from try_init")
+            close_file_logging()
+
+            content = log_path.read_text(encoding="utf-8")
+            assert "hello from try_init" in content
+        finally:
+            close_file_logging()
+            verbose_mode.reset(token)
+
+    def test_try_init_with_none(self) -> None:
+        """Test no-op when path is None."""
+        from conductor.cli.run import _try_init_file_logging
+
+        result = _try_init_file_logging(None)
+        assert result is False
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix-specific chmod permissions")
+    def test_try_init_with_permission_error(self, tmp_path: Path) -> None:
+        """Test graceful handling of OSError (warning to stderr, no raise)."""
+        import os
+        from io import StringIO
+
+        from rich.console import Console
+
+        from conductor.cli.run import _try_init_file_logging, close_file_logging
+
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        os.chmod(readonly_dir, 0o444)
+
+        stderr_output = StringIO()
+        mock_console = Console(file=stderr_output, no_color=True, highlight=False)
+
+        try:
+            with patch("conductor.cli.run._verbose_console", mock_console):
+                result = _try_init_file_logging(readonly_dir / "test.log")
+
+            assert result is False
+            assert "Cannot open log file" in stderr_output.getvalue()
+        finally:
+            close_file_logging()
+            os.chmod(readonly_dir, 0o755)
+
+
 class TestVerboseLogging:
     """Tests for verbose logging functions (migrated from test_verbose.py)."""
 
@@ -1620,6 +1682,163 @@ class TestFileLoggingDualWrite:
         finally:
             full_mode.reset(token_full)
             verbose_mode.reset(token_verbose)
+
+
+class TestYamlLogFileFallback:
+    """Tests for runtime.log_file fallback and CLI precedence."""
+
+    @staticmethod
+    def _write_workflow(tmp_path: Path, log_path: Path) -> Path:
+        workflow_file = tmp_path / "test.yaml"
+        workflow_file.write_text(
+            f"""\
+workflow:
+  name: test-workflow
+  entry_point: agent1
+  runtime:
+    log_file: "{log_path.as_posix()}"
+
+agents:
+  - name: agent1
+    prompt: "Hello"
+    routes:
+      - to: $end
+
+output:
+  result: "done"
+""",
+            encoding="utf-8",
+        )
+        return workflow_file
+
+    @staticmethod
+    def _run_with_mocked_engine(
+        workflow_file: Path,
+        *,
+        log_file: Path | None,
+    ) -> dict[str, object]:
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from conductor.cli.run import run_workflow_async
+
+        mock_registry = AsyncMock()
+        mock_registry.__aenter__ = AsyncMock(return_value=mock_registry)
+        mock_registry.__aexit__ = AsyncMock(return_value=False)
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value={"result": "done"})
+
+        with (
+            patch("conductor.cli.run.ProviderRegistry", return_value=mock_registry),
+            patch("conductor.cli.run.WorkflowEngine", return_value=mock_engine),
+        ):
+            return asyncio.run(run_workflow_async(workflow_file, {}, log_file=log_file))
+
+    def test_yaml_log_file_explicit_path(self, tmp_path: Path) -> None:
+        """Use runtime.log_file when the CLI option is unset."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        log_path = tmp_path / "yaml.log"
+        workflow_file = self._write_workflow(tmp_path, log_path)
+        stderr_output = StringIO()
+        mock_console = Console(
+            file=stderr_output,
+            no_color=True,
+            highlight=False,
+            width=500,
+        )
+
+        with patch("conductor.cli.run._verbose_console", mock_console):
+            result = self._run_with_mocked_engine(workflow_file, log_file=None)
+
+        assert result == {"result": "done"}
+        assert log_path.exists()
+        assert "Log written to" in stderr_output.getvalue()
+        assert str(log_path) in stderr_output.getvalue()
+
+    def test_cli_log_file_overrides_yaml(self, tmp_path: Path) -> None:
+        """Prefer the CLI log path over runtime.log_file."""
+        yaml_log_path = tmp_path / "yaml.log"
+        cli_log_path = tmp_path / "cli.log"
+        workflow_file = self._write_workflow(tmp_path, yaml_log_path)
+
+        result = self._run_with_mocked_engine(workflow_file, log_file=cli_log_path)
+
+        assert result == {"result": "done"}
+        assert cli_log_path.exists()
+        assert not yaml_log_path.exists()
+
+    def test_resume_yaml_log_file_fallback(self, tmp_path: Path) -> None:
+        """Use runtime.log_file when resume has no CLI log path."""
+        import asyncio
+        import json
+        from unittest.mock import AsyncMock, MagicMock
+
+        from conductor.cli.run import resume_workflow_async
+        from conductor.engine.checkpoint import CheckpointManager
+
+        log_path = tmp_path / "resume.log"
+        workflow_file = self._write_workflow(tmp_path, log_path)
+        workflow_hash = CheckpointManager.compute_workflow_hash(workflow_file)
+        checkpoint_file = tmp_path / "checkpoint.json"
+        checkpoint_file.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "workflow_path": str(workflow_file.resolve()),
+                    "workflow_hash": workflow_hash,
+                    "created_at": "2026-02-24T15:30:00+00:00",
+                    "failure": {
+                        "error_type": "ProviderError",
+                        "message": "Network error",
+                        "agent": "agent1",
+                        "iteration": 1,
+                    },
+                    "inputs": {},
+                    "current_agent": "agent1",
+                    "context": {
+                        "workflow_inputs": {},
+                        "agent_outputs": {},
+                        "current_iteration": 0,
+                        "execution_history": [],
+                    },
+                    "limits": {
+                        "current_iteration": 0,
+                        "max_iterations": 10,
+                        "execution_history": [],
+                    },
+                    "copilot_session_ids": {},
+                    "run_id": "",
+                    "event_log_path": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        mock_registry = AsyncMock()
+        mock_registry.__aenter__ = AsyncMock(return_value=mock_registry)
+        mock_registry.__aexit__ = AsyncMock(return_value=False)
+
+        mock_engine = MagicMock()
+        mock_engine.resume = AsyncMock(return_value={"result": "done"})
+
+        with (
+            patch("conductor.cli.run.ProviderRegistry", return_value=mock_registry),
+            patch("conductor.cli.run.WorkflowEngine", return_value=mock_engine),
+        ):
+            result = asyncio.run(
+                resume_workflow_async(
+                    workflow_file,
+                    checkpoint_file,
+                    log_file=None,
+                )
+            )
+
+        assert result == {"result": "done"}
+        assert log_path.exists()
 
 
 class TestFileLoggingStderrNotification:

--- a/tests/test_cli/test_logging.py
+++ b/tests/test_cli/test_logging.py
@@ -1690,8 +1690,7 @@ class TestYamlLogFileFallback:
     @staticmethod
     def _write_workflow(tmp_path: Path, log_path: Path) -> Path:
         workflow_file = tmp_path / "test.yaml"
-        workflow_file.write_text(
-            f"""\
+        workflow_yaml = f"""\
 workflow:
   name: test-workflow
   entry_point: agent1
@@ -1706,9 +1705,8 @@ agents:
 
 output:
   result: "done"
-""",
-            encoding="utf-8",
-        )
+"""
+        workflow_file.write_text(workflow_yaml, encoding="utf-8")
         return workflow_file
 
     @staticmethod

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -680,6 +680,23 @@ class TestRuntimeConfig:
         assert config.max_tokens is None
         assert config.timeout is None
 
+    def test_log_file_field(self) -> None:
+        """Test runtime.log_file field: default, 'auto', and explicit path."""
+        assert RuntimeConfig().log_file is None
+
+        config = RuntimeConfig(log_file="auto")
+        assert config.log_file == "auto"
+
+        config = RuntimeConfig(log_file="/tmp/my-workflow.log")
+        assert config.log_file == "/tmp/my-workflow.log"
+
+        original = RuntimeConfig(log_file="auto")
+        restored = RuntimeConfig(**original.model_dump())
+        assert restored.log_file == "auto"
+
+        serialized = RuntimeConfig().model_dump(exclude_none=True)
+        assert "log_file" not in serialized
+
     def test_custom_provider(self) -> None:
         """Test custom provider setting."""
         config = RuntimeConfig(provider="openai-agents", default_model="gpt-4")


### PR DESCRIPTION
# Summary
Add a log_file field to RuntimeConfig so workflow authors can set a default log destination in YAML.
The CLI --log-file flag continues to take precedence when specified.

# Motivation
Currently, file logging requires passing --log-file on every invocation.
When forgotten, crashes leave no diagnostic log.
This is especially painful for long-running workflows(30-60 min).
Other runtime fields(default_model, max_tokens, temperature, timeout) already support YAML defaults -- log_file should follow the same pattern.

# Usage
```
workflow:
  runtime:
    log_file: auto
```
Accepts the same values as CLI --log-file:
・auto -- Generate a timestamped path in $TMPDIR/conductor/.
・An explicit path (e.g. ./logs/run.log) -- Write to that path directly.
・Omitted -- No file logging(current default, unchanged).

# Design
CLI --log-file and YAML runtime.log_file become available at different times.
CLI is known before YAML parse: YAML is known only after load_config(). So:
・CLI --log-file specified -> log init before YAML parse(existing behavior, unchanged)
・CLI unset -> after load_config(), check runtime.log_file and init if present.
・CLI takes precedence when both are set.

Closes #472
