### PR TITLE
chore(release): cut 0.1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.33...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.34...HEAD)
+
+## [0.1.34](https://github.com/microsoft/conductor/compare/v0.1.33...v0.1.34) - 2026-08-24
 
 ### Added
 
@@ -21,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   A custom `base_url` requires an explicit `api_key`: an ambient `OPENAI_API_KEY`
   is never forwarded to a non-OpenAI endpoint.
+
+- **Fleet TUI launch directory** (#477) — `conductor fleet` can now start runs
+  in a directory other than the one it was itself launched from. `d` on the
+  Runs screen (or `ctrl+d` on New run) opens a directory picker; the chosen
+  directory is the base a relative workflow reference on the New Run screen
+  resolves against, and the working directory that a launched or resumed run's
+  detached child inherits. It is process-lifetime only — there is no
+  `config.toml` key and no state file, and it resets when `conductor fleet`
+  exits. It does not affect `runtime.working_dir` / `agent.working_dir`, and it
+  is not a filter: Runs and History still show the whole fleet. See
+  `docs/fleet.md`.
 
 - **`runtime.idle_timeout_seconds` / `runtime.max_idle_recovery_attempts`**
   (#488) — Copilot-only knobs to tune the idle watchdog for workflows with
@@ -87,6 +100,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   event into the input, silently replacing the prefilled launch directory
   with its parent before the user ever touched the tree. The mirror now
   fires only while the tree actually has focus.
+- **The Fleet Manager no longer loses data from large event logs** (#485).
+  The Runs, History, and run-detail screens read a run's JSONL event log
+  through three separate bounded windows — a 512 KiB tail, a 512 KiB head
+  recovery read, and an 8 MiB whole-log cap — that a long-lived or resumed run
+  outgrows. On a real 9.72 MB / 20,361-line log this lost the current step and
+  the token/cost totals, and a resumed run's second `workflow_started` fell
+  outside the head window, so the wrong workflow topology was reported. All
+  three windows are replaced by one streamed reader bounded only by the longest
+  individual line, and a resumed run's totals now accumulate across generations
+  while its status, gate, and topology reflect the current attempt. The Runs
+  screen's ~2s poll prefilters lines by event type before parsing them, so the
+  uncapped read is also faster than the capped one it replaces.
 - **A run record could silently fail to be removed on Windows** (#486).
   `remove_run_record` deleted a record with a single unretried `unlink`, and
   `remove_run_record_for_current_process` renamed it into a quarantine path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.33"
+version = "0.1.34"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -391,7 +391,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.33"
+version = "0.1.34"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Cuts release **0.1.34** (previous tag: `v0.1.33`).

## Commit audit

All **9** commits in `v0.1.33..main` were audited — none omitted silently.

| # | Commit | Subject | Disposition |
|---|--------|---------|-------------|
| 1 | `4c98ab7` | chore(deps): bump the github-actions group (#467) | Internal — CI workflows only |
| 2 | `2dbb712` | fix(mcp): support MCP 2.0 tool schemas (#420) | Fixed — already in changelog |
| 3 | `3d9b071` | feat(providers): native OpenAI provider on Pydantic AI (#421) | Added — already in changelog |
| 4 | `2e5689d` | test(fleet): wait on conditions instead of fixed sleeps (#478) | Internal — tests only |
| 5 | `3c07139` | feat(fleet): switch working directory for new runs (#479) | **Added — entry added by this PR** |
| 6 | `d83e278` | fix(fleet): Windows sharing-violation retries + dir picker (#487) | Fixed — already in changelog |
| 7 | `134b735` | fix(copilot): recover from a dead spawned runtime (#484) | Fixed — already in changelog |
| 8 | `75eceda` | fix(fleet): uncapped event-log streaming (#489) | **Fixed — entry added by this PR** |
| 9 | `812a7dc` | fix(providers): suppress idle watchdog during tool calls (#490) | Added + Fixed — already in changelog |

Two user-visible changes had shipped without a changelog entry (#479 and #489);
both are added here. No existing entries were removed, and no empty category
headings remain.

## Changelog summary for 0.1.34

**Added**
- Native `openai` provider on the shared Pydantic AI runtime, with MCP tools,
  structured output, interrupts, reasoning effort, and the full 0.0–2.0
  temperature range.
- Fleet TUI **launch directory** — `d` / `ctrl+d` picks the directory a new or
  resumed run is launched in and that relative workflow references resolve
  against.
- `runtime.idle_timeout_seconds` / `runtime.max_idle_recovery_attempts`
  (Copilot-only idle-watchdog tuning).

**Changed**
- `pydantic-ai` narrowed to `pydantic-ai-slim[anthropic,openai]`.
- The reserved `openai-agents` provider name was removed from the schema,
  factory, registry and diagnostics.

**Fixed**
- The Copilot idle watchdog no longer fires during long-running tool calls,
  which previously clobbered an agent's structured output.
- MCP 2.0 tool discovery and structured tool results.
- Retry classification now covers pydantic-ai's `ModelHTTPError` /
  `ModelAPIError`, so 408/429/5xx retry on Claude and OpenAI.
- `runtime.default_reasoning_effort` is no longer dropped at run time.
- The Fleet Manager no longer loses the current step, token/cost totals, or
  topology on large or resumed runs' event logs.
- The Fleet TUI directory picker no longer clobbers its own prefill.
- Run-record removal no longer silently fails on Windows sharing violations.
- The Copilot provider recovers automatically from a dead nested runtime.

## Validation

Run in an isolated `chore/release-0.1.34` worktree off `origin/main`:

- `make check` — ruff check, ruff format --check, `ty check` all clean.
- `uv run pytest -m "not real_api and not performance and not install_scripts"`
  (the CI-equivalent selection) — **7652 passed, 46 skipped, 0 failed**.
- `make validate-examples` — exit 0.
- `uv lock` — `uv.lock` changes only `conductor-cli` `0.1.33` → `0.1.34`.

`make test` (which unlike CI does *not* exclude `-m performance`) reported one
failure, `test_performance.py::TestForEachPerformance::test_100_item_array_with_max_concurrent_10`.
That module is `pytestmark = pytest.mark.performance` and is excluded from CI's
required selection. It is a wall-clock deadline (~500ms baseline + 200ms
allowance) that lost its budget to load from the surrounding 7682-test run; the
test passes in isolation (2.26s) and the whole module passes standalone (22
passed in 12.54s). Not a product regression, and untouched by this diff, which
changes only version strings and the changelog.

## Diff scope

`CHANGELOG.md`, `pyproject.toml`, `uv.lock` — nothing else.

## After merge

Merging this PR will be followed by tagging the merge commit `v0.1.34` and
pushing it, which triggers `.github/workflows/release.yml` to build and publish
the GitHub Release with its artifacts.
