### PR TITLE
fix(providers): openai backend uses PromptedOutput instead of ToolOutput for structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regardless of schema size or retry configuration. `PromptedOutput` asks
   the model to emit the schema as JSON in its normal text response instead,
   which these backends handle correctly; verified via a real end-to-end
-  workflow run against `qwen2.5-coder:14b-8k` over Ollama, which failed
-  consistently before this change and passed cleanly after. Scoped to the
-  `openai` backend only — the `claude`/Anthropic backend keeps `ToolOutput`,
-  since real tool-calling is reliable there.
+  workflow run against `qwen2.5-coder:14b-8k` over Ollama with a **flat**
+  output schema, which failed consistently before this change and passed
+  cleanly after. Scoped to the `openai` backend only — the `claude`/
+  Anthropic backend keeps `ToolOutput`, since real tool-calling is reliable
+  there.
+
+  **Known limitation, not fixed by this change:** `ToolOutput`'s rendered
+  tool schema is sanitized (`$ref`/`$defs` inlined, pydantic-internal keys
+  stripped) before being sent to the model; `PromptedOutput` has no
+  equivalent hook in its current public API and renders the raw
+  `model_json_schema()` — `$ref`/`$defs` included — for a **nested** output
+  schema. This can make a nested `output:` schema harder for a weak local
+  model to satisfy than a flat one, partially working against this fix's
+  own goal. `tests/test_providers/test_pydantic_ai_agent_builder.py::TestOpenAIBackend::test_openai_nested_output_schema_is_not_ref_inlined_known_limitation`
+  pins the current behavior as a concrete target for a follow-up fix.
 
 ## [0.1.36](https://github.com/microsoft/conductor/compare/v0.1.35...v0.1.36) - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entirely. See
   [`examples/claude-agent-sdk-setting-sources.yaml`](examples/claude-agent-sdk-setting-sources.yaml).
 
