### PR TITLE
test(fleet): wait on conditions instead of fixed sleeps in TUI poll tests

### DIFF
--- a/tests/test_fleet/conftest.py
+++ b/tests/test_fleet/conftest.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -77,3 +79,64 @@ async def settle(pilot: Any) -> None:
     with contextlib.suppress(WorkerCancelled, WorkerFailed):
         await asyncio.wait_for(pilot.app.workers.wait_for_complete(), timeout=30)
     await pilot.pause()
+
+
+async def wait_for(
+    pilot: Any,
+    predicate: Callable[[], bool],
+    *,
+    message: str,
+    timeout: float = 20.0,
+) -> None:
+    """Pump the app until ``predicate`` holds, instead of sleeping a fixed time.
+
+    The screens these tests drive refresh on a **real** ``set_interval``
+    timer (shrunk to 0.05s by the tests that exercise polling), and each
+    tick hops through ``asyncio.to_thread`` before rendering. How long a
+    tick-plus-scan actually takes is a property of the machine, not of the
+    test: on CI it runs under ``coverage`` tracing on a small shared
+    runner, where a measured scan is several times slower than on a
+    developer box. A fixed ``await asyncio.sleep(0.3)`` followed by an
+    assertion therefore encodes a guess about machine speed, and asserts
+    against pre-tick state whenever the guess is wrong -- which is exactly
+    how ``test_poll_tick_removes_completed_run`` failed on Windows CI while
+    passing everywhere else.
+
+    Waiting on the *condition* removes the guess: a fast machine returns on
+    the first sample, a slow one takes longer, and only a genuinely wedged
+    screen reaches the deadline and fails -- with ``message`` naming the
+    regression rather than an opaque ``assert 1 == 0``.
+
+    Samples with a plain ``asyncio.sleep`` rather than ``pilot.pause()``.
+    That is deliberate and load-bearing: ``pilot.pause()`` waits for the
+    app to go *idle*, which under a 20Hz poll timer takes ~1 second per
+    call (measured), so a ``pause``-driven loop gets only a handful of
+    samples however long its deadline is. Yielding to the event loop is
+    all that is actually required for a worker to finish and render, since
+    the render half runs on that loop. A single ``pilot.pause()`` is done
+    once the predicate holds, so anything asserted about *painted* output
+    afterwards sees a settled screen.
+
+    Args:
+        pilot: The Textual ``Pilot`` driving the app under test.
+        predicate: Called on each sample; must be cheap and side-effect
+            free. Should describe a **monotonic** condition ("the row
+            appeared") rather than a transient one ("a refresh is in
+            flight"), since a transient condition can switch back between
+            two samples however fast the loop runs.
+        message: Assertion message describing the regression a timeout
+            implies.
+        timeout: Seconds before giving up. Generous by default because it
+            is only ever reached on failure.
+
+    Raises:
+        AssertionError: If ``predicate`` never held before the deadline.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if predicate():
+            await pilot.pause()
+            return
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"{message} (waited {timeout:g}s)")
+        await asyncio.sleep(0.01)

--- a/tests/test_fleet/test_tui_run_detail.py
+++ b/tests/test_fleet/test_tui_run_detail.py
@@ -33,7 +33,7 @@ from conductor.fleet.tui.app import FleetApp
 from conductor.fleet.tui.screens.run_detail import RunDetailScreen, _collect_detail
 from conductor.fleet.tui.screens.runs import RunsScreen
 from conductor.fleet.tui.screens.step_detail import StepDetailScreen
-from tests.test_fleet.conftest import settle
+from tests.test_fleet.conftest import settle, wait_for
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -587,8 +587,11 @@ class TestRunDetailPolling:
 
             # Wait out several poll intervals (real time -- set_interval is
             # a real asyncio timer, not something pilot.pause() advances).
-            await asyncio.sleep(0.3)
-            await settle(pilot)
+            await wait_for(
+                pilot,
+                lambda: "completed" in str(table.get_row_at(0)[2]).lower(),
+                message="the poll tick never picked up the appended agent_completed event",
+            )
 
             row = table.get_row_at(0)
             assert "completed" in str(row[2]).lower()
@@ -620,8 +623,11 @@ class TestRunDetailPolling:
 
             _write_jsonl(log_path, [_workflow_started_event(["researcher"])])
 
-            await asyncio.sleep(0.3)
-            await settle(pilot)
+            await wait_for(
+                pilot,
+                lambda: table.display is True,
+                message="the placeholder never recovered once workflow_started arrived",
+            )
 
             assert table.display is True
             assert placeholder.display is False
@@ -761,6 +767,14 @@ class TestRunDetailWorkerThreading:
             async with app.run_test() as pilot:
                 await settle(pilot)
                 await pilot.press("enter")
+
+                # "No *second* call" only means something once the first
+                # one has happened -- see the Runs-screen twin of this test.
+                await wait_for(
+                    pilot,
+                    lambda: call_count >= 1,
+                    message="the mount refresh never entered the collector",
+                )
 
                 # Several poll intervals elapse while the collector is
                 # blocked -- none of them may start a second worker.

--- a/tests/test_fleet/test_tui_runs.py
+++ b/tests/test_fleet/test_tui_runs.py
@@ -31,7 +31,7 @@ from conductor.fleet.tui.anim import FRAME_INTERVAL
 from conductor.fleet.tui.app import FleetApp
 from conductor.fleet.tui.screens import runs as runs_module
 from conductor.fleet.tui.screens.runs import RunScan, RunsScreen, _collect_runs
-from tests.test_fleet.conftest import settle
+from tests.test_fleet.conftest import settle, wait_for
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -70,32 +70,40 @@ def fleet_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
-async def _assert_guard_released(pilot: Any, screen: RunsScreen, *, timeout: float = 5.0) -> None:
-    """Assert ``_refreshing`` *clears*, rather than sampling it once.
+async def _assert_screen_still_refreshes(
+    pilot: Any, screen: RunsScreen, tmp_path: Path, *, run_id: str
+) -> None:
+    """Prove the ``_refreshing`` guard was released, via what a user sees.
 
-    The guard-recovery tests shrink ``POLL_INTERVAL_SECONDS`` so a later
-    tick can be observed unattended, which means the flag legitimately
-    flips back to ``True`` every interval -- including during ``settle()``'s
-    trailing ``pilot.pause()``, where a tick can dispatch a fresh refresh
-    between the last worker finishing and the assertion reading the flag.
-    A single-instant ``assert screen._refreshing is False`` therefore fails
-    at random (it did, on CI and ~20% of local runs) for a reason that has
-    nothing to do with the ``finally`` it is meant to pin.
+    The property under test is that one transient error cannot stop the
+    screen refreshing for the rest of the session. The obvious way to check
+    that -- reading ``screen._refreshing`` and expecting ``False`` -- cannot
+    be made reliable, because the flag is *transient*: these tests shrink
+    ``POLL_INTERVAL_SECONDS`` to 0.05 so a later tick can be observed, so
+    the flag legitimately returns to ``True`` 20 times a second. Sampling it
+    is a coin flip, and a slow machine loads the coin: measured under
+    ``coverage`` (how CI runs), the flag is ``True`` ~35% of the time while
+    ``pilot.pause()`` costs ~1s a call, so a 5s sampling loop gets only ~4
+    looks and can legitimately see ``True`` on every one. That is how this
+    passed locally and failed on CI three times.
 
-    What that ``finally`` actually guarantees is that the flag *clears*.
-    Without it the flag latches ``True`` for the rest of the session and
-    every subsequent tick is dropped, so this wait times out -- the
-    regression is still caught, just not by a coin flip.
+    So assert the *consequence* instead. A new record is written and the
+    table is expected to grow to include it. That condition is monotonic --
+    once true it stays true, so no sampling rate can miss it -- and it is
+    unreachable if the guard latched, because then every subsequent poll
+    tick is dropped and no scan ever runs again. It is also strictly
+    stronger than reading the flag: it proves the screen recovered all the
+    way to rendering, not merely that a boolean flipped.
     """
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if screen._refreshing is False:
-            return
-        await pilot.pause()
-        await asyncio.sleep(0.01)
-    raise AssertionError(
-        "_refreshing never cleared -- a transient failure wedged the screen, "
-        "so no later refresh can run"
+    before = screen.query_one(DataTable).row_count
+    _write_record(tmp_path, run_id, workflow_name=run_id)
+    await wait_for(
+        pilot,
+        lambda: screen.query_one(DataTable).row_count == before + 1,
+        message=(
+            "the screen never refreshed again after a transient failure -- the "
+            "_refreshing guard was not released, so every later poll tick is dropped"
+        ),
     )
 
 
@@ -349,12 +357,12 @@ class TestRunsScreenPolling:
 
             _write_record(tmp_path, "run-new", workflow_name="newwf")
 
-            # Wait out several poll intervals (real time -- set_interval is
-            # a real asyncio timer, not something pilot.pause() advances).
-            await asyncio.sleep(0.3)
-            await settle(pilot)
+            await wait_for(
+                pilot,
+                lambda: table.row_count == 1,
+                message="the poll tick never picked up the newly written record",
+            )
 
-            assert table.row_count == 1
             row = table.get_row_at(0)
             assert "newwf" in row[0]
 
@@ -377,10 +385,11 @@ class TestRunsScreenPolling:
 
             remove_run_record("run-a")
 
-            await asyncio.sleep(0.3)
-            await settle(pilot)
-
-            assert table.row_count == 0
+            await wait_for(
+                pilot,
+                lambda: table.row_count == 0,
+                message="the poll tick never dropped the removed run from the table",
+            )
 
 
 class TestCollectRuns:
@@ -504,6 +513,17 @@ class TestRunsScreenWorkerThreading:
         with patch("conductor.fleet.tui.screens.runs._collect_runs", side_effect=_blocking_collect):
             app = FleetApp()
             async with app.run_test() as pilot:
+                # "No *second* call" only means something once the first
+                # one has happened; asserting both at a fixed deadline
+                # conflates "the tick was skipped" with "the mount refresh
+                # had not started yet", which is what a slow CI runner
+                # produces.
+                await wait_for(
+                    pilot,
+                    lambda: call_count >= 1,
+                    message="the mount refresh never entered the collector",
+                )
+
                 # Several poll intervals elapse while the collector is
                 # blocked -- none of them may start a second worker.
                 await asyncio.sleep(0.3)
@@ -741,14 +761,33 @@ class TestRunsScreenCursorPreservation:
         app = FleetApp()
         async with app.run_test() as pilot:
             await settle(pilot)
-            table = app.screen.query_one(DataTable)
+            screen = app.screen
+            assert isinstance(screen, RunsScreen)
+            table = screen.query_one(DataTable)
             assert table.row_count == 2
 
             table.move_cursor(row=1)
             selected_row = table.get_row_at(table.cursor_row)
 
-            await asyncio.sleep(0.3)
-            await settle(pilot)
+            # Wait for a tick to actually rebuild the table. Sleeping a
+            # fixed 0.3s instead would pass *vacuously* on a machine slow
+            # enough that no tick landed -- the test would stop exercising
+            # the rebuild precisely on the runs where it is slowest, which
+            # is where a regression is most likely to show.
+            rebuilds = 0
+            real_render = type(screen)._render_runs
+
+            def _counting_render(self_, scan):
+                nonlocal rebuilds
+                rebuilds += 1
+                return real_render(self_, scan)
+
+            with patch.object(type(screen), "_render_runs", _counting_render):
+                await wait_for(
+                    pilot,
+                    lambda: rebuilds >= 1,
+                    message="no poll tick rebuilt the table, so the selection was never at risk",
+                )
 
             # Compared on the workflow cell rather than the whole row: the
             # Burn sparkline legitimately changes between polls (that is
@@ -971,16 +1010,25 @@ class TestRunsScreenGuardRecovery:
             with patch(
                 "conductor.fleet.tui.screens.runs.read_run_records",
                 side_effect=OSError("transient failure"),
-            ):
+            ) as failing_read:
                 screen.refresh_runs()
