### PR TITLE
chore(release): cut 0.1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.34...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.35...HEAD)
 
-### Fixed
-
-- **Plugin flavor resolution (Claude vs. Copilot builds)** (#497). A
-  Claude-built plugin's `agents/*.md` subagents (no `.agent.md` suffix) were
-  silently never loaded — the candidate-file rule was hardcoded to the
-  Copilot build's convention. Flavor is now read off the manifest that
-  actually matched and threaded as a tie-break-only axis through plugin
-  resolution, so `provider: copilot` agents using a Claude-built plugin now
-  get its subagents too. Also adds `~/.copilot/settings.json` marketplace
-  resolution as a fallback for `plugin@marketplace` references, and several
-  new non-fatal warnings when a build cannot be determined unambiguously.
-
-## [0.1.34](https://github.com/microsoft/conductor/compare/v0.1.33...v0.1.34) - 2026-08-24
+## [0.1.35](https://github.com/microsoft/conductor/compare/v0.1.34...v0.1.35) - 2026-08-28
 
 ### Removed
 
@@ -35,6 +23,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   syntax will be designed against a concrete requirement (emitting an event,
   invoking a `type: script` step, or calling a webhook) rather than rendering a
   template and throwing it away.
+
+### Fixed
+
+- **`conductor doctor`'s table output no longer dies part-written on a
+  `cp1252` console** (#401). The Installed/Credentials/Connection/Models
+  columns hardcoded `✓`/`✗`/`○`/`⚠`, none of which cp1252 can encode, so a
+  run on a legacy Windows console raised `UnicodeEncodeError` mid-table,
+  after the Environment section had already printed. `conductor doctor`
+  now resolves each glyph once per invocation against the output console's
+  stream encoding, falling back to `OK`/`X`/`o`/`!` when the Unicode
+  glyphs cannot be encoded; the `--json` path was already safe and is
+  unchanged.
+- **Plugin flavor resolution (Claude vs. Copilot builds)** (#497). A
+  Claude-built plugin's `agents/*.md` subagents (no `.agent.md` suffix) were
+  silently never loaded — the candidate-file rule was hardcoded to the
+  Copilot build's convention. Flavor is now read off the manifest that
+  actually matched and threaded as a tie-break-only axis through plugin
+  resolution, so `provider: copilot` agents using a Claude-built plugin now
+  get its subagents too. Also adds `~/.copilot/settings.json` marketplace
+  resolution as a fallback for `plugin@marketplace` references, and several
+  new non-fatal warnings when a build cannot be determined unambiguously.
+
+## [0.1.34](https://github.com/microsoft/conductor/compare/v0.1.33...v0.1.34) - 2026-08-24
 
 ### Added
 
@@ -110,15 +121,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as fatal.
 - `runtime.default_reasoning_effort` was silently dropped at run time for every
   provider and is now forwarded through `ProviderRegistry`.
-- **`conductor doctor`'s table output no longer dies part-written on a
-  `cp1252` console** (#401). The Installed/Credentials/Connection/Models
-  columns hardcoded `✓`/`✗`/`○`/`⚠`, none of which cp1252 can encode, so a
-  run on a legacy Windows console raised `UnicodeEncodeError` mid-table,
-  after the Environment section had already printed. `conductor doctor`
-  now resolves each glyph once per invocation against the output console's
-  stream encoding, falling back to `OK`/`X`/`o`/`!` when the Unicode
-  glyphs cannot be encoded; the `--json` path was already safe and is
-  unchanged.
 - **MCP tool discovery and structured tool results no longer break with MCP
   2.0** (#419). MCP 2.0 renamed the Python field on `mcp.types.Tool` from
   `inputSchema` to `input_schema` and on `mcp.types.CallToolResult` from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.34"
+version = "0.1.35"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -391,7 +391,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.34"
+version = "0.1.35"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release preparation for **v0.1.35** (previous release: **v0.1.34**, 2026-08-24).

## Commit audit

All **4** commits in `v0.1.34..main` were audited; every one has an explicit disposition.

| # | Commit | PR | Change | Class |
|---|--------|-----|--------|-------|
| 1 | `6cdbabb` | #480 (issue #476) | Remove dead workflow lifecycle hooks | Removed |
| 2 | `9760b72` | #469 (issue #401) | `conductor doctor` glyphs resolved per console encoding | Fixed |
| 3 | `d3c43a1` | #498 (issue #497) | Plugin flavor resolution (Claude vs Copilot builds) | Fixed |
| 4 | `c363ee7` | #499 | Expand `~` against the passed-in home, not the environment | Internal — no changelog |

Commit 4 is deliberately not in the changelog: it has no user-visible behaviour change in production (`home` is always `Path.home()`, which is what `expanduser` already resolved to). It was an internal correctness fix that unbroke the red Windows CI on `main`.

## Changelog corrections

Two entries were **misfiled into the already-released `[0.1.34]` section** and have been moved into `[0.1.35]`:

- The lifecycle-hooks removal (#476) had been inserted as a new `### Removed` heading under `[0.1.34]`, but PR #480 merged 2026-08-25 — *after* v0.1.34 was published on 2026-08-24. Verified against the tag: `HooksConfig` still exists at `v0.1.34` and is removed only on `main`.
- The `conductor doctor` cp1252 fix (#401) had been appended to `[0.1.34]`'s `### Fixed`, but PR #469 merged 2026-08-27. Verified: `_resolve_glyphs` does not exist at `v0.1.34` at all.

Both entries claimed shipped-in-0.1.34 behaviour that v0.1.34 users do not have. The `[0.1.34]` section now accurately reflects that tag's contents.

The plugin-flavor entry (#497) was already correctly under `[Unreleased]`.

## Release section

`[0.1.35]` contains **Removed** (lifecycle hooks) and **Fixed** (doctor glyphs, plugin flavor). A fresh empty `[Unreleased]` compare link was added above it.

## Validation

All run against this branch, rebased on `c363ee7`:

- `make check` — ruff check, ruff format, `ty check` all pass
- `make test` — **7745 passed, 58 skipped**
- `make validate-examples` — pass (schema changed in the release range)
- `git diff --check` — clean

## Diff scope

Only the three release files: `CHANGELOG.md`, `pyproject.toml`, `uv.lock`. The lockfile change is the `conductor-cli` project version only (1 line); no dependencies moved.

## Next step

Merging this PR will be followed by pushing the **`v0.1.35`** tag at the merge commit, which triggers `.github/workflows/release.yml` to build and publish the GitHub Release with its artifacts.