+### Fixed
+
+- **`openai` provider structured output uses `PromptedOutput` instead of
+  `ToolOutput`** — several widely-used local models served behind an
+  OpenAI-compatible endpoint (e.g. Ollama) do not reliably emit a real
+  function/tool call for structured output, even when explicitly requested
+  (see [ollama/ollama#8095](https://github.com/ollama/ollama/issues/8095),
+  [ollama/ollama#8063](https://github.com/ollama/ollama/issues/8063),
+  [pydantic/pydantic-ai#877](https://github.com/pydantic/pydantic-ai/issues/877)).
+  Under the previous `ToolOutput` wrapping, any agent with a non-empty
+  `output:` schema against such a model exhausted its parse-recovery budget
+  and raised `UnexpectedModelBehavior: Exceeded maximum output retries`,
+  regardless of schema size or retry configuration. `PromptedOutput` asks
+  the model to emit the schema as JSON in its normal text response instead,
+  which these backends handle correctly; verified via a real end-to-end
+  workflow run against `qwen2.5-coder:14b-8k` over Ollama, which failed
+  consistently before this change and passed cleanly after. Scoped to the
+  `openai` backend only — the `claude`/Anthropic backend keeps `ToolOutput`,
+  since real tool-calling is reliable there.
+
 ## [0.1.36](https://github.com/microsoft/conductor/compare/v0.1.35...v0.1.36) - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own goal. `tests/test_providers/test_pydantic_ai_agent_builder.py::TestOpenAIBackend::test_openai_nested_output_schema_is_not_ref_inlined_known_limitation`
   pins the current behavior as a concrete target for a follow-up fix.
 
+  **Workaround, until that follow-up lands:** avoid a nested `output:`
+  schema on an `openai`-backend agent step entirely. Have each agent step
+  return a flat schema, then reassemble the nested structure in a
+  downstream `type: script` (or `type: set`) step — nesting is pure data
+  shaping and needs no LLM call, so it never hits this limitation. This is
+  also the same decomposition pattern that improves parse-recovery
+  reliability on weak local models generally (smaller, flatter one-shot
+  generations retry more predictably than one large structured call), so
+  it is a good default shape for a local-model-backed workflow regardless
+  of this specific limitation. See `examples/` (a worked example is a good
+  follow-up addition here).
+
 ## [0.1.36](https://github.com/microsoft/conductor/compare/v0.1.35...v0.1.36) - 2026-09-02
 
 ### Added

--- a/src/conductor/providers/_pydantic_ai/agent_builder.py
+++ b/src/conductor/providers/_pydantic_ai/agent_builder.py
@@ -20,7 +20,7 @@ from openai import AsyncOpenAI
 from pydantic_ai import Agent, AgentRetries
 from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings
-from pydantic_ai.output import ToolOutput
+from pydantic_ai.output import PromptedOutput, ToolOutput
 from pydantic_ai.providers.anthropic import AnthropicProvider
 from pydantic_ai.providers.openai import OpenAIProvider
 
@@ -215,19 +215,34 @@ def _resolve_anthropic_model(
 
 def _build_output_type(
     agent: AgentDef,
-) -> type[Any] | ToolOutput[Any] | None:
+    backend: str = "anthropic",
+) -> type[Any] | ToolOutput[Any] | PromptedOutput[Any] | None:
     """Translate the agent's ``output`` schema into a Pydantic AI output spec.
 
     An empty or missing schema means plain text output (``None`` is returned
     so callers fall back to the default ``str`` output). Otherwise, the schema
-    is converted to a dynamic Pydantic model and wrapped in ``ToolOutput`` to
-    request tool-based structured output as required by the provider plan.
+    is converted to a dynamic Pydantic model.
+
+    For the ``openai`` backend (typically an OpenAI-compatible endpoint such
+    as Ollama, vLLM, or LM Studio), the output is wrapped in ``PromptedOutput``
+    rather than ``ToolOutput``. Several widely-used local models do not
+    reliably emit a real function/tool call for structured output over an
+    OpenAI-compatible API, even when explicitly requested (see
+    ollama/ollama#8095, ollama/ollama#8063, pydantic/pydantic-ai#877) --
+    ``ToolOutput`` on these backends silently fails after exhausting the
+    parse-recovery budget (``UnexpectedModelBehavior: Exceeded maximum output
+    retries``). ``PromptedOutput`` instead asks the model to emit the schema
+    as JSON in its normal text response, which these backends handle
+    correctly. The Anthropic backend is left on ``ToolOutput`` since real
+    tool-calling is reliable there.
 
     Args:
         agent: The Conductor agent definition.
+        backend: Which LLM backend this agent will run against.
 
     Returns:
-        A ``ToolOutput`` wrapping the dynamic model, or ``None`` for text output.
+        A ``PromptedOutput`` (openai backend) or ``ToolOutput`` (anthropic
+        backend) wrapping the dynamic model, or ``None`` for text output.
     """
     dynamic_model = output_schema_to_pydantic_model(
         f"{agent.name}Output",
@@ -235,6 +250,8 @@ def _build_output_type(
     )
     if dynamic_model is None:
         return None
+    if backend == "openai":
+        return PromptedOutput(dynamic_model)
     return ToolOutput(dynamic_model)
 
 
@@ -595,7 +612,7 @@ def build_agent(
             timeout=timeout,
         )
 
-    output_type = _build_output_type(agent)
+    output_type = _build_output_type(agent, backend)
     if output_type is None:
         output_type = str
 

--- a/src/conductor/providers/_pydantic_ai/agent_builder.py
+++ b/src/conductor/providers/_pydantic_ai/agent_builder.py
@@ -233,8 +233,17 @@ def _build_output_type(
     parse-recovery budget (``UnexpectedModelBehavior: Exceeded maximum output
     retries``). ``PromptedOutput`` instead asks the model to emit the schema
     as JSON in its normal text response, which these backends handle
-    correctly. The Anthropic backend is left on ``ToolOutput`` since real
-    tool-calling is reliable there.
+    correctly for flat/scalar output schemas. The Anthropic backend is left
+    on ``ToolOutput`` since real tool-calling is reliable there.
+
+    KNOWN LIMITATION: ``ToolOutput``'s rendered tool schema is sanitized
+    (``$ref``/``$defs`` inlined, pydantic-internal keys stripped) before
+    being sent to the model; ``PromptedOutput`` has no equivalent hook in
+    its current public API and renders the raw ``model_json_schema()`` for
+    a nested output schema, ``$ref``/``$defs`` included. This can make a
+    nested ``output:`` schema harder for a weak local model to satisfy than
+    a flat one. See the pinned regression test
+    ``TestOpenAIBackend::test_openai_nested_output_schema_is_not_ref_inlined_known_limitation``.
 
     Args:
         agent: The Conductor agent definition.

--- a/src/conductor/providers/_pydantic_ai/agent_builder.py
+++ b/src/conductor/providers/_pydantic_ai/agent_builder.py
@@ -245,6 +245,11 @@ def _build_output_type(
     a flat one. See the pinned regression test
     ``TestOpenAIBackend::test_openai_nested_output_schema_is_not_ref_inlined_known_limitation``.
 
+    Workaround until a follow-up fix lands: keep each ``openai``-backend
+    agent step's ``output:`` schema flat, and reassemble any nested
+    structure in a downstream ``type: script``/``type: set`` step instead
+    -- nesting is pure data shaping and needs no LLM call.
+
     Args:
         agent: The Conductor agent definition.
         backend: Which LLM backend this agent will run against.

--- a/tests/test_providers/test_pydantic_ai_agent_builder.py
+++ b/tests/test_providers/test_pydantic_ai_agent_builder.py
@@ -175,6 +175,46 @@ class TestOpenAIBackend:
         assert isinstance(pydantic_agent.output_type, PromptedOutput)
         assert not isinstance(pydantic_agent.output_type, ToolOutput)
 
+    def test_openai_nested_output_schema_is_not_ref_inlined_known_limitation(self) -> None:
+        """KNOWN LIMITATION, tracked as a follow-up, not fixed by this test.
+
+        ToolOutput's rendered tool schema is sanitized via
+        ``_sanitize_json_schema`` (inlining ``$ref``/``$defs``, stripping
+        pydantic-internal keys) before being sent to the model. PromptedOutput
+        has no equivalent hook in its public API (``outputs``/``name``/
+        ``description``/``template`` only) -- it renders the dynamic model's
+        raw ``model_json_schema()`` into the prompt, ``$ref``/``$defs`` and
+        all. For a *nested* output schema this means the openai/PromptedOutput
+        path hands a weak local model a schema shape it must dereference
+        itself, which is exactly the class of prompt the models this fix
+        targets are weakest at satisfying -- a real, open gap this fix does
+        not close. This test pins the current (undesirable but honest)
+        behavior so a future fix has a concrete regression target, and so a
+        silent behavior change doesn't go unnoticed either way.
+        """
+        agent_def = AgentDef(
+            name="nested_formatter",
+            output={
+                "nested": OutputField(
+                    type="object",
+                    properties={"inner": OutputField(type="string")},
+                )
+            },
+        )
+
+        pydantic_agent = build_agent(
+            agent_def, system_prompt="", rendered_prompt="", backend="openai"
+        )
+
+        assert isinstance(pydantic_agent.output_type, PromptedOutput)
+        rendered_schema = pydantic_agent._output_schema.object_def.json_schema
+        assert "$defs" in rendered_schema, (
+            "If this now fails, PromptedOutput's rendered schema is no longer "
+            "$ref-shaped for nested output -- the known limitation documented "
+            "above may have been resolved; update this test and the CHANGELOG "
+            "entry to reflect nested-schema coverage."
+        )
+
     def test_openai_sampling_settings(self) -> None:
         """OpenAI model settings must carry temperature, max_tokens and timeout."""
         agent_def = AgentDef(name="sampler")

--- a/tests/test_providers/test_pydantic_ai_agent_builder.py
+++ b/tests/test_providers/test_pydantic_ai_agent_builder.py
@@ -2,7 +2,8 @@
 
 Tests verify that build_agent() maps Conductor agent configuration to Pydantic
 AI constructs with parity to the existing Claude provider: model resolution,
-system prompt wiring, structured output via ToolOutput, sampling settings,
+system prompt wiring, structured output via ToolOutput (anthropic) /
+PromptedOutput (openai), sampling settings,
 extended-thinking budgets, and Anthropic API constraint coercion.
 """
 
@@ -20,7 +21,7 @@ from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.function import FunctionModel
 from pydantic_ai.models.openai import OpenAIChatModel
-from pydantic_ai.output import ToolOutput
+from pydantic_ai.output import PromptedOutput, ToolOutput
 
 from conductor.config.schema import AgentDef, OutputField, ReasoningConfig
 from conductor.exceptions import ValidationError
@@ -149,8 +150,18 @@ class TestOpenAIModelMapping:
 class TestOpenAIBackend:
     """Tests specific to the openai backend branch."""
 
-    def test_openai_output_schema_becomes_tool_output(self) -> None:
-        """OpenAI backend must wrap a non-empty output schema in ToolOutput."""
+    def test_openai_output_schema_becomes_prompted_output(self) -> None:
+        """OpenAI backend must wrap a non-empty output schema in PromptedOutput.
+
+        Not ToolOutput: several widely-used local models served behind an
+        OpenAI-compatible endpoint (e.g. Ollama) do not reliably emit a real
+        tool call for structured output, even when explicitly requested (see
+        ollama/ollama#8095, ollama/ollama#8063, pydantic/pydantic-ai#877) --
+        ToolOutput exhausts the parse-recovery budget and raises
+        UnexpectedModelBehavior on these backends. PromptedOutput asks the
+        model to emit the schema as JSON in its normal text response
+        instead, which these backends handle correctly.
+        """
         agent_def = AgentDef(
             name="formatter",
             output={"answer": OutputField(type="string")},
@@ -161,7 +172,8 @@ class TestOpenAIBackend:
         )
 
         assert isinstance(pydantic_agent.model, OpenAIChatModel)
-        assert isinstance(pydantic_agent.output_type, ToolOutput)
+        assert isinstance(pydantic_agent.output_type, PromptedOutput)
+        assert not isinstance(pydantic_agent.output_type, ToolOutput)
 
     def test_openai_sampling_settings(self) -> None:
         """OpenAI model settings must carry temperature, max_tokens and timeout."""


### PR DESCRIPTION
## Summary

- Several widely-used local models served behind an OpenAI-compatible endpoint (e.g. Ollama) do not reliably emit a real function/tool call for structured output, even when explicitly requested. Under `ToolOutput`, any agent with a non-empty `output:` schema against such a model exhausted its parse-recovery budget and raised `UnexpectedModelBehavior: Exceeded maximum output retries`, regardless of schema size or retry configuration.
- Switches `_build_output_type` to return `PromptedOutput` instead of `ToolOutput` when `backend == "openai"`. The `claude`/Anthropic backend is untouched (still `ToolOutput`, since real tool-calling is reliable there).
- Matches known upstream reports: [ollama/ollama#8095](https://github.com/ollama/ollama/issues/8095) ("structured output with tools always produces empty tool_calls array"), [ollama/ollama#8063](https://github.com/ollama/ollama/issues/8063), [pydantic/pydantic-ai#877](https://github.com/pydantic/pydantic-ai/issues/877) ("Ollama can't return structured output").

## Known limitation (documented, not fixed here)

`ToolOutput`'s rendered tool schema is sanitized (`$ref`/`$defs` inlined, pydantic-internal keys stripped) before being sent to the model. `PromptedOutput`'s current public API (`outputs`/`name`/`description`/`template`) has no equivalent hook, so it renders the raw `model_json_schema()` for a **nested** output schema — `$ref`/`$defs` included. This can make a nested `output:` schema harder for a weak local model to satisfy than a flat one, partially working against this fix's own goal. A regression test pins this behavior as a concrete target for a follow-up rather than silently shipping an overclaim.

**Workaround, until a follow-up fix lands:** keep each `openai`-backend agent step's `output:` schema flat, and reassemble any nested structure in a downstream `type: script` (or `type: set`) step instead — nesting is pure data shaping and needs no LLM call. This is also the same decomposition pattern that improves parse-recovery reliability on weak local models generally, so it's a good default shape for a local-model-backed workflow regardless of this specific limitation.

## Test plan

- [x] `uv run pytest tests/test_providers/test_pydantic_ai_agent_builder.py -q` — 49 passed (includes new tests for both the flat-schema fix and the pinned nested-schema limitation)
- [x] `uv run pytest tests/test_providers/ -q` — 1567 passed, 1 skipped, 1 pre-existing unrelated failure (`test_copilot.py::TestLogRecoveryAttempt::test_omits_tag_when_unnamed`, confirmed failing identically on a clean `origin/main` checkout before this change)
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run ty check src/conductor/providers/_pydantic_ai/agent_builder.py` — clean
- [x] Real end-to-end verification: ran an actual conductor workflow (a flat output schema) against `qwen2.5-coder:14b-8k` over a real Ollama endpoint — failed consistently with `ToolOutput` (`UnexpectedModelBehavior: Exceeded maximum output retries`) before this change, passed cleanly after
- [x] Adversarially reviewed for other call sites assuming `ToolOutput` on the openai backend, retry-semantics changes, and unintended effects on `hermes.py`/`aca.py` — none found; both confirmed to not import `agent_builder`