+                # Wait for the injected failure to actually be hit rather
+                # than assuming the dispatch above did it: a poll tick may
+                # legitimately already be in flight, in which case that
+                # explicit request is dropped by the very guard under test
+                # and it is the *next* tick that fails.
+                await wait_for(
+                    pilot,
+                    lambda: failing_read.call_count >= 1,
+                    message=(
+                        "no scan ran while the failure was injected -- the screen was "
+                        "already wedged before this test injected anything"
+                    ),
+                    timeout=5.0,
+                )
                 await settle(pilot)
 
-            await _assert_guard_released(pilot, screen)
-
-            # And it genuinely recovers on a later tick.
-            await asyncio.sleep(0.3)
-            await settle(pilot)
-            assert screen.query_one(DataTable).row_count == 1
+            await _assert_screen_still_refreshes(pilot, screen, tmp_path, run_id="run-b")
 
     async def test_a_render_failure_does_not_wedge_the_screen_or_exit_the_app(
         self, fleet_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -997,18 +1045,24 @@ class TestRunsScreenGuardRecovery:
             screen = app.screen
             assert isinstance(screen, RunsScreen)
 
-            with patch.object(type(screen), "_render_runs", side_effect=RuntimeError("render bug")):
+            with patch.object(
+                type(screen), "_render_runs", side_effect=RuntimeError("render bug")
+            ) as failing_render:
                 screen.refresh_runs()
-                await settle(pilot)
-                await asyncio.sleep(0.2)
+                await wait_for(
+                    pilot,
+                    lambda: failing_render.call_count >= 1,
+                    message=(
+                        "no render ran while the failure was injected -- the screen was "
+                        "already wedged before this test injected anything"
+                    ),
+                    timeout=5.0,
+                )
                 await settle(pilot)
 
             assert app.is_running
-            await _assert_guard_released(pilot, screen)
 
-            await asyncio.sleep(0.2)
-            await settle(pilot)
-            assert screen.query_one(DataTable).row_count == 1
+            await _assert_screen_still_refreshes(pilot, screen, tmp_path, run_id="run-b")
 
     async def test_two_dispatches_on_one_turn_start_only_one_worker(
         self, fleet_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Problem

Main's CI has been failing intermittently. The failures are **flaky tests, not a product regression** — `src/` needs no change.

Two failures on `main`, both in the Fleet Manager TUI pilot tests:

| Run | Test | Failure |
|---|---|---|
| [32296506434](https://github.com/microsoft/conductor/actions/runs/32296506434) (3.13/ubuntu) | `test_a_scan_failure_does_not_wedge_the_screen` | `_refreshing never cleared` |
| [32272384555](https://github.com/microsoft/conductor/actions/runs/32272384555) (3.13/windows) | `test_poll_tick_removes_completed_run` | `assert 1 == 0` |

The first also failed on [32044377141](https://github.com/microsoft/conductor/actions/runs/32044377141) (Aug 17), in its pre-#464 single-sample form — so this is a recurring flake a previous fix attempt did not close.

## Root cause

These tests assert on state that only becomes true once a **real** `set_interval` poll tick lands, but wait a fixed `asyncio.sleep(0.3)` or sample a transient flag. CI runs pytest **under `coverage` tracing** on a small shared runner, where a tick-plus-scan is several times slower than on a developer box, so the fixed wait encodes a guess about machine speed and asserts against pre-tick state when the guess is wrong.

The guard-recovery test is the more interesting one. Instrumenting it:

- `pilot.pause()` costs **~1s per call** under the tests' 20 Hz timer (it waits for the app to go *idle*, which a 0.05s poll timer keeps deferring), so the helper's 5s deadline yielded only **~4 samples**.
- `_refreshing` is legitimately `True` **19.5%** of the time idle and **34.8%** under coverage.

So the assertion was a coin flip that a slow machine loads — it can see `True` on every sample and report a wedged screen. The `finally` in `_refresh_worker` that it guards is correct and present.

## Fix

- Add `wait_for(pilot, predicate, message=...)` to `tests/test_fleet/conftest.py`: polls a condition to a deadline, samples with `asyncio.sleep` rather than the ~1s `pilot.pause()`, and fails with a message naming the regression instead of an opaque `assert 1 == 0`.
- Rewrite the two guard-recovery tests to assert a **monotonic, user-visible consequence** — a newly written record appears in the table — rather than sampling a transient flag. That cannot be missed by any sampling rate, is unreachable if the guard latched, and proves recovery all the way to rendering.
- Convert the affected poll sites in `test_tui_runs.py` and `test_tui_run_detail.py`.
- Fix two latent siblings of the same bug: an `assert call_count == 1` that could observe `0` before the mount refresh had entered the collector, and a selection-preservation test that passed **vacuously** when no tick landed inside the fixed sleep.

## Verification

- **Mutation test** — removing the `finally` in `_refresh_worker` makes both rewritten tests fail deterministically in ~2s with the intended message (`no scan ran while the failure was injected -- the screen was already wedged...`). The new assertions are not vacuous.
- **Contention test** — 2 contended CPUs + coverage (~6x slowdown, worse than CI): reworked tests **8/8 pass**; the previous versions reproduced the failure **1/8** under identical conditions.
- Full CI-equivalent suite (`-m "not real_api and not performance"`, with coverage): **7426 passed, 60 skipped**.
- `make lint` and `make typecheck` clean.
- Bonus: the affected tests run ~2x faster, since they now return as soon as the condition holds instead of sleeping fixed durations and calling the slow `settle()`.