### PR TITLE
fix(plugins): expand '~' against the passed-in home, not the environment

### DIFF
--- a/src/conductor/plugins/copilot_settings.py
+++ b/src/conductor/plugins/copilot_settings.py
@@ -44,13 +44,41 @@ logger = logging.getLogger(__name__)
 COPILOT_SETTINGS_RELATIVE: Path = Path(".copilot") / "settings.json"
 
 
+def _expand_home(raw: str, home: Path) -> str:
+    """Expand a leading ``~`` against *home* rather than the environment.
+
+    ``os.path.expanduser`` reads ``$HOME`` on POSIX but prefers
+    ``%USERPROFILE%`` on Windows, so it resolves against whichever
+    ambient variable the platform happens to prefer — not the ``home``
+    this settings file was actually read from. That defeats the
+    isolation ``home`` exists to provide, and makes the same settings
+    file expand to two different directories on two platforms whenever
+    the two variables disagree.
+
+    The ``~`` in ``<home>/.copilot/settings.json`` names that same home,
+    so it is expanded against it directly. In production the two are
+    identical, since the caller passes the real home.
+
+    ``~otheruser`` names a different account's home, which is not this
+    home's to rewrite, so it is left to the ambient lookup — the only
+    thing that can resolve it.
+    """
+    if raw == "~":
+        return str(home)
+    # ntpath treats both separators after '~'; posixpath treats only '/'.
+    if raw.startswith("~/") or (os.name == "nt" and raw.startswith("~\\")):
+        return str(home / raw[2:])
+    return os.path.expanduser(raw)
+
+
 def read_copilot_marketplaces(home: Path) -> dict[str, Path]:
     """Parse directory-backed marketplaces out of the Copilot CLI's settings.
 
     Args:
         home: Home directory to read ``.copilot/settings.json`` under. A
             parameter rather than a lookup so tests never read the
-            developer's real ``~``.
+            developer's real ``~``. A leading ``~`` in an entry's path is
+            expanded against this same directory, for the same reason.
 
     Returns:
         Marketplace name to absolute, expanded, normalised directory path,
@@ -99,7 +127,7 @@ def read_copilot_marketplaces(home: Path) -> dict[str, Path]:
         path = source.get("path")
         if not isinstance(path, str) or not path.strip():
             continue
-        resolved[name.strip()] = Path(os.path.normpath(os.path.expanduser(path.strip())))
+        resolved[name.strip()] = Path(os.path.normpath(_expand_home(path.strip(), home)))
     return resolved
 
 

--- a/tests/test_plugins/test_copilot_settings.py
+++ b/tests/test_plugins/test_copilot_settings.py
@@ -38,8 +38,16 @@ class TestReadCopilotMarketplaces:
 
         assert read_copilot_marketplaces(home) == {"jason-tools": target}
 
-    def test_tilde_paths_are_expanded(self, home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("HOME", str(home))
+    def test_tilde_paths_are_expanded(self, home: Path) -> None:
+        """``~`` expands against the passed-in home, not the ambient one.
+
+        The autouse isolation fixture points ``$HOME``/``%USERPROFILE%``
+        at a *different* directory, so this pins that the expansion never
+        reads the environment. Asserting it that way matters: while the
+        expansion did read the environment, this passed on POSIX and
+        failed only on Windows, because ``posixpath.expanduser`` reads
+        ``$HOME`` where ``ntpath.expanduser`` prefers ``%USERPROFILE%``.
+        """
         _write_settings(
             home,
             {"mine": {"source": {"path": "~/src/conductor-workflows", "source": "directory"}}},
@@ -48,6 +56,11 @@ class TestReadCopilotMarketplaces:
         result = read_copilot_marketplaces(home)
 
         assert result == {"mine": home / "src" / "conductor-workflows"}
+
+    def test_bare_tilde_is_the_home_directory(self, home: Path) -> None:
+        _write_settings(home, {"mine": {"source": {"path": "~", "source": "directory"}}})
+
+        assert read_copilot_marketplaces(home) == {"mine": home}
 
     def test_trailing_slash_is_normalised(self, home: Path, tmp_path: Path) -> None:
         target = tmp_path / "repo"


### PR DESCRIPTION
Fixes the red CI on `main`. The `Test (Python 3.13, windows-latest)` job has been failing since d3c43a1 (#498) on a single test:

```
FAILED tests/test_plugins/test_copilot_settings.py::TestReadCopilotMarketplaces::test_tilde_paths_are_expanded
  {'mine': .../test_tilde_paths_are_expanded0/isolated-home/src/conductor-workflows}
!= {'mine': .../test_tilde_paths_are_expanded0/home/src/conductor-workflows'}
```

Every other job — including both Linux test matrices — was green, which is the tell.

## Root cause

`read_copilot_marketplaces()` takes `home` as an explicit parameter, and its own docstring says why:

> `home`: Home directory to read `.copilot/settings.json` under. A parameter rather than a lookup **so tests never read the developer's real `~`**.

It then expanded each entry's leading `~` with `os.path.expanduser()`, which reads the ambient environment — doing precisely what the parameter exists to prevent. The function was internally inconsistent; Windows just made it observable:

- `posixpath.expanduser` reads `$HOME`.
- `ntpath.expanduser` prefers `%USERPROFILE%`.

`tests/test_plugins/conftest.py`'s autouse isolation fixture sets **both** to `tmp_path/"isolated-home"`. The tilde test overrode only `$HOME`, so the expansion agreed with the test's `home` fixture on Linux **by luck** and resolved to `isolated-home` on Windows.

## The fix

Expand a leading `~` against the `home` argument rather than the environment. The `~` inside `<home>/.copilot/settings.json` names that same home, so this is the correct reading of the file.

**No production behaviour change.** Every caller reaches `resolve_plugins`, which does `home = Path.home() if home is None else home`, and no production caller passes a `home` — so `home` is always `Path.home()`, which is itself `expanduser('~')`. The two were always identical outside tests.

`~otheruser` still defers to the ambient lookup, since another account's home is not this home's to rewrite.

## Test change

The test no longer overrides `$HOME`, so it asserts the actual contract: the ambient home stays pointed at `isolated-home`, and the expansion must ignore it. I verified the updated tests **fail on Linux against the old implementation**, so this regression is now caught on any platform instead of only on Windows CI. Added a bare-`~` case covering the new branch.

## Validation

- `make check` — ruff check, ruff format, `ty check` all pass
- `make test` — **7745 passed, 58 skipped** on Python 3.13
- `tests/test_plugins/` — 413 passed, 9 skipped
- New tests confirmed to fail against the pre-fix source (genuine regression test)

## Changelog

Deliberately none: there is no user-visible behaviour change in production (see above). This is an internal correctness fix that unbreaks Windows CI.