### PR TITLE
chore(release): cut 0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,88 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.35...HEAD)
+## [Unreleased](https://github.com/microsoft/conductor/compare/v0.1.36...HEAD)
+
+## [0.1.36](https://github.com/microsoft/conductor/compare/v0.1.35...v0.1.36) - 2026-09-02
+
+### Added
+
+- **`conductor mcp serve`** (#432) — exposes your registered Conductor
+  workflows as [MCP](https://modelcontextprotocol.io/) tools to any
+  MCP-compatible host (Claude Code, VS Code, Cursor, etc.) over stdio,
+  with no workflow edits required: every workflow in every configured
+  registry is exposed by default, with a typed `inputSchema` derived from
+  its own `input:` block. A tool call always forks a real detached
+  `conductor run` — the server never executes a workflow in-process — and
+  by default **returns immediately** with a run handle carrying the
+  `run_id`, dashboard `url` and `port`, the captured log paths, and the
+  `conductor fleet` / `conductor status` commands for watching it from a
+  terminal, so the caller can report the run back and move on while it
+  keeps going. A caller may opt into a bounded wait per call
+  (`_wait_seconds`, capped by `--max-wait-seconds`), which changes only
+  whether *that call* blocks — never how the workflow runs; start the
+  server with `--max-wait-seconds 0` to make every invocation
+  non-blocking regardless of what a caller requests. A run that has not
+  completed (immediate, at-gate, failed, or timed-out) returns the handle;
+  a run that completes within a bounded wait
+  returns its output inline, or — once serialized `output:` exceeds 50 KB
+  — spilled to a file with a `resource_link` and no dashboard `url`. New
+  `conductor_run_status` / `conductor_await_run` / `conductor_cancel_run`
+  / `conductor_list_runs` tools answer for a `run_id` before, during, at a
+  human gate, and after a run has finished — the human gate is never
+  auto-skipped; a run that reaches one parks and reports its dashboard
+  approval URL until a person resolves it. Optional `introspect`/`diagnose`
+  toolsets (off by default; enable with `--toolsets`) add event-query,
+  per-step detail, `conductor doctor`/`conductor validate` equivalents, and
+  links (never file contents) to a run's raw logs. `--allow`/`--deny`
+  narrow or force the exposed set; a registry above `--max-direct-tools`
+  (default 25) degrades to a two-tool discovery pair instead of failing or
+  overflowing a host's tool-count limit. See
+  [`docs/mcp-server.md`](docs/mcp-server.md) for the full guide, including
+  a dedicated *Limits* section for what this release deliberately does not
+  do (no `outputSchema`, no Streamable HTTP transport, tool call payloads
+  withheld unless `--introspect-full`).
+- **`workflow.mcp:` block** — per-workflow configuration read by
+  `conductor mcp serve` to decide how a workflow is exposed as an MCP
+  tool: `expose` (default `true`), `mode` (`async`/`sync`/`auto`),
+  `read_only`, `destructive`, and `estimated_minutes`. Every field
+  defaults to the value that keeps an existing workflow with no `mcp:`
+  block at all exposed identically to one that declares the defaults
+  explicitly, so no existing workflow needs editing. An unknown key
+  inside the block is a `conductor validate` schema error, not a silently
+  ignored typo. See `examples/mcp-serve.yaml`.
+
+### Changed
+
+- **`conductor status` and `conductor fleet list` now also list
+  recently-completed runs, not just currently-running ones — a contract
+  change to what these commands mean.** Previously both meant "runs alive
+  right now"; a finished run disappeared the moment its process exited.
+  Each command now renders (or, for `status --json`, returns in an
+  additive `completed` array) a bounded set of recently-completed runs
+  with their terminal status (`completed`/`failed`), when they ended,
+  duration, tokens/cost, and error type for a failure — sourced from the
+  terminal run record every run now writes on exit. `conductor fleet
+  list`'s completed rows are bounded by `[fleet.retention].keep_last`.
+  Both commands remain read-only: listing a completed run never removes
+  its terminal record. Pass `--live` to either command to restore the
+  exact previous scope (`status --json --live` also drops the
+  `completed` key from the payload entirely, so an existing scripted
+  consumer of `payload["running"]` is otherwise unaffected by this
+  change). The Fleet Manager TUI's History screen also gained a failed
+  run's error message and a completed run's rendered output, reachable
+  by selecting a row, without adding a new column to its table.
+
+### Fixed
+
+- **The `mcp` SDK dependency is now bounded below its breaking 2.0 release**
+  (`mcp>=1.28.1,<2`). `mcp` 2.0.0 renamed the camelCase attributes the
+  existing MCP client reads (`Tool.inputSchema` -> `input_schema`), so an
+  installation whose lock had already floated to `mcp` 2.x had a client
+  that connected to a server and then raised `AttributeError` on every
+  tool listing — MCP tools were silently non-functional. Re-locking with
+  this bound restores them; the pin does not change behavior for anyone
+  already on `mcp` 1.x.
 
 ## [0.1.35](https://github.com/microsoft/conductor/compare/v0.1.34...v0.1.35) - 2026-08-28
 
@@ -91,74 +172,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The previously reserved `openai-agents` provider name has been removed from the
   schema, factory, registry and diagnostics. Workflows that named it now fail at
   schema load time rather than at the first agent execution.
-
-### Added
-
-- **`conductor mcp serve`** (#432) — exposes your registered Conductor
-  workflows as [MCP](https://modelcontextprotocol.io/) tools to any
-  MCP-compatible host (Claude Code, VS Code, Cursor, etc.) over stdio,
-  with no workflow edits required: every workflow in every configured
-  registry is exposed by default, with a typed `inputSchema` derived from
-  its own `input:` block. A tool call always forks a real detached
-  `conductor run` — the server never executes a workflow in-process — and
-  by default **returns immediately** with a run handle carrying the
-  `run_id`, dashboard `url` and `port`, the captured log paths, and the
-  `conductor fleet` / `conductor status` commands for watching it from a
-  terminal, so the caller can report the run back and move on while it
-  keeps going. A caller may opt into a bounded wait per call
-  (`_wait_seconds`, capped by `--max-wait-seconds`), which changes only
-  whether *that call* blocks — never how the workflow runs; start the
-  server with `--max-wait-seconds 0` to make every invocation
-  non-blocking regardless of what a caller requests. A run that has not
-  completed (immediate, at-gate, failed, or timed-out) returns the handle;
-  a run that completes within a bounded wait
-  returns its output inline, or — once serialized `output:` exceeds 50 KB
-  — spilled to a file with a `resource_link` and no dashboard `url`. New
-  `conductor_run_status` / `conductor_await_run` / `conductor_cancel_run`
-  / `conductor_list_runs` tools answer for a `run_id` before, during, at a
-  human gate, and after a run has finished — the human gate is never
-  auto-skipped; a run that reaches one parks and reports its dashboard
-  approval URL until a person resolves it. Optional `introspect`/`diagnose`
-  toolsets (off by default; enable with `--toolsets`) add event-query,
-  per-step detail, `conductor doctor`/`conductor validate` equivalents, and
-  links (never file contents) to a run's raw logs. `--allow`/`--deny`
-  narrow or force the exposed set; a registry above `--max-direct-tools`
-  (default 25) degrades to a two-tool discovery pair instead of failing or
-  overflowing a host's tool-count limit. See
-  [`docs/mcp-server.md`](docs/mcp-server.md) for the full guide, including
-  a dedicated *Limits* section for what this release deliberately does not
-  do (no `outputSchema`, no Streamable HTTP transport, tool call payloads
-  withheld unless `--introspect-full`).
-- **`workflow.mcp:` block** — per-workflow configuration read by
-  `conductor mcp serve` to decide how a workflow is exposed as an MCP
-  tool: `expose` (default `true`), `mode` (`async`/`sync`/`auto`),
-  `read_only`, `destructive`, and `estimated_minutes`. Every field
-  defaults to the value that keeps an existing workflow with no `mcp:`
-  block at all exposed identically to one that declares the defaults
-  explicitly, so no existing workflow needs editing. An unknown key
-  inside the block is a `conductor validate` schema error, not a silently
-  ignored typo. See `examples/mcp-serve.yaml`.
-
-### Changed
-
-- **`conductor status` and `conductor fleet list` now also list
-  recently-completed runs, not just currently-running ones — a contract
-  change to what these commands mean.** Previously both meant "runs alive
-  right now"; a finished run disappeared the moment its process exited.
-  Each command now renders (or, for `status --json`, returns in an
-  additive `completed` array) a bounded set of recently-completed runs
-  with their terminal status (`completed`/`failed`), when they ended,
-  duration, tokens/cost, and error type for a failure — sourced from the
-  terminal run record every run now writes on exit. `conductor fleet
-  list`'s completed rows are bounded by `[fleet.retention].keep_last`.
-  Both commands remain read-only: listing a completed run never removes
-  its terminal record. Pass `--live` to either command to restore the
-  exact previous scope (`status --json --live` also drops the
-  `completed` key from the payload entirely, so an existing scripted
-  consumer of `payload["running"]` is otherwise unaffected by this
-  change). The Fleet Manager TUI's History screen also gained a failed
-  run's error message and a completed run's rendered output, reachable
-  by selecting a row, without adding a new column to its table.
 
 ### Fixed
 
@@ -578,14 +591,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (rejecting one this package does not declare, which uv would otherwise
   accept with a warning and a zero exit status), and `--no-preserve-extras` /
   `CONDUCTOR_INSTALL_NO_PRESERVE_EXTRAS` drops back to a bare install.
-- **The `mcp` SDK dependency is now bounded below its breaking 2.0 release**
-  (`mcp>=1.28.1,<2`). `mcp` 2.0.0 renamed the camelCase attributes the
-  existing MCP client reads (`Tool.inputSchema` -> `input_schema`), so an
-  installation whose lock had already floated to `mcp` 2.x had a client
-  that connected to a server and then raised `AttributeError` on every
-  tool listing — MCP tools were silently non-functional. Re-locking with
-  this bound restores them; the pin does not change behavior for anyone
-  already on `mcp` 1.x.
 - **Fleet Manager History no longer accumulates an entire retained event log
   into memory to build one entry** (#436). `_read_full_log` now streams
   parsed events one at a time instead of materializing them into a list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conductor-cli"
-version = "0.1.35"
+version = "0.1.36"
 description = "A CLI tool for defining and running multi-agent workflows with the GitHub Copilot SDK"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -391,7 +391,7 @@ wheels = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.1.35"
+version = "0.1.36"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release **0.1.36** (previous tag: `v0.1.35`).

## Commit audit

**1 commit** in `v0.1.35..main`, fully audited:

| Commit | Subject | PR | Disposition |
|--------|---------|----|-------------|
| `4e1ea0a` | feat(mcp): `conductor mcp serve` — expose workflows as MCP tools (#432) | #491 | Added + Changed + Fixed — changelog copy already written, but **misplaced**; relocated (see below) |

## Changelog

The audit found a defect: #491 was rebased onto a newer `main` and its changelog
hunks landed inside **already-published** version sections rather than
`[Unreleased]`, which was left empty:

- `### Added` (`conductor mcp serve`, `workflow.mcp:` block) and `### Changed`
  (`conductor status` / `conductor fleet list` now list recently-completed runs)
  had landed inside `## [0.1.34]`.
- `### Fixed` (`mcp>=1.28.1,<2` SDK bound) had landed inside `## [0.1.31]`.

Neither of those releases contains this work. All three blocks are moved
**verbatim** into the new `## [0.1.36]` section — no wording changed, nothing
added or dropped — and the two released sections are restored to their
pre-#491 contents. `[0.1.34]` no longer carries a duplicate `### Added` /
`### Changed` pair.

`[Unreleased]` is re-created empty, pointing at `v0.1.36...HEAD`.

## Release diff

Only the three release files:

- `CHANGELOG.md` — 0.1.36 section finalized, misplacement repaired
- `pyproject.toml` — `version = "0.1.36"`
- `uv.lock` — re-locked with `uv lock`; the only change is the
  `conductor-cli` project version (no dependency movement)

## Validation

All run against this branch and passing:

- `make check` — ruff check, ruff format --check, `ty check` — all clean
- `make test` — **8194 passed**, 58 skipped, 14 deselected
- `make validate-examples` — all examples valid (run because the release range
  touched `config/schema.py` and added `examples/mcp-serve.yaml`)
- `git diff --check` — clean

## After merge

Merging this PR will be followed by tagging the merge commit `v0.1.36` and
pushing it, which triggers `.github/workflows/release.yml` to build and publish
the GitHub Release with its artifacts. The release is **not** created manually.
